### PR TITLE
fix: install ballast-go from release assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ case "$ARCH" in
 esac
 curl -fsSL -o /tmp/ballast-go.tar.gz "https://github.com/everydaydevopsio/ballast/releases/download/v${VERSION}/ballast-go_${VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xzf /tmp/ballast-go.tar.gz -C /tmp
-install -m 0755 /tmp/ballast-go ~/.local/bin/ballast-go
+mkdir -p "${HOME}/.local/bin"
+install -m 0755 /tmp/ballast-go "${HOME}/.local/bin/ballast-go"
 ballast-go install --target cursor --all
 ```
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -680,6 +680,7 @@ func releasedGoInstallCommand(version string, projectRoot string) ([]string, err
 	if err != nil {
 		return nil, err
 	}
+	checksumURL := releasedGoChecksumURL(release)
 	destination := filepath.Join(projectRoot, ".ballast", "bin", "ballast-go")
 
 	if runtime.GOOS == "windows" {
@@ -687,23 +688,38 @@ func releasedGoInstallCommand(version string, projectRoot string) ([]string, err
 			`New-Item -ItemType Directory -Path $tmp | Out-Null; ` +
 			`try { ` +
 			`$archive = Join-Path $tmp 'ballast-go.zip'; ` +
+			`$checksums = Join-Path $tmp 'ballast-go_checksums.txt'; ` +
 			`Invoke-WebRequest -Uri $args[0] -OutFile $archive; ` +
+			`Invoke-WebRequest -Uri $args[1] -OutFile $checksums; ` +
+			`$archiveName = [System.IO.Path]::GetFileName($args[0]); ` +
+			`$expected = Select-String -Path $checksums -Pattern ("  " + [regex]::Escape($archiveName) + "$") | ForEach-Object { ($_ -split '\s+')[0] } | Select-Object -First 1; ` +
+			`if (-not $expected) { throw "missing checksum for $archiveName" }; ` +
+			`$actual = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant(); ` +
+			`if ($actual -ne $expected.ToLowerInvariant()) { throw "checksum mismatch for $archiveName" }; ` +
 			`Expand-Archive -Path $archive -DestinationPath $tmp -Force; ` +
-			`Copy-Item (Join-Path $tmp 'ballast-go.exe') $args[1] -Force ` +
+			`Copy-Item (Join-Path $tmp 'ballast-go.exe') $args[2] -Force ` +
 			`} finally { ` +
 			`Remove-Item $tmp -Recurse -Force -ErrorAction SilentlyContinue ` +
 			`}`
-		return []string{"powershell", "-NoProfile", "-Command", script, url, destination + ".exe"}, nil
+		return []string{"powershell", "-NoProfile", "-Command", script, url, checksumURL, destination + ".exe"}, nil
 	}
 
 	script := `set -e
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 archive="$tmpdir/ballast-go.tar.gz"
+checksums="$tmpdir/ballast-go_checksums.txt"
 curl -fsSL "$1" -o "$archive"
+curl -fsSL "$2" -o "$checksums"
+archive_name="$(basename "$1")"
+set -- $(grep "  $archive_name$" "$checksums")
+[ "${1:-}" != "" ]
+expected_checksum="$1"
+set -- $(openssl dgst -sha256 -r "$archive")
+[ "${1:-}" = "$expected_checksum" ]
 tar -xzf "$archive" -C "$tmpdir"
-install -m 0755 "$tmpdir/ballast-go" "$2"`
-	return []string{"sh", "-c", script, "sh", url, destination}, nil
+install -m 0755 "$tmpdir/ballast-go" "$3"`
+	return []string{"sh", "-c", script, "sh", url, checksumURL, destination}, nil
 }
 
 func releasedGoArchiveURL(release string) (string, error) {
@@ -713,6 +729,10 @@ func releasedGoArchiveURL(release string) (string, error) {
 	}
 	filename := fmt.Sprintf("ballast-go_%s_%s_%s.%s", release, goos, goarch, archiveExt)
 	return fmt.Sprintf("https://github.com/everydaydevopsio/ballast/releases/download/v%s/%s", release, filename), nil
+}
+
+func releasedGoChecksumURL(release string) string {
+	return fmt.Sprintf("https://github.com/everydaydevopsio/ballast/releases/download/v%s/ballast-go_checksums.txt", release)
 }
 
 func releasedGoArchiveParts(goos string, goarch string) (string, string, string, error) {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -288,10 +288,13 @@ func TestRunInstallCLIGoUsesReleaseArchiveForPinnedVersion(t *testing.T) {
 	}
 	got := strings.Join(commands[0], " ")
 	if !strings.Contains(got, "https://github.com/everydaydevopsio/ballast/releases/download/v5.0.2/ballast-go_5.0.2_") {
-		t.Fatalf("expected go install to use a release archive, got %q", got)
+		t.Fatalf("expected installer to use a release archive, got %q", got)
+	}
+	if !strings.Contains(got, "https://github.com/everydaydevopsio/ballast/releases/download/v5.0.2/ballast-go_checksums.txt") {
+		t.Fatalf("expected installer to verify the published checksum asset, got %q", got)
 	}
 	if strings.Contains(got, "go install github.com/everydaydevopsio/ballast/packages/ballast-go/cmd/ballast-go@") {
-		t.Fatalf("expected go install to avoid the invalid module path, got %q", got)
+		t.Fatalf("expected installer to avoid the invalid module path, got %q", got)
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,8 @@ case "$ARCH" in
 esac
 curl -fsSL -o /tmp/ballast-go.tar.gz "https://github.com/everydaydevopsio/ballast/releases/download/v${VERSION}/ballast-go_${VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xzf /tmp/ballast-go.tar.gz -C /tmp
-install -m 0755 /tmp/ballast-go ~/.local/bin/ballast-go
+mkdir -p "${HOME}/.local/bin"
+install -m 0755 /tmp/ballast-go "${HOME}/.local/bin/ballast-go"
 ballast-go install --target cursor --all
 ```
 


### PR DESCRIPTION
## Summary
- switch released `ballast-go` installs in the wrapper from `go install` to the published GitHub release archives
- add a regression test covering the broken `doctor --fix` Go backend install path
- update Go installation docs to match the release-asset distribution model

## Testing
- `pnpm test`
- `pnpm run test:coverage`
- `go test ./...` (in `cli/ballast`)
