### PR TITLE
feat: add ballast list command and skills sync conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ pnpm run prettier:fix     # Auto-fix formatting
 - **CI**: When `CI=true` or `--yes` is set and `.rulesrc.json` is missing, `--target` and `--agent` (or `--all`) are required.
 - **Agents**: Only agents shipped in this repo are installable (no external bundle discovery).
 - **Docs sync**: When you add or update an agent, update the docs in `docs/` so they stay in sync: add or update `docs/agents/<id>.md` for that agent, and update the agent table in `docs/README.md` (and any other references, e.g. `docs/installation.md` if needed).
+- **Skills sync**: When you add or update a skill, keep all of the following in sync in the same change: (1) add or update `docs/skills/<id>.md` with the skill guide; (2) add the skill to the Available Skills list and Guides section in `docs/skills/README.md`; (3) add the skill to the Skill Guide Index in `docs/README.md`; (4) add the skill to the Skill Model and Skills sections in `README.md`. The canonical list of available skills is `COMMON_SKILL_IDS` in `packages/ballast-typescript/src/agents.ts` — docs must stay in sync with it.
 
 ## Command Sync
 
@@ -68,6 +69,7 @@ Default license for this project: **MIT**. If you add or modify license setup (L
 - Keep tests next to source (`*.test.ts`); use Jest.
 - Run `pnpm run build` before relying on `packages/ballast-typescript/bin/ballast.js` or `packages/ballast-typescript/dist/`.
 - When adding or updating an agent: update `docs/agents/<id>.md` and the agent table in `docs/README.md` so docs stay in sync (see **Docs sync** under Conventions).
+- When adding or updating a skill: update `docs/skills/<id>.md`, `docs/skills/README.md`, `docs/README.md`, and `README.md` so docs stay in sync (see **Skills sync** under Conventions).
 - See **CLAUDE.md** for more detailed architecture and **rules-installer-architecture.md** for design notes.
 
 ## Installed agent rules

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Common skills (all languages):
 - `aws-health-review`
 - `aws-live-health-review`
 - `aws-weekly-security-review`
+- `github-health-check`
 
 Skill sources in this repo:
 
@@ -89,6 +90,7 @@ Skills are reusable task guides that Ballast installs for the target AI tool alo
 - `aws-health-review`: run a weekly read-only AWS operational health baseline and append prioritized TODO follow-up
 - `aws-live-health-review`: generate a current-state AWS operational snapshot for EC2, RDS, ALB, alarms, and logs
 - `aws-weekly-security-review`: run a weekly read-only AWS security baseline review with prioritized findings
+- `github-health-check`: run a comprehensive GitHub repository health check covering CI status, open PRs, Dependabot, code coverage, and security alerts
 
 ### Install a skill
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Common skills:
 - `aws-health-review`
 - `aws-live-health-review`
 - `aws-weekly-security-review`
+- `github-health-check`
 
 Guide index:
 
@@ -49,6 +50,7 @@ Guide index:
 - [skills/aws-health-review.md](skills/aws-health-review.md)
 - [skills/aws-live-health-review.md](skills/aws-live-health-review.md)
 - [skills/aws-weekly-security-review.md](skills/aws-weekly-security-review.md)
+- [skills/github-health-check.md](skills/github-health-check.md)
 - [skills/owasp-security-scan.md](skills/owasp-security-scan.md)
 
 ## Installation and Monorepos

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -39,9 +39,16 @@ Skills install to the target tool's expected location:
 
 Codex also records installed skills in the root `AGENTS.md`. Claude records them in the root `CLAUDE.md`.
 
+`github-health-check`
+
+- Type: common skill
+- Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
+- Installed by: `--skill github-health-check` or `--all-skills`
+
 ## Guides
 
 - [owasp-security-scan.md](owasp-security-scan.md)
 - [aws-health-review.md](aws-health-review.md)
 - [aws-live-health-review.md](aws-live-health-review.md)
 - [aws-weekly-security-review.md](aws-weekly-security-review.md)
+- [github-health-check.md](github-health-check.md)

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -28,6 +28,12 @@ Ballast ships reusable skill guides alongside its agent rules.
 - Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
 - Installed by: `--skill aws-weekly-security-review` or `--all-skills`
 
+`github-health-check`
+
+- Type: common skill
+- Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
+- Installed by: `--skill github-health-check` or `--all-skills`
+
 ## Installation Targets
 
 Skills install to the target tool's expected location:
@@ -38,12 +44,6 @@ Skills install to the target tool's expected location:
 - Codex: `.codex/rules/<skill>.md`
 
 Codex also records installed skills in the root `AGENTS.md`. Claude records them in the root `CLAUDE.md`.
-
-`github-health-check`
-
-- Type: common skill
-- Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
-- Installed by: `--skill github-health-check` or `--all-skills`
 
 ## Guides
 

--- a/docs/skills/github-health-check.md
+++ b/docs/skills/github-health-check.md
@@ -1,0 +1,48 @@
+# `github-health-check`
+
+The `github-health-check` skill runs a comprehensive GitHub repository health audit using the `gh` CLI. It produces a structured report with status indicators and actionable items, and auto-merges safe Dependabot PRs.
+
+## When To Use It
+
+Use this skill when you want to:
+
+- audit overall repository health
+- check CI workflow status and failure trends
+- review open pull requests and stale branches
+- merge safe Dependabot dependency updates
+- check security alerts and code scanning results
+- review branch protection and Snyk integration
+- get a prioritized list of items that need attention
+
+## Install It
+
+Examples:
+
+```bash
+pnpm exec ballast-typescript install --target codex --skill github-health-check
+ballast-go install --target claude --skill github-health-check
+ballast install --target opencode --skill github-health-check --yes
+```
+
+## Prerequisites
+
+The skill requires the `gh` CLI to be authenticated:
+
+```bash
+gh auth status
+```
+
+## Output Expectations
+
+The skill should:
+
+1. produce a structured Markdown health report
+2. use `PASS`, `WARN`, `FAIL`, and `ERROR` status indicators
+3. include actionable remediation guidance for each finding
+4. auto-merge Dependabot PRs that pass all required checks
+5. surface a prioritized list of items needing attention
+
+## Notes
+
+- The source of truth for this skill is `skills/common/github-health-check/SKILL.md`.
+- All GitHub API access is read-only except for merging safe Dependabot PRs.

--- a/packages/ballast-typescript/src/cli.test.ts
+++ b/packages/ballast-typescript/src/cli.test.ts
@@ -19,6 +19,12 @@ describe('parseArgs', () => {
     });
   });
 
+  test('returns list for list command', () => {
+    expect(parseArgs(['node', 'ballast-typescript', 'list'])).toEqual({
+      list: true
+    });
+  });
+
   test('does not treat doctor as a later install argument', () => {
     expect(
       parseArgs([

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { runInstall } from './install';
-import { LANGUAGES, Language } from './agents';
+import { LANGUAGES, Language, AGENT_IDS, SKILL_IDS } from './agents';
 import { runDoctor } from './doctor';
 import { BALLAST_VERSION } from './version';
 
@@ -21,13 +21,17 @@ export type ParseArgsResult =
   | CliOptions
   | { help: true }
   | { version: true }
-  | { doctor: true };
+  | { doctor: true }
+  | { list: true };
 
 export function parseArgs(argv: string[]): ParseArgsResult {
   const args = argv.slice(2);
   const command = args[0];
   if (command === 'doctor') {
     return { doctor: true };
+  }
+  if (command === 'list') {
+    return { list: true };
   }
   const options: CliOptions = {
     targets: [],
@@ -120,17 +124,18 @@ export function printHelp(): void {
   console.log(`
 ${pkg.name} v${pkg.version}
 
-Usage: ballast-typescript install [options]
+Usage: ballast-typescript <command> [options]
 
 Commands:
   install    Install agent rules for the chosen AI platform (default)
+  list       List available agents and skills
   doctor     Check local Ballast CLI versions and .rulesrc.json metadata
 
 Options:
   --target, -t <platforms>  AI platform(s): cursor, claude, opencode, codex (comma-separated or repeated)
   --language, -l <lang>     Language profile: ${LANGUAGES.join(', ')} (default: typescript)
-  --agent, -a <agents>      Agent(s): linting, local-dev, docs, cicd, observability, publishing, logging, testing (comma-separated)
-  --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review (comma-separated)
+  --agent, -a <agents>      Agent(s) to install (comma-separated); run 'list' to see available agents
+  --skill, -s <skills>      Skill(s) to install (comma-separated); run 'list' to see available skills
   --all                     Install all agents
   --all-skills              Install all skills
   --force, -f               Overwrite existing rule files
@@ -140,15 +145,27 @@ Options:
   --version, -v             Show version
 
 Examples:
+  ballast-typescript list
   ballast-typescript install
   ballast-typescript install --target cursor --agent linting
   ballast-typescript install --target cursor,claude --all
   ballast-typescript install --language python --target cursor --all
   ballast-typescript install --target claude --all --force
   ballast-typescript install --target claude --skill owasp-security-scan
-  ballast-typescript install --target codex --skill aws-health-review
   ballast-typescript install --target cursor --agent linting --patch
   ballast-typescript install --yes --target cursor --all
+`);
+}
+
+export function printList(): void {
+  console.log(`
+Agents
+------
+${AGENT_IDS.map((id) => `  ${id}`).join('\n')}
+
+Skills
+------
+${SKILL_IDS.map((id) => `  ${id}`).join('\n')}
 `);
 }
 
@@ -174,6 +191,10 @@ export async function main(): Promise<void> {
     if (command === 'doctor') {
       process.exit(runDoctor());
     }
+    if (command === 'list') {
+      printList();
+      process.exit(0);
+    }
     console.error(`Unknown command: ${command}`);
     console.error('Run ballast-typescript --help for usage.');
     process.exit(1);
@@ -190,6 +211,10 @@ export async function main(): Promise<void> {
   }
   if ('doctor' in options && options.doctor) {
     process.exit(runDoctor());
+  }
+  if ('list' in options && options.list) {
+    printList();
+    process.exit(0);
   }
   const cliOptions = options as CliOptions;
   if (!LANGUAGES.includes(cliOptions.language as (typeof LANGUAGES)[number])) {

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -212,10 +212,6 @@ export async function main(): Promise<void> {
   if ('doctor' in options && options.doctor) {
     process.exit(runDoctor());
   }
-  if ('list' in options && options.list) {
-    printList();
-    process.exit(0);
-  }
   const cliOptions = options as CliOptions;
   if (!LANGUAGES.includes(cliOptions.language as (typeof LANGUAGES)[number])) {
     console.error(


### PR DESCRIPTION
## Summary

- Add `ballast-typescript list` command that dynamically reads from `AGENT_IDS` and `SKILL_IDS` in `agents.ts`, so the output never goes stale when agents or skills are added
- Remove hardcoded agent/skill lists from `--help`; replace with a pointer to run `list`
- Add **Skills sync** convention to `AGENTS.md` so agents know to keep docs in sync with `COMMON_SKILL_IDS` whenever a skill is added or changed
- Add `github-health-check` to all skill docs (it was in code but missing from `README.md`, `docs/README.md`, and `docs/skills/README.md`)

## Test plan

- [ ] `ballast-typescript list` prints all agents and skills (including `github-health-check`)
- [ ] `ballast-typescript --help` no longer contains hardcoded agent/skill lists; references `list` instead
- [ ] `pnpm test` passes (173 tests)
- [ ] `pnpm run build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)