### PR TITLE
Update ballast-python uv lockfile

### DIFF
--- a/packages/ballast-python/uv.lock
+++ b/packages/ballast-python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "ballast-python"
-version = "5.0.6"
+version = "5.1.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- regenerate `packages/ballast-python/uv.lock`
- align the editable `ballast-python` package version in the lockfile with `pyproject.toml`
- prevent the Python pre-push hook from rewriting the lockfile on unrelated changes

## Testing
- `uv lock --check`
- `uv run python -m unittest tests.test_cli`