### PR TITLE
Forward --force through ballast upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ ballast doctor
 ballast install-cli --language python
 ballast upgrade
 ballast upgrade --patch
+ballast upgrade --force
 ```
 
 ### Homebrew wrapper on macOS
@@ -276,7 +277,7 @@ Ballast only installs shipped agents and skills and follows the single overwrite
 
 - `ballast install`: install rules for the detected or selected language; `--target` merges into saved targets, `--remove-target` removes saved targets with Ballast-managed cleanup, and `--refresh-config` reapplies saved `.rulesrc.json` settings
 - `ballast doctor`: inspect local Ballast CLI versions and `.rulesrc.json` metadata; add `--fix` to install/upgrade backend CLIs and refresh config automatically, and add `--patch` to merge backend file updates during that refresh
-- `ballast upgrade [--patch]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` forwards patch mode to the backend refresh
+- `ballast upgrade [--patch] [--force]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` and `--force` forward to the backend refresh
 - `ballast install-cli [--language <typescript|python|go|ansible|terraform>] [--version <x.y.z>]`: install or upgrade backend CLIs into the current repo’s `.ballast/` directory; omit `--version` for the latest release. The `ansible` and `terraform` selections reuse the `ballast-go` backend.
 
 ## Config Files

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -348,7 +348,7 @@ func printUsage() {
 	fmt.Println("  install     Install agent rules for the detected or selected language (`--refresh-config` reuses saved .rulesrc.json settings)")
 	fmt.Println("  install-cli Install or upgrade backend CLIs (latest by default, or a specific --version)")
 	fmt.Println("  doctor      Check local Ballast CLI versions and .rulesrc.json metadata (`--fix` installs/upgrades CLIs and refreshes config; add `--patch` with `--fix` to merge backend file updates during refresh)")
-	fmt.Println("  upgrade     Rewrite .rulesrc.json to the running ballast version and sync backend CLIs (`--patch` forwards patch mode to the backend refresh)")
+	fmt.Println("  upgrade     Rewrite .rulesrc.json to the running ballast version and sync backend CLIs (`--patch` and `--force` forward to the backend refresh)")
 	fmt.Println("  help        Show help for ballast")
 	fmt.Println("  version     Print the ballast wrapper version")
 	fmt.Println()
@@ -369,6 +369,7 @@ func printUsage() {
 	fmt.Println("  ballast doctor --fix")
 	fmt.Println("  ballast upgrade")
 	fmt.Println("  ballast upgrade --patch")
+	fmt.Println("  ballast upgrade --force")
 	fmt.Println("  ballast install-cli --language go --version 5.0.2")
 	fmt.Println("  ballast install --target cursor --all --yes   # auto-detect and install across a TypeScript/Python/Go/Ansible/Terraform repo")
 	fmt.Println("  ballast --language python install --target codex --agent linting")
@@ -568,37 +569,13 @@ func runDoctor(selectedLanguage language, args []string) int {
 	printDoctorSummary(root, selectedLanguage, fix)
 
 	if fix {
-		desiredVersion := normalizeVersion(desiredDoctorInstallVersion(root))
-		if exitCode := installCLIs(selectedLanguage, desiredVersion); exitCode != 0 {
-			return exitCode
-		}
-		if fileExists(filepath.Join(root, ".rulesrc.json")) {
-			refreshArgs := []string{"install", "--refresh-config"}
-			if patch {
-				refreshArgs = append(refreshArgs, "--patch")
-			}
-			if selectedLanguage != "" {
-				refreshArgs = append([]string{"--language", string(selectedLanguage)}, refreshArgs...)
-			}
-			exitCode := run(refreshArgs)
-			if exitCode != 0 {
-				return exitCode
-			}
-			if desiredVersion != "" {
-				if err := rewriteDoctorConfigVersion(root, desiredVersion); err != nil {
-					fmt.Println(err)
-					return 1
-				}
-			}
-			return 0
-		}
-		return 0
+		return runDoctorFix(root, selectedLanguage, patch, false)
 	}
 	return 0
 }
 
 func runUpgrade(selectedLanguage language, args []string) int {
-	patch, err := parseUpgradePatch(args)
+	patch, force, err := parseUpgradeOptions(args)
 	if err != nil {
 		fmt.Println(err)
 		return 1
@@ -620,11 +597,40 @@ func runUpgrade(selectedLanguage language, args []string) int {
 		fmt.Println(err)
 		return 1
 	}
-	doctorArgs := []string{"--fix"}
-	if patch {
-		doctorArgs = append(doctorArgs, "--patch")
+	printDoctorSummary(root, selectedLanguage, true)
+	return runDoctorFix(root, selectedLanguage, patch, force)
+}
+
+func runDoctorFix(root string, selectedLanguage language, patch bool, force bool) int {
+	desiredVersion := normalizeVersion(desiredDoctorInstallVersion(root))
+	if exitCode := installCLIs(selectedLanguage, desiredVersion); exitCode != 0 {
+		return exitCode
 	}
-	return runDoctor(selectedLanguage, doctorArgs)
+	if !fileExists(filepath.Join(root, ".rulesrc.json")) {
+		return 0
+	}
+
+	refreshArgs := []string{"install", "--refresh-config"}
+	if patch {
+		refreshArgs = append(refreshArgs, "--patch")
+	}
+	if force {
+		refreshArgs = append(refreshArgs, "--force")
+	}
+	if selectedLanguage != "" {
+		refreshArgs = append([]string{"--language", string(selectedLanguage)}, refreshArgs...)
+	}
+	exitCode := run(refreshArgs)
+	if exitCode != 0 {
+		return exitCode
+	}
+	if desiredVersion != "" {
+		if err := rewriteDoctorConfigVersion(root, desiredVersion); err != nil {
+			fmt.Println(err)
+			return 1
+		}
+	}
+	return 0
 }
 
 func desiredDoctorInstallVersion(root string) string {
@@ -724,17 +730,20 @@ func parseDoctorFix(args []string) (bool, bool, error) {
 	return fix, patch, nil
 }
 
-func parseUpgradePatch(args []string) (bool, error) {
+func parseUpgradeOptions(args []string) (bool, bool, error) {
 	patch := false
+	force := false
 	for _, arg := range args {
 		switch arg {
 		case "--patch":
 			patch = true
+		case "--force":
+			force = true
 		default:
-			return false, fmt.Errorf("unknown upgrade option: %s", arg)
+			return false, false, fmt.Errorf("unknown upgrade option: %s", arg)
 		}
 	}
-	return patch, nil
+	return patch, force, nil
 }
 
 func parseInstallCLIVersion(args []string) (string, error) {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -429,6 +429,52 @@ func TestRunUpgradePatchForwardsPatchToRefreshInstall(t *testing.T) {
 	}
 }
 
+func TestRunUpgradeForceForwardsForceToRefreshInstall(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	var invocation backendInvocation
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		invocation = backendInvocation{Binary: binary, Args: append([]string(nil), args...)}
+		return 0, nil
+	}
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.5",
+  "target":"claude",
+  "agents":["local-dev"],
+  "languages":["typescript"],
+  "paths":{"typescript":["."]}
+}`)
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"upgrade", "--force"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if got := strings.Join(invocation.Args, " "); !strings.Contains(got, "install --force --yes") {
+		t.Fatalf("expected upgrade --force to refresh config via install --force --yes, got %q", got)
+	}
+}
+
 func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 	originalEnsure := ensureInstalledFunc
 	originalExec := execToolFunc

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -475,6 +475,183 @@ func TestRunUpgradeForceForwardsForceToRefreshInstall(t *testing.T) {
 	}
 }
 
+func TestRunDoctorFixForwardsSelectedLanguageToRefreshInstall(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	refreshCount := 0
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		refreshCount++
+		return 0, nil
+	}
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.5",
+  "target":"claude",
+  "agents":["linting"],
+  "languages":["typescript","python","go"],
+  "paths":{
+    "typescript":["packages/ballast-typescript"],
+    "python":["packages/ballast-python"],
+    "go":["packages/ballast-go"]
+  }
+}`)
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"--language", "go", "doctor", "--fix"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if len(commands) != 1 {
+		t.Fatalf("expected one backend install command for go, got %#v", commands)
+	}
+	if refreshCount != 1 {
+		t.Fatalf("expected refresh install to run once for the selected language, got %d", refreshCount)
+	}
+}
+
+func TestRunDoctorFixSkipsRefreshWhenConfigIsMissing(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	refreshCount := 0
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		refreshCount++
+		return 0, nil
+	}
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
+
+	if exitCode := runDoctorFix(root, langGo, false, false); exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if refreshCount != 0 {
+		t.Fatalf("expected no refresh install when .rulesrc.json is missing, got %d", refreshCount)
+	}
+}
+
+func TestRunDoctorFixReportsRewriteFailure(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	refreshCount := 0
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		refreshCount++
+		if refreshCount == 1 {
+			if err := os.Chmod(filepath.Join(dir, ".rulesrc.json"), 0o444); err != nil {
+				t.Fatalf("failed to make .rulesrc.json read-only: %v", err)
+			}
+		}
+		return 0, nil
+	}
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
+	mustWriteFile(t, filepath.Join(root, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.5",
+  "target":"claude",
+  "agents":["linting"],
+  "languages":["typescript","python","go"],
+  "paths":{
+    "typescript":["packages/ballast-typescript"],
+    "python":["packages/ballast-python"],
+    "go":["packages/ballast-go"]
+  }
+}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"--language", "go", "upgrade"})
+			if exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d", exitCode)
+			}
+		})
+	})
+
+	if refreshCount != 1 {
+		t.Fatalf("expected a single refresh install before rewrite failure, got %d", refreshCount)
+	}
+	if !strings.Contains(output, "rulesrc.json") {
+		t.Fatalf("expected rewrite failure to be reported, got %q", output)
+	}
+}
+
+func TestRunUpgradeRejectsUnknownOption(t *testing.T) {
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"upgrade", "--bogus"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "unknown upgrade option: --bogus") {
+		t.Fatalf("expected upgrade option error, got %q", output)
+	}
+}
+
+func TestRunUpgradeRequiresExistingConfig(t *testing.T) {
+	output := captureStdout(t, func() {
+		withWorkingDir(t, t.TempDir(), func() {
+			exitCode := run([]string{"upgrade"})
+			if exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d", exitCode)
+			}
+		})
+	})
+
+	if !strings.Contains(output, "upgrade requires an existing .rulesrc.json") {
+		t.Fatalf("expected missing config error, got %q", output)
+	}
+}
+
 func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 	originalEnsure := ensureInstalledFunc
 	originalExec := execToolFunc

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -192,7 +192,7 @@ For single-language TypeScript installs, the `git-hooks` rules should use `pre-c
 
 - `ballast install`: install rules for the detected or selected language; `--target` merges into saved targets, `--remove-target` removes saved targets with Ballast-managed cleanup, and `--refresh-config` reapplies saved `.rulesrc.json` settings
 - `ballast doctor`: inspect local Ballast CLI versions and `.rulesrc.json` metadata; add `--fix` to install/upgrade backend CLIs and refresh config automatically, and add `--patch` to merge backend file updates during that refresh
-- `ballast upgrade [--patch]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` forwards patch mode to the backend refresh
+- `ballast upgrade [--patch] [--force]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` and `--force` forward to the backend refresh
 - `ballast install-cli [--language <typescript|python|go|ansible|terraform>] [--version <x.y.z>]`: install or upgrade backend CLIs into the current repo’s `.ballast/` directory; omit `--version` for the latest release. The `ansible` and `terraform` selections reuse the `ballast-go` backend.
 
 ## Config Persistence


### PR DESCRIPTION
## Summary
- forward `--force` from `ballast upgrade` into the backend refresh install
- add a wrapper regression test covering `ballast upgrade --force`
- update wrapper help and installation docs to document `upgrade --force`

## Testing
- `pnpm test`
- `pnpm run test:coverage`
- `go test .` from `cli/ballast`
