### PR TITLE
feat: introduce internal agent/skill registry in Go CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,14 @@ repos:
         language: system
         types: [text]
 
+      - id: ballast-unit-tests-pre-push
+        name: pre-push unit tests for cli and language packages
+        entry: scripts/run-unit-tests-pre-push.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: ["pre-push"]
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -41,27 +49,11 @@ repos:
         stages: ["pre-commit"]
 
       - id: sub-pre-commit
-        alias: ballast-typescript-pre-push
-        name: "pre-push for packages/ballast-typescript/"
-        args: ["-p", "packages/ballast-typescript"]
-        pass_filenames: false
-        always_run: true
-        stages: ["pre-push"]
-
-      - id: sub-pre-commit
         alias: ballast-python
         name: "pre-commit for packages/ballast-python/"
         args: ["-p", "packages/ballast-python"]
         files: "^packages/ballast-python/.*"
         stages: ["pre-commit"]
-
-      - id: sub-pre-commit
-        alias: ballast-python-pre-push
-        name: "pre-push for packages/ballast-python/"
-        args: ["-p", "packages/ballast-python"]
-        pass_filenames: false
-        always_run: true
-        stages: ["pre-push"]
 
       - id: sub-pre-commit
         alias: ballast-go
@@ -71,24 +63,8 @@ repos:
         stages: ["pre-commit"]
 
       - id: sub-pre-commit
-        alias: ballast-go-pre-push
-        name: "pre-push for packages/ballast-go/"
-        args: ["-p", "packages/ballast-go"]
-        pass_filenames: false
-        always_run: true
-        stages: ["pre-push"]
-
-      - id: sub-pre-commit
         alias: ballast-cli
         name: "pre-commit for cli/ballast/"
         args: ["-p", "cli/ballast"]
         files: "^cli/ballast/.*"
         stages: ["pre-commit"]
-
-      - id: sub-pre-commit
-        alias: ballast-cli-pre-push
-        name: "pre-push for cli/ballast/"
-        args: ["-p", "cli/ballast"]
-        pass_filenames: false
-        always_run: true
-        stages: ["pre-push"]

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -127,11 +127,6 @@ var runCommandFunc = runCommand
 var resolveInstalledVersionFunc = resolveInstalledVersion
 var collectDoctorBackendsFunc = collectDoctorBackends
 
-var commonAgents = []string{"local-dev", "docs", "cicd", "observability", "publishing", "git-hooks"}
-var languageAgents = []string{"linting", "logging", "testing"}
-var supportedAgents = append(slices.Clone(commonAgents), languageAgents...)
-var supportedSkills = []string{"owasp-security-scan"}
-
 type monorepoConfig struct {
 	Target         string              `json:"target,omitempty"`
 	Targets        []string            `json:"targets,omitempty"`
@@ -1376,14 +1371,24 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 
 	selectedAgents := installAgents
 	if installAll {
-		selectedAgents = append(slices.Clone(commonAgents), languageAgents...)
+		selectedAgents = append(commonAgentIDs(), languageAgentIDs()...)
 	}
 	selectedSkills := installSkills
 	if installAllSkills {
-		selectedSkills = slices.Clone(supportedSkills)
+		selectedSkills = activeSkillIDs()
 	}
 	if err := validateSelectedAgents(selectedAgents); err != nil {
 		return nil, err
+	}
+	for _, agent := range selectedAgents {
+		if w := deprecationWarningForAgent(agent); w != "" {
+			fmt.Fprintln(os.Stderr, "warning:", w)
+		}
+	}
+	for _, skill := range selectedSkills {
+		if w := deprecationWarningForSkill(skill); w != "" {
+			fmt.Fprintln(os.Stderr, "warning:", w)
+		}
 	}
 
 	// Compute agents and skills to persist: merge explicit selection with existing
@@ -1430,8 +1435,8 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		}, nil
 	}
 
-	commonSelection := filterAgents(selectedAgents, commonAgents)
-	languageSelection := filterAgents(selectedAgents, languageAgents)
+	commonSelection := filterAgents(selectedAgents, commonAgentIDs())
+	languageSelection := filterAgents(selectedAgents, languageAgentIDs())
 	baseArgs := withTargetSelection(stripMonorepoFlags(args), requestedTargets)
 
 	plan := make([]backendInvocation, 0, len(profiles)+1)
@@ -1467,7 +1472,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if len(plan) == 0 {
 		return nil, fmt.Errorf(
 			"no supported agents selected for monorepo install; supported agents: %s",
-			strings.Join(supportedAgents, ", "),
+			strings.Join(activeAgentIDs(), ", "),
 		)
 	}
 
@@ -1983,8 +1988,8 @@ func managedRulePaths(root string, target string, config *monorepoConfig) []stri
 	paths := []string{}
 	ext := targetRuleExtension(target)
 	rulesRoot := targetRulesRoot(root, target)
-	commonSelection := filterAgents(config.Agents, commonAgents)
-	languageSelection := filterAgents(config.Agents, languageAgents)
+	commonSelection := filterAgents(config.Agents, commonAgentIDs())
+	languageSelection := filterAgents(config.Agents, languageAgentIDs())
 	for _, agent := range commonSelection {
 		for _, suffix := range ruleSuffixesForAgent(agent) {
 			base := agentBaseName(agent, suffix)
@@ -2190,12 +2195,7 @@ func agentBaseName(agent string, suffix string) string {
 }
 
 func skillDescription(skill string) string {
-	switch skill {
-	case "owasp-security-scan":
-		return "run an OWASP-aligned security audit across Go, TypeScript, and Python projects"
-	default:
-		return skill
-	}
+	return skillDescriptionFromRegistry(skill)
 }
 
 func hasPatchFlag(args []string) bool {
@@ -2341,7 +2341,7 @@ func indexNextHeading(content string) int {
 func validateSelectedAgents(agents []string) error {
 	invalid := []string{}
 	for _, agent := range uniqueStrings(agents) {
-		if !slices.Contains(supportedAgents, agent) {
+		if !isValidAgent(agent) {
 			invalid = append(invalid, agent)
 		}
 	}
@@ -2349,7 +2349,7 @@ func validateSelectedAgents(agents []string) error {
 		return fmt.Errorf(
 			"unsupported agent selection: %s (supported agents: %s)",
 			strings.Join(invalid, ", "),
-			strings.Join(supportedAgents, ", "),
+			strings.Join(activeAgentIDs(), ", "),
 		)
 	}
 	return nil
@@ -2358,7 +2358,7 @@ func validateSelectedAgents(agents []string) error {
 func validateSelectedSkills(skills []string) error {
 	invalid := []string{}
 	for _, skill := range uniqueStrings(skills) {
-		if !slices.Contains(supportedSkills, skill) {
+		if !isValidSkill(skill) {
 			invalid = append(invalid, skill)
 		}
 	}
@@ -2366,7 +2366,7 @@ func validateSelectedSkills(skills []string) error {
 		return fmt.Errorf(
 			"unsupported skill selection: %s (supported skills: %s)",
 			strings.Join(invalid, ", "),
-			strings.Join(supportedSkills, ", "),
+			strings.Join(activeSkillIDs(), ", "),
 		)
 	}
 	return nil

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1375,7 +1375,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	}
 	selectedSkills := installSkills
 	if installAllSkills {
-		selectedSkills = activeSkillIDs()
+		selectedSkills = supportedSkillIDs()
 	}
 	if err := validateSelectedAgents(selectedAgents); err != nil {
 		return nil, err
@@ -1472,7 +1472,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if len(plan) == 0 {
 		return nil, fmt.Errorf(
 			"no supported agents selected for monorepo install; supported agents: %s",
-			strings.Join(activeAgentIDs(), ", "),
+			strings.Join(supportedAgentIDs(), ", "),
 		)
 	}
 
@@ -2349,7 +2349,7 @@ func validateSelectedAgents(agents []string) error {
 		return fmt.Errorf(
 			"unsupported agent selection: %s (supported agents: %s)",
 			strings.Join(invalid, ", "),
-			strings.Join(activeAgentIDs(), ", "),
+			strings.Join(supportedAgentIDs(), ", "),
 		)
 	}
 	return nil
@@ -2366,7 +2366,7 @@ func validateSelectedSkills(skills []string) error {
 		return fmt.Errorf(
 			"unsupported skill selection: %s (supported skills: %s)",
 			strings.Join(invalid, ", "),
-			strings.Join(activeSkillIDs(), ", "),
+			strings.Join(supportedSkillIDs(), ", "),
 		)
 	}
 	return nil

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -2568,3 +2568,48 @@ func captureStdout(t *testing.T, fn func()) string {
 
 	return buf.String()
 }
+
+func TestRegistryConsistency(t *testing.T) {
+	// Every agentRegistry entry must have a non-empty ID.
+	for _, e := range agentRegistry {
+		if e.ID == "" {
+			t.Error("agentRegistry contains an entry with an empty ID")
+		}
+	}
+	// Every skillRegistry entry must have a non-empty ID and description.
+	for _, e := range skillRegistry {
+		if e.ID == "" {
+			t.Error("skillRegistry contains an entry with an empty ID")
+		}
+		if e.Description == "" {
+			t.Errorf("skillRegistry entry %q has no description", e.ID)
+		}
+	}
+	// No duplicate IDs in agentRegistry.
+	seen := map[string]bool{}
+	for _, e := range agentRegistry {
+		if seen[e.ID] {
+			t.Errorf("agentRegistry has duplicate ID %q", e.ID)
+		}
+		seen[e.ID] = true
+	}
+	// No duplicate IDs in skillRegistry.
+	seen = map[string]bool{}
+	for _, e := range skillRegistry {
+		if seen[e.ID] {
+			t.Errorf("skillRegistry has duplicate ID %q", e.ID)
+		}
+		seen[e.ID] = true
+	}
+	// Deprecated entries must have a non-nil Deprecated field.
+	for _, e := range agentRegistry {
+		if e.Status == statusDeprecated && e.Deprecated == nil {
+			t.Errorf("agent %q is deprecated but has no deprecation info", e.ID)
+		}
+	}
+	for _, e := range skillRegistry {
+		if e.Status == statusDeprecated && e.Deprecated == nil {
+			t.Errorf("skill %q is deprecated but has no deprecation info", e.ID)
+		}
+	}
+}

--- a/cli/ballast/registry.go
+++ b/cli/ballast/registry.go
@@ -1,0 +1,213 @@
+package main
+
+// registry.go — single source of truth for all supported agents and skills.
+//
+// When adding, removing, or deprecating an agent or skill:
+//   1. Add/update its entry here.
+//   2. For skills, update skillDescription in main.go accordingly.
+//   3. Keep packages/ballast-typescript/src/agents.ts in sync:
+//      - COMMON_AGENT_IDS / LANGUAGE_AGENT_IDS must match agentRegistry entries.
+//      - COMMON_SKILL_IDS must match skillRegistry entries (non-removed).
+
+// entryStatus tracks the lifecycle state of a registry entry.
+type entryStatus string
+
+const (
+	statusActive     entryStatus = "active"
+	statusDeprecated entryStatus = "deprecated" // warn but still allow
+	statusRemoved    entryStatus = "removed"    // reject at validation
+)
+
+// agentKind controls how an agent is dispatched in monorepo installs.
+// common agents are installed once at the repo root; language agents are
+// installed once per language sub-project.
+type agentKind string
+
+const (
+	kindCommon   agentKind = "common"
+	kindLanguage agentKind = "language"
+)
+
+type deprecationNote struct {
+	Since   string // semver version when deprecated
+	Remove  string // semver version when it will be removed (empty = TBD)
+	Message string // human-readable migration hint
+}
+
+type agentEntry struct {
+	ID         string
+	Kind       agentKind
+	Status     entryStatus
+	Deprecated *deprecationNote // non-nil when Status == statusDeprecated
+}
+
+type skillEntry struct {
+	ID          string
+	Description string
+	Status      entryStatus
+	Deprecated  *deprecationNote // non-nil when Status == statusDeprecated
+}
+
+// agentRegistry is the authoritative list of all agents.
+// Keep in sync with COMMON_AGENT_IDS / LANGUAGE_AGENT_IDS in
+// packages/ballast-typescript/src/agents.ts.
+var agentRegistry = []agentEntry{
+	// Common agents — installed once at repo root, language-agnostic.
+	{ID: "local-dev", Kind: kindCommon, Status: statusActive},
+	{ID: "docs", Kind: kindCommon, Status: statusActive},
+	{ID: "cicd", Kind: kindCommon, Status: statusActive},
+	{ID: "observability", Kind: kindCommon, Status: statusActive},
+	{ID: "publishing", Kind: kindCommon, Status: statusActive},
+	{ID: "git-hooks", Kind: kindCommon, Status: statusActive},
+
+	// Language agents — installed once per language sub-project.
+	{ID: "linting", Kind: kindLanguage, Status: statusActive},
+	{ID: "logging", Kind: kindLanguage, Status: statusActive},
+	{ID: "testing", Kind: kindLanguage, Status: statusActive},
+}
+
+// skillRegistry is the authoritative list of all skills.
+// Keep in sync with COMMON_SKILL_IDS in
+// packages/ballast-typescript/src/agents.ts.
+var skillRegistry = []skillEntry{
+	{
+		ID:          "owasp-security-scan",
+		Description: "run an OWASP-aligned security audit across Go, TypeScript, and Python projects",
+		Status:      statusActive,
+	},
+	{
+		ID:          "aws-health-review",
+		Description: "run a weekly read-only AWS health review covering configuration, performance, errors, and warnings",
+		Status:      statusActive,
+	},
+	{
+		ID:          "aws-live-health-review",
+		Description: "run a read-only AWS live health review for current EC2, RDS, ALB, CloudWatch alarms, and logs",
+		Status:      statusActive,
+	},
+	{
+		ID:          "aws-weekly-security-review",
+		Description: "run a weekly read-only AWS security baseline review and generate a prioritized findings report",
+		Status:      statusActive,
+	},
+	{
+		ID:          "github-health-check",
+		Description: "run a comprehensive GitHub repository health check covering CI status, branch hygiene, and repo configuration",
+		Status:      statusActive,
+	},
+}
+
+// — Agent registry helpers —————————————————————————————————————————————————
+
+// activeAgentIDs returns all non-removed agent IDs.
+func activeAgentIDs() []string {
+	var ids []string
+	for _, e := range agentRegistry {
+		if e.Status != statusRemoved {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// commonAgentIDs returns non-removed agent IDs with kindCommon.
+func commonAgentIDs() []string {
+	var ids []string
+	for _, e := range agentRegistry {
+		if e.Kind == kindCommon && e.Status != statusRemoved {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// languageAgentIDs returns non-removed agent IDs with kindLanguage.
+func languageAgentIDs() []string {
+	var ids []string
+	for _, e := range agentRegistry {
+		if e.Kind == kindLanguage && e.Status != statusRemoved {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// isValidAgent reports whether id is a known, non-removed agent.
+func isValidAgent(id string) bool {
+	for _, e := range agentRegistry {
+		if e.ID == id && e.Status != statusRemoved {
+			return true
+		}
+	}
+	return false
+}
+
+// deprecationWarningForAgent returns a non-empty warning string when the agent
+// is deprecated, empty string otherwise.
+func deprecationWarningForAgent(id string) string {
+	for _, e := range agentRegistry {
+		if e.ID == id && e.Status == statusDeprecated && e.Deprecated != nil {
+			msg := "agent " + id + " is deprecated since " + e.Deprecated.Since
+			if e.Deprecated.Remove != "" {
+				msg += " and will be removed in " + e.Deprecated.Remove
+			}
+			if e.Deprecated.Message != "" {
+				msg += ": " + e.Deprecated.Message
+			}
+			return msg
+		}
+	}
+	return ""
+}
+
+// — Skill registry helpers —————————————————————————————————————————————————
+
+// activeSkillIDs returns all non-removed skill IDs.
+func activeSkillIDs() []string {
+	var ids []string
+	for _, e := range skillRegistry {
+		if e.Status != statusRemoved {
+			ids = append(ids, e.ID)
+		}
+	}
+	return ids
+}
+
+// isValidSkill reports whether id is a known, non-removed skill.
+func isValidSkill(id string) bool {
+	for _, e := range skillRegistry {
+		if e.ID == id && e.Status != statusRemoved {
+			return true
+		}
+	}
+	return false
+}
+
+// skillDescriptionFromRegistry returns the description for a skill from the
+// registry, falling back to the skill ID if not found.
+func skillDescriptionFromRegistry(id string) string {
+	for _, e := range skillRegistry {
+		if e.ID == id {
+			return e.Description
+		}
+	}
+	return id
+}
+
+// deprecationWarningForSkill returns a non-empty warning string when the skill
+// is deprecated, empty string otherwise.
+func deprecationWarningForSkill(id string) string {
+	for _, e := range skillRegistry {
+		if e.ID == id && e.Status == statusDeprecated && e.Deprecated != nil {
+			msg := "skill " + id + " is deprecated since " + e.Deprecated.Since
+			if e.Deprecated.Remove != "" {
+				msg += " and will be removed in " + e.Deprecated.Remove
+			}
+			if e.Deprecated.Message != "" {
+				msg += ": " + e.Deprecated.Message
+			}
+			return msg
+		}
+	}
+	return ""
+}

--- a/cli/ballast/registry.go
+++ b/cli/ballast/registry.go
@@ -4,7 +4,7 @@ package main
 //
 // When adding, removing, or deprecating an agent or skill:
 //   1. Add/update its entry here.
-//   2. For skills, update skillDescription in main.go accordingly.
+//   2. For skills, add/update the Description field in skillRegistry here.
 //   3. Keep packages/ballast-typescript/src/agents.ts in sync:
 //      - COMMON_AGENT_IDS / LANGUAGE_AGENT_IDS must match agentRegistry entries.
 //      - COMMON_SKILL_IDS must match skillRegistry entries (non-removed).
@@ -99,8 +99,8 @@ var skillRegistry = []skillEntry{
 
 // — Agent registry helpers —————————————————————————————————————————————————
 
-// activeAgentIDs returns all non-removed agent IDs.
-func activeAgentIDs() []string {
+// supportedAgentIDs returns all non-removed agent IDs (active and deprecated).
+func supportedAgentIDs() []string {
 	var ids []string
 	for _, e := range agentRegistry {
 		if e.Status != statusRemoved {
@@ -162,8 +162,8 @@ func deprecationWarningForAgent(id string) string {
 
 // — Skill registry helpers —————————————————————————————————————————————————
 
-// activeSkillIDs returns all non-removed skill IDs.
-func activeSkillIDs() []string {
+// supportedSkillIDs returns all non-removed skill IDs (active and deprecated).
+func supportedSkillIDs() []string {
 	var ids []string
 	for _, e := range skillRegistry {
 		if e.Status != statusRemoved {

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -31,6 +31,7 @@ var commonSkills = []string{
 	"aws-health-review",
 	"aws-live-health-review",
 	"aws-weekly-security-review",
+	"github-health-check",
 }
 
 var descriptionRegex = regexp.MustCompile(`(?m)^description:\s*['\"]?(.+?)['\"]?\s*$`)
@@ -339,7 +340,7 @@ Options:
   --target, -t <platform>   AI platforms: %s (comma-separated or repeatable)
   --language, -l <lang>     Language profile: %s (default: go)
   --agent, -a <agents>      Agent(s): linting, local-dev, docs, cicd, observability, publishing, git-hooks, logging, testing (comma-separated)
-  --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review (comma-separated)
+  --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check (comma-separated)
   --all                     Install all agents
   --all-skills              Install all skills
   --force                   Overwrite existing rule files

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -81,15 +81,19 @@ func TestRunInstallHelpFlag(t *testing.T) {
 	if !strings.Contains(output, "aws-health-review") {
 		t.Fatalf("expected new skills in help output, got %q", output)
 	}
+	if !strings.Contains(output, "github-health-check") {
+		t.Fatalf("expected github-health-check in help output, got %q", output)
+	}
 }
 
-func TestListSkillsIncludesAWSReviews(t *testing.T) {
+func TestListSkillsIncludesAllRegistrySkills(t *testing.T) {
 	got := listSkills("go")
 	want := []string{
 		"owasp-security-scan",
 		"aws-health-review",
 		"aws-live-health-review",
 		"aws-weekly-security-review",
+		"github-health-check",
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("expected %v, got %v", want, got)

--- a/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: github-health-check
+description: >
+  Run a comprehensive GitHub repository health check. Use this skill whenever
+  the user asks to: check GitHub health, audit the repo, check CI status,
+  review open PRs, merge Dependabot PRs, check code coverage, check security
+  alerts, check Snyk integration, keep GitHub in good shape, or any variation
+  of "how is the repo doing". Also trigger for: "check dependabot PRs",
+  "any PRs to merge", "check branch status", "repo health", "GitHub status
+  check", "what needs attention in GitHub", "tidy up GitHub".
+---
+
+# GitHub Repository Health Check Skill
+
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs.
+
+---
+
+## Prerequisites
+
+```bash
+# Verify gh is authenticated and repo context is available
+gh auth status
+gh repo view --json name,owner,defaultBranchRef
+```
+
+Capture the repo owner and name for use in API calls:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+NAME=$(gh repo view --json name --jq '.name')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+---
+
+## Check 1 — GitHub Actions Status (default branch)
+
+```bash
+# Recent workflow runs on the default branch
+gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
+  --json status,conclusion,name,workflowName,createdAt,url \
+  --jq '.[] | {workflow: .workflowName, status: .status, conclusion: .conclusion, created: .createdAt, url: .url}'
+```
+
+**Interpret results:**
+- Group runs by workflow name; show the latest run per workflow
+- Flag any workflow whose latest run concluded with `failure` or `cancelled`
+- Flag workflows that haven't run in more than 14 days
+- Show overall summary: X workflows passing, Y failing
+
+```bash
+# Check for any in-progress or queued runs
+gh run list --branch "$DEFAULT_BRANCH" --status in_progress --json workflowName,url
+gh run list --branch "$DEFAULT_BRANCH" --status queued --json workflowName,url
+```
+
+---
+
+## Check 2 — Branch Freshness vs Latest Release
+
+```bash
+# Get the latest release tag
+LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "none"')
+echo "Latest release: $LATEST_TAG"
+
+# Count commits on default branch since last release
+if [ "$LATEST_TAG" != "none" ]; then
+  git fetch --tags 2>/dev/null || true
+  COMMITS_AHEAD=$(git rev-list "${LATEST_TAG}..HEAD" --count 2>/dev/null || echo "unknown")
+  echo "Commits since last release: $COMMITS_AHEAD"
+
+  # Show recent unreleased commits
+  git log "${LATEST_TAG}..HEAD" --oneline 2>/dev/null | head -10 || true
+fi
+
+# Get last release date
+gh release list --limit 1 --json tagName,publishedAt \
+  --jq '.[] | "Tag: \(.tagName)  Published: \(.publishedAt)"'
+```
+
+**Interpret results:**
+- If commits ahead > 20: warn that a release may be overdue
+- If last release was more than 30 days ago: note it
+- If no releases exist: note that versioned releases are not configured
+
+---
+
+## Check 3 — Open Pull Requests
+
+```bash
+# List all open PRs with key metadata
+gh pr list --state open --json number,title,author,isDraft,createdAt,labels,headRefName,reviewDecision,statusCheckRollup \
+  --jq '.[] | {
+    number: .number,
+    title: .title,
+    author: .author.login,
+    isDraft: .isDraft,
+    created: .createdAt,
+    branch: .headRefName,
+    review: .reviewDecision,
+    checks: (.statusCheckRollup // [] | {
+      total: length,
+      passing: map(select(.conclusion == "SUCCESS")) | length,
+      failing: map(select(.conclusion == "FAILURE")) | length
+    })
+  }'
+```
+
+**Report:**
+- Total open PRs, draft vs ready
+- PRs older than 7 days without activity (stale)
+- PRs with failing checks
+- PRs awaiting review
+
+### Dependabot PR Auto-Merge
+
+```bash
+# Get all open Dependabot PRs
+gh pr list --state open --author "app/dependabot" \
+  --json number,title,headRefName,statusCheckRollup,isDraft,mergeable
+```
+
+For each Dependabot PR returned, apply this decision logic:
+
+1. **Parse the version bump** from the PR title (format: "Bump X from A.B.C to D.E.F"):
+   - Extract `from` version and `to` version
+   - Compare the major version (first number): if major version changes → **SKIP** (major upgrade)
+   - If only minor/patch changes → candidate for auto-merge
+
+2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+   ```bash
+   gh pr checks <PR_NUMBER> --json name,state,conclusion
+   ```
+
+3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
+
+4. **Auto-merge if all conditions pass** (no confirmation needed):
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --auto
+   ```
+
+5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
+
+**Example major version detection:**
+- "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
+- "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
+- "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
+
+---
+
+## Check 4 — Code Coverage (Codecov)
+
+```bash
+# Check for codecov configuration file
+ls .codecov.yml codecov.yml .codecov.yaml codecov.yaml 2>/dev/null || echo "No codecov config file found"
+
+# Check for codecov in CI workflows
+grep -rl "codecov" .github/workflows/ 2>/dev/null || echo "No codecov step found in workflows"
+
+# Check README for codecov badge
+grep -i "codecov" README.md 2>/dev/null | head -3 || echo "No codecov badge in README"
+
+# Check if codecov token is configured as a repo secret (presence only, not value)
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i codecov || echo "No CODECOV secret found"
+```
+
+**Interpret results:**
+- If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
+- If present: confirm coverage reporting is active
+
+---
+
+## Check 5 — Security Alerts
+
+```bash
+# Count open Dependabot security alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
+  echo "Could not fetch Dependabot alert count (check repo permissions)"
+
+# Show top severity alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
+  --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
+
+# Code scanning alerts (SAST / CodeQL)
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
+  echo "Code scanning: not enabled or no access"
+
+# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
+  echo "Secret scanning: not enabled or no access"
+```
+
+**Interpret results:**
+- Open Dependabot security alerts > 0: list them with severity (critical/high first)
+- Code scanning alerts: show count and any critical/high items
+- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+---
+
+## Check 6 — Snyk Integration
+
+```bash
+# Check for .snyk policy file
+ls .snyk 2>/dev/null && echo "Snyk policy file found: .snyk" || echo "No .snyk file"
+
+# Check CI workflows for Snyk
+grep -rl "snyk" .github/workflows/ 2>/dev/null || echo "No Snyk step found in workflows"
+
+# Check README for Snyk badge
+grep -i "snyk" README.md 2>/dev/null | head -3 || echo "No Snyk badge in README"
+
+# Check for snyk-related secrets
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i snyk || echo "No SNYK secret found"
+```
+
+**Interpret results:**
+- If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
+- If partially configured: note what's present and what's missing
+
+---
+
+## Check 7 — Branch Protection Rules
+
+```bash
+# Check protection rules on the default branch
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null || \
+  echo "WARNING: No branch protection rules found on ${DEFAULT_BRANCH}"
+
+# Parse and summarize key protections
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null | \
+  python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    good, bad = [], []
+    if p.get('required_pull_request_reviews'): good.append('PR reviews required')
+    else: bad.append('No required PR reviews')
+    if p.get('required_status_checks'): good.append('Status checks required')
+    else: bad.append('No required status checks')
+    if p.get('enforce_admins', {}).get('enabled'): good.append('Rules enforced for admins')
+    if p.get('allow_force_pushes', {}).get('enabled'): bad.append('Force pushes allowed on main')
+    if p.get('allow_deletions', {}).get('enabled'): bad.append('Branch deletion allowed')
+    for g in good: print('OK:', g)
+    for b in bad: print('WARN:', b)
+except Exception as e: print('Could not parse:', e)
+" 2>/dev/null || true
+```
+
+**Flag missing protections:**
+- No required PR reviews: warn
+- No required status checks: warn
+- Force pushes allowed on main: warn
+- No branch protection at all: flag as high priority
+
+---
+
+## Check 8 — Stale Branches
+
+```bash
+# List remote branches not merged to default branch, sorted by last commit date
+git fetch --prune 2>/dev/null || true
+git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --sort=-committerdate \
+  --format='%(committerdate:relative)|%(refname:short)' 2>/dev/null | \
+  grep -v "HEAD\|${DEFAULT_BRANCH}" | head -20
+
+# Count stale branches (no commits in 30+ days, not yet merged)
+STALE_COUNT=$(git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --format='%(committerdate:unix)|%(refname:short)' 2>/dev/null | \
+  python3 -c "
+import sys
+from datetime import datetime, timezone
+cutoff = datetime.now(timezone.utc).timestamp() - 30 * 86400
+count = 0
+for line in sys.stdin:
+    parts = line.strip().split('|')
+    if len(parts) == 2 and parts[0].isdigit() and int(parts[0]) < cutoff:
+        count += 1
+print(count)
+" 2>/dev/null || echo "0")
+echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
+```
+
+---
+
+## Check 9 — Repository Housekeeping
+
+```bash
+# Check for essential files
+for f in README.md LICENSE .gitignore .github/dependabot.yml SECURITY.md .github/CODEOWNERS CODEOWNERS; do
+  [ -f "$f" ] && echo "OK: $f" || echo "MISSING: $f"
+done
+
+# Dependabot config check
+if [ -f ".github/dependabot.yml" ]; then
+  echo "Dependabot ecosystems configured:"
+  grep "package-ecosystem" .github/dependabot.yml | sort | uniq -c
+else
+  echo "WARNING: No .github/dependabot.yml — automated dependency updates not configured"
+fi
+
+# Check repo has a description and topics
+gh repo view --json description,repositoryTopics \
+  --jq '"Description: \(.description // "MISSING — add in repo settings")\nTopics: \(.repositoryTopics.nodes | map(.topic.name) | join(", ") | if . == "" then "NONE — add topics for discoverability" else . end)"'
+```
+
+---
+
+## Check 10 — Workflow Health Patterns
+
+```bash
+# Detect consistently failing workflows (>50% failure rate over recent runs)
+gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
+  --json workflowName,conclusion,createdAt \
+  --jq 'group_by(.workflowName) | .[] | {
+    workflow: .[0].workflowName,
+    runs: length,
+    failures: map(select(.conclusion == "failure")) | length
+  } | select(.runs >= 3) |
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+```
+
+---
+
+## Check 11 — Release & Tag Health
+
+```bash
+# List recent releases
+gh release list --limit 5 --json tagName,publishedAt,isDraft,isPrerelease \
+  --jq '.[] | "\(.tagName) [\(if .isDraft then "DRAFT" elif .isPrerelease then "PRE-RELEASE" else "RELEASED" end)] — \(.publishedAt)"'
+
+# Check for unpublished draft releases
+DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | length' 2>/dev/null || echo "0")
+[ "$DRAFT_COUNT" -gt 0 ] && echo "WARNING: $DRAFT_COUNT unpublished draft release(s)" || true
+```
+
+---
+
+## Check 12 — Actions Permissions & Secrets Health
+
+```bash
+# Check default workflow permissions
+gh api "/repos/${OWNER}/${NAME}/actions/permissions" \
+  --jq '"Actions enabled: \(.enabled)\nDefault permission: \(.default_workflow_permissions // "unknown")"' 2>/dev/null
+
+# List repo secret names and ages (values never shown)
+echo "--- Repository Secrets ---"
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" \
+  --jq '.secrets[] | "\(.name) (last updated: \(.updated_at))"' 2>/dev/null
+
+# Warn about secrets not rotated in 180+ days
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" 2>/dev/null | \
+  python3 -c "
+import sys, json
+from datetime import datetime, timezone
+try:
+    data = json.load(sys.stdin)
+    for s in data.get('secrets', []):
+        updated = s.get('updated_at', '')
+        try:
+            dt = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+            age = (datetime.now(timezone.utc) - dt).days
+            if age > 180:
+                print(f'STALE SECRET ({age} days): {s[\"name\"]} — consider rotating')
+        except: pass
+except: pass
+" 2>/dev/null || true
+```
+
+---
+
+## Generate Health Report
+
+After running all checks, present findings in this structure:
+
+```text
+## GitHub Repository Health Report
+**Repo**: owner/name
+**Date**: <today>
+**Default Branch**: main
+
+---
+### Overall Status: [HEALTHY | NEEDS ATTENTION | CRITICAL]
+
+---
+### CI/CD  ✅/⚠️/❌
+| Workflow | Latest Status | Last Run |
+|----------|--------------|----------|
+| ...      | ✅/❌        | ...      |
+
+---
+### Pull Requests
+- Open PRs: N (D draft, R ready for review)
+- Stale PRs (>7 days, no activity): N
+- Dependabot PRs auto-merged: N (list titles)
+- Dependabot PRs skipped: N (list with reason)
+
+---
+### Security  ✅/⚠️/❌
+- Dependabot alerts: N open (X critical, Y high)
+- Code scanning (CodeQL): enabled/NOT ENABLED
+- Secret scanning: N open alerts
+- Snyk: configured / NOT CONFIGURED ⚠️
+- Branch protection on main: summary of rules
+
+---
+### Code Coverage  ✅/⚠️
+- Codecov: configured / NOT CONFIGURED ⚠️
+
+---
+### Repository Housekeeping  ✅/⚠️
+- Missing essential files: list or "none"
+- Dependabot auto-updates: configured / missing
+- Stale unmerged branches: N
+- Draft releases: N
+
+---
+### Recommended Actions (prioritized)
+1. [CRITICAL] ...
+2. [HIGH] ...
+3. [MEDIUM] ...
+4. [LOW/NICE-TO-HAVE] ...
+```
+
+---
+
+## Edge Cases
+
+- **Private repo without security features**: Some APIs require admin access; note when commands fail with 403/404 and suggest the user checks repo settings manually
+- **Org-managed repos**: Branch protection and secrets may be inherited from org settings; note this if the API returns 403
+- **No releases yet**: Skip release freshness checks; note that versioned releases are not configured
+- **Rate limiting**: If `gh` returns 429, note that data may be incomplete and suggest retrying
+- **Monorepo**: If multiple `package.json` / `go.mod` / `pyproject.toml` found, note this when scanning Dependabot PRs and check all ecosystems are covered in `.github/dependabot.yml`
+- **gh not authenticated**: Exit immediately with instructions: run `gh auth login`
+- **No open PRs**: Confirm the repo is clean; no merging needed

--- a/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/claude-settings.json
+++ b/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/claude-settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh auth*)",
+      "Bash(gh repo*)",
+      "Bash(gh run*)",
+      "Bash(gh release*)",
+      "Bash(gh pr*)",
+      "Bash(gh api*)",
+      "Bash(git fetch*)",
+      "Bash(git log*)",
+      "Bash(git rev-list*)",
+      "Bash(git branch*)",
+      "Bash(git describe*)",
+      "Bash(python3 -c*)"
+    ]
+  }
+}

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -36,6 +36,7 @@ COMMON_SKILLS = [
     "aws-health-review",
     "aws-live-health-review",
     "aws-weekly-security-review",
+    "github-health-check",
 ]
 SKILLS_BY_LANGUAGE = {
     "typescript": COMMON_SKILLS,

--- a/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
@@ -1,0 +1,441 @@
+---
+name: github-health-check
+description: >
+  Run a comprehensive GitHub repository health check. Use this skill whenever
+  the user asks to: check GitHub health, audit the repo, check CI status,
+  review open PRs, merge Dependabot PRs, check code coverage, check security
+  alerts, check Snyk integration, keep GitHub in good shape, or any variation
+  of "how is the repo doing". Also trigger for: "check dependabot PRs",
+  "any PRs to merge", "check branch status", "repo health", "GitHub status
+  check", "what needs attention in GitHub", "tidy up GitHub".
+---
+
+# GitHub Repository Health Check Skill
+
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs.
+
+---
+
+## Prerequisites
+
+```bash
+# Verify gh is authenticated and repo context is available
+gh auth status
+gh repo view --json name,owner,defaultBranchRef
+```
+
+Capture the repo owner and name for use in API calls:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+NAME=$(gh repo view --json name --jq '.name')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+---
+
+## Check 1 — GitHub Actions Status (default branch)
+
+```bash
+# Recent workflow runs on the default branch
+gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
+  --json status,conclusion,name,workflowName,createdAt,url \
+  --jq '.[] | {workflow: .workflowName, status: .status, conclusion: .conclusion, created: .createdAt, url: .url}'
+```
+
+**Interpret results:**
+- Group runs by workflow name; show the latest run per workflow
+- Flag any workflow whose latest run concluded with `failure` or `cancelled`
+- Flag workflows that haven't run in more than 14 days
+- Show overall summary: X workflows passing, Y failing
+
+```bash
+# Check for any in-progress or queued runs
+gh run list --branch "$DEFAULT_BRANCH" --status in_progress --json workflowName,url
+gh run list --branch "$DEFAULT_BRANCH" --status queued --json workflowName,url
+```
+
+---
+
+## Check 2 — Branch Freshness vs Latest Release
+
+```bash
+# Get the latest release tag
+LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "none"')
+echo "Latest release: $LATEST_TAG"
+
+# Count commits on default branch since last release
+if [ "$LATEST_TAG" != "none" ]; then
+  git fetch --tags 2>/dev/null || true
+  COMMITS_AHEAD=$(git rev-list "${LATEST_TAG}..HEAD" --count 2>/dev/null || echo "unknown")
+  echo "Commits since last release: $COMMITS_AHEAD"
+
+  # Show recent unreleased commits
+  git log "${LATEST_TAG}..HEAD" --oneline 2>/dev/null | head -10 || true
+fi
+
+# Get last release date
+gh release list --limit 1 --json tagName,publishedAt \
+  --jq '.[] | "Tag: \(.tagName)  Published: \(.publishedAt)"'
+```
+
+**Interpret results:**
+- If commits ahead > 20: warn that a release may be overdue
+- If last release was more than 30 days ago: note it
+- If no releases exist: note that versioned releases are not configured
+
+---
+
+## Check 3 — Open Pull Requests
+
+```bash
+# List all open PRs with key metadata
+gh pr list --state open --json number,title,author,isDraft,createdAt,labels,headRefName,reviewDecision,statusCheckRollup \
+  --jq '.[] | {
+    number: .number,
+    title: .title,
+    author: .author.login,
+    isDraft: .isDraft,
+    created: .createdAt,
+    branch: .headRefName,
+    review: .reviewDecision,
+    checks: (.statusCheckRollup // [] | {
+      total: length,
+      passing: map(select(.conclusion == "SUCCESS")) | length,
+      failing: map(select(.conclusion == "FAILURE")) | length
+    })
+  }'
+```
+
+**Report:**
+- Total open PRs, draft vs ready
+- PRs older than 7 days without activity (stale)
+- PRs with failing checks
+- PRs awaiting review
+
+### Dependabot PR Auto-Merge
+
+```bash
+# Get all open Dependabot PRs
+gh pr list --state open --author "app/dependabot" \
+  --json number,title,headRefName,statusCheckRollup,isDraft,mergeable
+```
+
+For each Dependabot PR returned, apply this decision logic:
+
+1. **Parse the version bump** from the PR title (format: "Bump X from A.B.C to D.E.F"):
+   - Extract `from` version and `to` version
+   - Compare the major version (first number): if major version changes → **SKIP** (major upgrade)
+   - If only minor/patch changes → candidate for auto-merge
+
+2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+   ```bash
+   gh pr checks <PR_NUMBER> --json name,state,conclusion
+   ```
+
+3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
+
+4. **Auto-merge if all conditions pass** (no confirmation needed):
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --auto
+   ```
+
+5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
+
+**Example major version detection:**
+- "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
+- "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
+- "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
+
+---
+
+## Check 4 — Code Coverage (Codecov)
+
+```bash
+# Check for codecov configuration file
+ls .codecov.yml codecov.yml .codecov.yaml codecov.yaml 2>/dev/null || echo "No codecov config file found"
+
+# Check for codecov in CI workflows
+grep -rl "codecov" .github/workflows/ 2>/dev/null || echo "No codecov step found in workflows"
+
+# Check README for codecov badge
+grep -i "codecov" README.md 2>/dev/null | head -3 || echo "No codecov badge in README"
+
+# Check if codecov token is configured as a repo secret (presence only, not value)
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i codecov || echo "No CODECOV secret found"
+```
+
+**Interpret results:**
+- If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
+- If present: confirm coverage reporting is active
+
+---
+
+## Check 5 — Security Alerts
+
+```bash
+# Count open Dependabot security alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
+  echo "Could not fetch Dependabot alert count (check repo permissions)"
+
+# Show top severity alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
+  --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
+
+# Code scanning alerts (SAST / CodeQL)
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
+  echo "Code scanning: not enabled or no access"
+
+# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
+  echo "Secret scanning: not enabled or no access"
+```
+
+**Interpret results:**
+- Open Dependabot security alerts > 0: list them with severity (critical/high first)
+- Code scanning alerts: show count and any critical/high items
+- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+---
+
+## Check 6 — Snyk Integration
+
+```bash
+# Check for .snyk policy file
+ls .snyk 2>/dev/null && echo "Snyk policy file found: .snyk" || echo "No .snyk file"
+
+# Check CI workflows for Snyk
+grep -rl "snyk" .github/workflows/ 2>/dev/null || echo "No Snyk step found in workflows"
+
+# Check README for Snyk badge
+grep -i "snyk" README.md 2>/dev/null | head -3 || echo "No Snyk badge in README"
+
+# Check for snyk-related secrets
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i snyk || echo "No SNYK secret found"
+```
+
+**Interpret results:**
+- If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
+- If partially configured: note what's present and what's missing
+
+---
+
+## Check 7 — Branch Protection Rules
+
+```bash
+# Check protection rules on the default branch
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null || \
+  echo "WARNING: No branch protection rules found on ${DEFAULT_BRANCH}"
+
+# Parse and summarize key protections
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null | \
+  python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    good, bad = [], []
+    if p.get('required_pull_request_reviews'): good.append('PR reviews required')
+    else: bad.append('No required PR reviews')
+    if p.get('required_status_checks'): good.append('Status checks required')
+    else: bad.append('No required status checks')
+    if p.get('enforce_admins', {}).get('enabled'): good.append('Rules enforced for admins')
+    if p.get('allow_force_pushes', {}).get('enabled'): bad.append('Force pushes allowed on main')
+    if p.get('allow_deletions', {}).get('enabled'): bad.append('Branch deletion allowed')
+    for g in good: print('OK:', g)
+    for b in bad: print('WARN:', b)
+except Exception as e: print('Could not parse:', e)
+" 2>/dev/null || true
+```
+
+**Flag missing protections:**
+- No required PR reviews: warn
+- No required status checks: warn
+- Force pushes allowed on main: warn
+- No branch protection at all: flag as high priority
+
+---
+
+## Check 8 — Stale Branches
+
+```bash
+# List remote branches not merged to default branch, sorted by last commit date
+git fetch --prune 2>/dev/null || true
+git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --sort=-committerdate \
+  --format='%(committerdate:relative)|%(refname:short)' 2>/dev/null | \
+  grep -v "HEAD\|${DEFAULT_BRANCH}" | head -20
+
+# Count stale branches (no commits in 30+ days, not yet merged)
+STALE_COUNT=$(git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --format='%(committerdate:unix)|%(refname:short)' 2>/dev/null | \
+  python3 -c "
+import sys
+from datetime import datetime, timezone
+cutoff = datetime.now(timezone.utc).timestamp() - 30 * 86400
+count = 0
+for line in sys.stdin:
+    parts = line.strip().split('|')
+    if len(parts) == 2 and parts[0].isdigit() and int(parts[0]) < cutoff:
+        count += 1
+print(count)
+" 2>/dev/null || echo "0")
+echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
+```
+
+---
+
+## Check 9 — Repository Housekeeping
+
+```bash
+# Check for essential files
+for f in README.md LICENSE .gitignore .github/dependabot.yml SECURITY.md .github/CODEOWNERS CODEOWNERS; do
+  [ -f "$f" ] && echo "OK: $f" || echo "MISSING: $f"
+done
+
+# Dependabot config check
+if [ -f ".github/dependabot.yml" ]; then
+  echo "Dependabot ecosystems configured:"
+  grep "package-ecosystem" .github/dependabot.yml | sort | uniq -c
+else
+  echo "WARNING: No .github/dependabot.yml — automated dependency updates not configured"
+fi
+
+# Check repo has a description and topics
+gh repo view --json description,repositoryTopics \
+  --jq '"Description: \(.description // "MISSING — add in repo settings")\nTopics: \(.repositoryTopics.nodes | map(.topic.name) | join(", ") | if . == "" then "NONE — add topics for discoverability" else . end)"'
+```
+
+---
+
+## Check 10 — Workflow Health Patterns
+
+```bash
+# Detect consistently failing workflows (>50% failure rate over recent runs)
+gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
+  --json workflowName,conclusion,createdAt \
+  --jq 'group_by(.workflowName) | .[] | {
+    workflow: .[0].workflowName,
+    runs: length,
+    failures: map(select(.conclusion == "failure")) | length
+  } | select(.runs >= 3) |
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+```
+
+---
+
+## Check 11 — Release & Tag Health
+
+```bash
+# List recent releases
+gh release list --limit 5 --json tagName,publishedAt,isDraft,isPrerelease \
+  --jq '.[] | "\(.tagName) [\(if .isDraft then "DRAFT" elif .isPrerelease then "PRE-RELEASE" else "RELEASED" end)] — \(.publishedAt)"'
+
+# Check for unpublished draft releases
+DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | length' 2>/dev/null || echo "0")
+[ "$DRAFT_COUNT" -gt 0 ] && echo "WARNING: $DRAFT_COUNT unpublished draft release(s)" || true
+```
+
+---
+
+## Check 12 — Actions Permissions & Secrets Health
+
+```bash
+# Check default workflow permissions
+gh api "/repos/${OWNER}/${NAME}/actions/permissions" \
+  --jq '"Actions enabled: \(.enabled)\nDefault permission: \(.default_workflow_permissions // "unknown")"' 2>/dev/null
+
+# List repo secret names and ages (values never shown)
+echo "--- Repository Secrets ---"
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" \
+  --jq '.secrets[] | "\(.name) (last updated: \(.updated_at))"' 2>/dev/null
+
+# Warn about secrets not rotated in 180+ days
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" 2>/dev/null | \
+  python3 -c "
+import sys, json
+from datetime import datetime, timezone
+try:
+    data = json.load(sys.stdin)
+    for s in data.get('secrets', []):
+        updated = s.get('updated_at', '')
+        try:
+            dt = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+            age = (datetime.now(timezone.utc) - dt).days
+            if age > 180:
+                print(f'STALE SECRET ({age} days): {s[\"name\"]} — consider rotating')
+        except: pass
+except: pass
+" 2>/dev/null || true
+```
+
+---
+
+## Generate Health Report
+
+After running all checks, present findings in this structure:
+
+```text
+## GitHub Repository Health Report
+**Repo**: owner/name
+**Date**: <today>
+**Default Branch**: main
+
+---
+### Overall Status: [HEALTHY | NEEDS ATTENTION | CRITICAL]
+
+---
+### CI/CD  ✅/⚠️/❌
+| Workflow | Latest Status | Last Run |
+|----------|--------------|----------|
+| ...      | ✅/❌        | ...      |
+
+---
+### Pull Requests
+- Open PRs: N (D draft, R ready for review)
+- Stale PRs (>7 days, no activity): N
+- Dependabot PRs auto-merged: N (list titles)
+- Dependabot PRs skipped: N (list with reason)
+
+---
+### Security  ✅/⚠️/❌
+- Dependabot alerts: N open (X critical, Y high)
+- Code scanning (CodeQL): enabled/NOT ENABLED
+- Secret scanning: N open alerts
+- Snyk: configured / NOT CONFIGURED ⚠️
+- Branch protection on main: summary of rules
+
+---
+### Code Coverage  ✅/⚠️
+- Codecov: configured / NOT CONFIGURED ⚠️
+
+---
+### Repository Housekeeping  ✅/⚠️
+- Missing essential files: list or "none"
+- Dependabot auto-updates: configured / missing
+- Stale unmerged branches: N
+- Draft releases: N
+
+---
+### Recommended Actions (prioritized)
+1. [CRITICAL] ...
+2. [HIGH] ...
+3. [MEDIUM] ...
+4. [LOW/NICE-TO-HAVE] ...
+```
+
+---
+
+## Edge Cases
+
+- **Private repo without security features**: Some APIs require admin access; note when commands fail with 403/404 and suggest the user checks repo settings manually
+- **Org-managed repos**: Branch protection and secrets may be inherited from org settings; note this if the API returns 403
+- **No releases yet**: Skip release freshness checks; note that versioned releases are not configured
+- **Rate limiting**: If `gh` returns 429, note that data may be incomplete and suggest retrying
+- **Monorepo**: If multiple `package.json` / `go.mod` / `pyproject.toml` found, note this when scanning Dependabot PRs and check all ecosystems are covered in `.github/dependabot.yml`
+- **gh not authenticated**: Exit immediately with instructions: run `gh auth login`
+- **No open PRs**: Confirm the repo is clean; no merging needed

--- a/packages/ballast-python/ballast/skills/common/github-health-check/claude-settings.json
+++ b/packages/ballast-python/ballast/skills/common/github-health-check/claude-settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh auth*)",
+      "Bash(gh repo*)",
+      "Bash(gh run*)",
+      "Bash(gh release*)",
+      "Bash(gh pr*)",
+      "Bash(gh api*)",
+      "Bash(git fetch*)",
+      "Bash(git log*)",
+      "Bash(git rev-list*)",
+      "Bash(git branch*)",
+      "Bash(git describe*)",
+      "Bash(python3 -c*)"
+    ]
+  }
+}

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -406,13 +406,16 @@ class PatchInstallTests(unittest.TestCase):
                 "aws-health-review",
                 "aws-live-health-review",
                 "aws-weekly-security-review",
+                "github-health-check",
             ],
         )
         self.assertEqual(
             cli.parse_skill_tokens(
-                "owasp-security-scan,aws-health-review", False, "python"
+                "owasp-security-scan,aws-health-review,github-health-check",
+                False,
+                "python",
             ),
-            ["owasp-security-scan", "aws-health-review"],
+            ["owasp-security-scan", "aws-health-review", "github-health-check"],
         )
 
     def test_build_cursor_skill_format_uses_folded_description_text(self) -> None:

--- a/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
@@ -1,0 +1,451 @@
+---
+name: github-health-check
+description: >
+  Run a comprehensive GitHub repository health check. Use this skill whenever
+  the user asks to: check GitHub health, audit the repo, check CI status,
+  review open PRs, merge Dependabot PRs, check code coverage, check security
+  alerts, check Snyk integration, keep GitHub in good shape, or any variation
+  of "how is the repo doing". Also trigger for: "check dependabot PRs",
+  "any PRs to merge", "check branch status", "repo health", "GitHub status
+  check", "what needs attention in GitHub", "tidy up GitHub".
+---
+
+# GitHub Repository Health Check Skill
+
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs.
+
+---
+
+## Prerequisites
+
+```bash
+# Verify gh is authenticated and repo context is available
+gh auth status
+gh repo view --json name,owner,defaultBranchRef
+```
+
+Capture the repo owner and name for use in API calls:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+NAME=$(gh repo view --json name --jq '.name')
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+```
+
+---
+
+## Check 1 — GitHub Actions Status (default branch)
+
+```bash
+# Recent workflow runs on the default branch
+gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
+  --json status,conclusion,name,workflowName,createdAt,url \
+  --jq '.[] | {workflow: .workflowName, status: .status, conclusion: .conclusion, created: .createdAt, url: .url}'
+```
+
+**Interpret results:**
+
+- Group runs by workflow name; show the latest run per workflow
+- Flag any workflow whose latest run concluded with `failure` or `cancelled`
+- Flag workflows that haven't run in more than 14 days
+- Show overall summary: X workflows passing, Y failing
+
+```bash
+# Check for any in-progress or queued runs
+gh run list --branch "$DEFAULT_BRANCH" --status in_progress --json workflowName,url
+gh run list --branch "$DEFAULT_BRANCH" --status queued --json workflowName,url
+```
+
+---
+
+## Check 2 — Branch Freshness vs Latest Release
+
+```bash
+# Get the latest release tag
+LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // "none"')
+echo "Latest release: $LATEST_TAG"
+
+# Count commits on default branch since last release
+if [ "$LATEST_TAG" != "none" ]; then
+  git fetch --tags 2>/dev/null || true
+  COMMITS_AHEAD=$(git rev-list "${LATEST_TAG}..HEAD" --count 2>/dev/null || echo "unknown")
+  echo "Commits since last release: $COMMITS_AHEAD"
+
+  # Show recent unreleased commits
+  git log "${LATEST_TAG}..HEAD" --oneline 2>/dev/null | head -10 || true
+fi
+
+# Get last release date
+gh release list --limit 1 --json tagName,publishedAt \
+  --jq '.[] | "Tag: \(.tagName)  Published: \(.publishedAt)"'
+```
+
+**Interpret results:**
+
+- If commits ahead > 20: warn that a release may be overdue
+- If last release was more than 30 days ago: note it
+- If no releases exist: note that versioned releases are not configured
+
+---
+
+## Check 3 — Open Pull Requests
+
+```bash
+# List all open PRs with key metadata
+gh pr list --state open --json number,title,author,isDraft,createdAt,labels,headRefName,reviewDecision,statusCheckRollup \
+  --jq '.[] | {
+    number: .number,
+    title: .title,
+    author: .author.login,
+    isDraft: .isDraft,
+    created: .createdAt,
+    branch: .headRefName,
+    review: .reviewDecision,
+    checks: (.statusCheckRollup // [] | {
+      total: length,
+      passing: map(select(.conclusion == "SUCCESS")) | length,
+      failing: map(select(.conclusion == "FAILURE")) | length
+    })
+  }'
+```
+
+**Report:**
+
+- Total open PRs, draft vs ready
+- PRs older than 7 days without activity (stale)
+- PRs with failing checks
+- PRs awaiting review
+
+### Dependabot PR Auto-Merge
+
+```bash
+# Get all open Dependabot PRs
+gh pr list --state open --author "app/dependabot" \
+  --json number,title,headRefName,statusCheckRollup,isDraft,mergeable
+```
+
+For each Dependabot PR returned, apply this decision logic:
+
+1. **Parse the version bump** from the PR title (format: "Bump X from A.B.C to D.E.F"):
+   - Extract `from` version and `to` version
+   - Compare the major version (first number): if major version changes → **SKIP** (major upgrade)
+   - If only minor/patch changes → candidate for auto-merge
+
+2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+
+   ```bash
+   gh pr checks <PR_NUMBER> --json name,state,conclusion
+   ```
+
+3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
+
+4. **Auto-merge if all conditions pass** (no confirmation needed):
+
+   ```bash
+   gh pr merge <PR_NUMBER> --squash --auto
+   ```
+
+5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
+
+**Example major version detection:**
+
+- "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
+- "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
+- "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
+
+---
+
+## Check 4 — Code Coverage (Codecov)
+
+```bash
+# Check for codecov configuration file
+ls .codecov.yml codecov.yml .codecov.yaml codecov.yaml 2>/dev/null || echo "No codecov config file found"
+
+# Check for codecov in CI workflows
+grep -rl "codecov" .github/workflows/ 2>/dev/null || echo "No codecov step found in workflows"
+
+# Check README for codecov badge
+grep -i "codecov" README.md 2>/dev/null | head -3 || echo "No codecov badge in README"
+
+# Check if codecov token is configured as a repo secret (presence only, not value)
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i codecov || echo "No CODECOV secret found"
+```
+
+**Interpret results:**
+
+- If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
+- If present: confirm coverage reporting is active
+
+---
+
+## Check 5 — Security Alerts
+
+```bash
+# Count open Dependabot security alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
+  echo "Could not fetch Dependabot alert count (check repo permissions)"
+
+# Show top severity alerts
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
+  --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
+
+# Code scanning alerts (SAST / CodeQL)
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
+  echo "Code scanning: not enabled or no access"
+
+# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
+  echo "Secret scanning: not enabled or no access"
+```
+
+**Interpret results:**
+
+- Open Dependabot security alerts > 0: list them with severity (critical/high first)
+- Code scanning alerts: show count and any critical/high items
+- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+---
+
+## Check 6 — Snyk Integration
+
+```bash
+# Check for .snyk policy file
+ls .snyk 2>/dev/null && echo "Snyk policy file found: .snyk" || echo "No .snyk file"
+
+# Check CI workflows for Snyk
+grep -rl "snyk" .github/workflows/ 2>/dev/null || echo "No Snyk step found in workflows"
+
+# Check README for Snyk badge
+grep -i "snyk" README.md 2>/dev/null | head -3 || echo "No Snyk badge in README"
+
+# Check for snyk-related secrets
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/null | grep -i snyk || echo "No SNYK secret found"
+```
+
+**Interpret results:**
+
+- If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
+- If partially configured: note what's present and what's missing
+
+---
+
+## Check 7 — Branch Protection Rules
+
+```bash
+# Check protection rules on the default branch
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null || \
+  echo "WARNING: No branch protection rules found on ${DEFAULT_BRANCH}"
+
+# Parse and summarize key protections
+gh api "/repos/${OWNER}/${NAME}/branches/${DEFAULT_BRANCH}/protection" 2>/dev/null | \
+  python3 -c "
+import sys, json
+try:
+    p = json.load(sys.stdin)
+    good, bad = [], []
+    if p.get('required_pull_request_reviews'): good.append('PR reviews required')
+    else: bad.append('No required PR reviews')
+    if p.get('required_status_checks'): good.append('Status checks required')
+    else: bad.append('No required status checks')
+    if p.get('enforce_admins', {}).get('enabled'): good.append('Rules enforced for admins')
+    if p.get('allow_force_pushes', {}).get('enabled'): bad.append('Force pushes allowed on main')
+    if p.get('allow_deletions', {}).get('enabled'): bad.append('Branch deletion allowed')
+    for g in good: print('OK:', g)
+    for b in bad: print('WARN:', b)
+except Exception as e: print('Could not parse:', e)
+" 2>/dev/null || true
+```
+
+**Flag missing protections:**
+
+- No required PR reviews: warn
+- No required status checks: warn
+- Force pushes allowed on main: warn
+- No branch protection at all: flag as high priority
+
+---
+
+## Check 8 — Stale Branches
+
+```bash
+# List remote branches not merged to default branch, sorted by last commit date
+git fetch --prune 2>/dev/null || true
+git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --sort=-committerdate \
+  --format='%(committerdate:relative)|%(refname:short)' 2>/dev/null | \
+  grep -v "HEAD\|${DEFAULT_BRANCH}" | head -20
+
+# Count stale branches (no commits in 30+ days, not yet merged)
+STALE_COUNT=$(git branch -r --no-merged "origin/${DEFAULT_BRANCH}" \
+  --format='%(committerdate:unix)|%(refname:short)' 2>/dev/null | \
+  python3 -c "
+import sys
+from datetime import datetime, timezone
+cutoff = datetime.now(timezone.utc).timestamp() - 30 * 86400
+count = 0
+for line in sys.stdin:
+    parts = line.strip().split('|')
+    if len(parts) == 2 and parts[0].isdigit() and int(parts[0]) < cutoff:
+        count += 1
+print(count)
+" 2>/dev/null || echo "0")
+echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
+```
+
+---
+
+## Check 9 — Repository Housekeeping
+
+```bash
+# Check for essential files
+for f in README.md LICENSE .gitignore .github/dependabot.yml SECURITY.md .github/CODEOWNERS CODEOWNERS; do
+  [ -f "$f" ] && echo "OK: $f" || echo "MISSING: $f"
+done
+
+# Dependabot config check
+if [ -f ".github/dependabot.yml" ]; then
+  echo "Dependabot ecosystems configured:"
+  grep "package-ecosystem" .github/dependabot.yml | sort | uniq -c
+else
+  echo "WARNING: No .github/dependabot.yml — automated dependency updates not configured"
+fi
+
+# Check repo has a description and topics
+gh repo view --json description,repositoryTopics \
+  --jq '"Description: \(.description // "MISSING — add in repo settings")\nTopics: \(.repositoryTopics.nodes | map(.topic.name) | join(", ") | if . == "" then "NONE — add topics for discoverability" else . end)"'
+```
+
+---
+
+## Check 10 — Workflow Health Patterns
+
+```bash
+# Detect consistently failing workflows (>50% failure rate over recent runs)
+gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
+  --json workflowName,conclusion,createdAt \
+  --jq 'group_by(.workflowName) | .[] | {
+    workflow: .[0].workflowName,
+    runs: length,
+    failures: map(select(.conclusion == "failure")) | length
+  } | select(.runs >= 3) |
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+```
+
+---
+
+## Check 11 — Release & Tag Health
+
+```bash
+# List recent releases
+gh release list --limit 5 --json tagName,publishedAt,isDraft,isPrerelease \
+  --jq '.[] | "\(.tagName) [\(if .isDraft then "DRAFT" elif .isPrerelease then "PRE-RELEASE" else "RELEASED" end)] — \(.publishedAt)"'
+
+# Check for unpublished draft releases
+DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | length' 2>/dev/null || echo "0")
+[ "$DRAFT_COUNT" -gt 0 ] && echo "WARNING: $DRAFT_COUNT unpublished draft release(s)" || true
+```
+
+---
+
+## Check 12 — Actions Permissions & Secrets Health
+
+```bash
+# Check default workflow permissions
+gh api "/repos/${OWNER}/${NAME}/actions/permissions" \
+  --jq '"Actions enabled: \(.enabled)\nDefault permission: \(.default_workflow_permissions // "unknown")"' 2>/dev/null
+
+# List repo secret names and ages (values never shown)
+echo "--- Repository Secrets ---"
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" \
+  --jq '.secrets[] | "\(.name) (last updated: \(.updated_at))"' 2>/dev/null
+
+# Warn about secrets not rotated in 180+ days
+gh api "/repos/${OWNER}/${NAME}/actions/secrets" 2>/dev/null | \
+  python3 -c "
+import sys, json
+from datetime import datetime, timezone
+try:
+    data = json.load(sys.stdin)
+    for s in data.get('secrets', []):
+        updated = s.get('updated_at', '')
+        try:
+            dt = datetime.fromisoformat(updated.replace('Z', '+00:00'))
+            age = (datetime.now(timezone.utc) - dt).days
+            if age > 180:
+                print(f'STALE SECRET ({age} days): {s[\"name\"]} — consider rotating')
+        except: pass
+except: pass
+" 2>/dev/null || true
+```
+
+---
+
+## Generate Health Report
+
+After running all checks, present findings in this structure:
+
+```text
+## GitHub Repository Health Report
+**Repo**: owner/name
+**Date**: <today>
+**Default Branch**: main
+
+---
+### Overall Status: [HEALTHY | NEEDS ATTENTION | CRITICAL]
+
+---
+### CI/CD  ✅/⚠️/❌
+| Workflow | Latest Status | Last Run |
+|----------|--------------|----------|
+| ...      | ✅/❌        | ...      |
+
+---
+### Pull Requests
+- Open PRs: N (D draft, R ready for review)
+- Stale PRs (>7 days, no activity): N
+- Dependabot PRs auto-merged: N (list titles)
+- Dependabot PRs skipped: N (list with reason)
+
+---
+### Security  ✅/⚠️/❌
+- Dependabot alerts: N open (X critical, Y high)
+- Code scanning (CodeQL): enabled/NOT ENABLED
+- Secret scanning: N open alerts
+- Snyk: configured / NOT CONFIGURED ⚠️
+- Branch protection on main: summary of rules
+
+---
+### Code Coverage  ✅/⚠️
+- Codecov: configured / NOT CONFIGURED ⚠️
+
+---
+### Repository Housekeeping  ✅/⚠️
+- Missing essential files: list or "none"
+- Dependabot auto-updates: configured / missing
+- Stale unmerged branches: N
+- Draft releases: N
+
+---
+### Recommended Actions (prioritized)
+1. [CRITICAL] ...
+2. [HIGH] ...
+3. [MEDIUM] ...
+4. [LOW/NICE-TO-HAVE] ...
+```
+
+---
+
+## Edge Cases
+
+- **Private repo without security features**: Some APIs require admin access; note when commands fail with 403/404 and suggest the user checks repo settings manually
+- **Org-managed repos**: Branch protection and secrets may be inherited from org settings; note this if the API returns 403
+- **No releases yet**: Skip release freshness checks; note that versioned releases are not configured
+- **Rate limiting**: If `gh` returns 429, note that data may be incomplete and suggest retrying
+- **Monorepo**: If multiple `package.json` / `go.mod` / `pyproject.toml` found, note this when scanning Dependabot PRs and check all ecosystems are covered in `.github/dependabot.yml`
+- **gh not authenticated**: Exit immediately with instructions: run `gh auth login`
+- **No open PRs**: Confirm the repo is clean; no merging needed

--- a/packages/ballast-typescript/skills/common/github-health-check/claude-settings.json
+++ b/packages/ballast-typescript/skills/common/github-health-check/claude-settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh auth*)",
+      "Bash(gh repo*)",
+      "Bash(gh run*)",
+      "Bash(gh release*)",
+      "Bash(gh pr*)",
+      "Bash(gh api*)",
+      "Bash(git fetch*)",
+      "Bash(git log*)",
+      "Bash(git rev-list*)",
+      "Bash(git branch*)",
+      "Bash(git describe*)",
+      "Bash(python3 -c*)"
+    ]
+  }
+}

--- a/packages/ballast-typescript/src/agents.test.ts
+++ b/packages/ballast-typescript/src/agents.test.ts
@@ -4,7 +4,11 @@ import {
   getAgentDir,
   isValidAgent,
   resolveAgents,
-  AGENT_IDS
+  AGENT_IDS,
+  SKILL_IDS,
+  listSkills,
+  isValidSkill,
+  resolveSkills
 } from './agents';
 
 describe('agents', () => {
@@ -101,6 +105,33 @@ describe('agents', () => {
     test('terraform profile uses same public agent ids', () => {
       expect(listAgents('terraform')).toEqual([...AGENT_IDS]);
       expect(isValidAgent('logging', 'terraform')).toBe(true);
+    });
+  });
+
+  describe('skills', () => {
+    test('returns all skill ids', () => {
+      expect(listSkills()).toEqual([...SKILL_IDS]);
+      expect(listSkills()).toContain('owasp-security-scan');
+      expect(listSkills()).toContain('aws-health-review');
+      expect(listSkills()).toContain('aws-live-health-review');
+      expect(listSkills()).toContain('aws-weekly-security-review');
+      expect(listSkills()).toContain('github-health-check');
+    });
+
+    test('validates known skills', () => {
+      expect(isValidSkill('owasp-security-scan')).toBe(true);
+      expect(isValidSkill('aws-health-review')).toBe(true);
+      expect(isValidSkill('aws-live-health-review')).toBe(true);
+      expect(isValidSkill('aws-weekly-security-review')).toBe(true);
+      expect(isValidSkill('github-health-check')).toBe(true);
+      expect(isValidSkill('unknown')).toBe(false);
+    });
+
+    test('resolves skill selections including all', () => {
+      expect(resolveSkills('all')).toEqual([...SKILL_IDS]);
+      expect(
+        resolveSkills(['owasp-security-scan', 'github-health-check', 'nope'])
+      ).toEqual(['owasp-security-scan', 'github-health-check']);
     });
   });
 });

--- a/packages/ballast-typescript/src/agents.ts
+++ b/packages/ballast-typescript/src/agents.ts
@@ -47,6 +47,10 @@ export const LANGUAGES = [
 ] as const;
 export type Language = (typeof LANGUAGES)[number];
 
+// Keep these lists in sync with agentRegistry / skillRegistry in
+// cli/ballast/registry.go — that file is the single source of truth.
+// When adding, removing, or deprecating an agent or skill, update registry.go
+// first, then mirror the change here.
 export const COMMON_AGENT_IDS = [
   'local-dev',
   'docs',

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import {
   getContent,
@@ -182,6 +183,19 @@ describe('build', () => {
   });
 
   describe('skills', () => {
+    test('common skill ids are all packaged in the typescript bundle', () => {
+      const packagedSkills = path.join(__dirname, '..', 'skills', 'common');
+      expect(
+        [
+          'owasp-security-scan',
+          'aws-health-review',
+          'aws-live-health-review',
+          'aws-weekly-security-review',
+          'github-health-check'
+        ].every((skillId) => fs.existsSync(path.join(packagedSkills, skillId)))
+      ).toBe(true);
+    });
+
     test('reads skill content', () => {
       const content = getSkillContent('owasp-security-scan');
       expect(content).toContain('name: owasp-security-scan');
@@ -192,6 +206,12 @@ describe('build', () => {
       const content = getSkillContent('aws-health-review');
       expect(content).toContain('name: aws-health-review');
       expect(content).toContain('# AWS Health Review');
+    });
+
+    test('reads github health skill content', () => {
+      const content = getSkillContent('github-health-check');
+      expect(content).toContain('name: github-health-check');
+      expect(content).toContain('# GitHub Repository Health Check Skill');
     });
 
     test('builds cursor skill format', () => {

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import path from 'path';
 import {
   getContent,
@@ -24,6 +23,7 @@ import {
   getSkillDestination,
   listTargets
 } from './build';
+import { COMMON_SKILL_IDS } from './agents';
 
 describe('build', () => {
   describe('listRuleSuffixes', () => {
@@ -183,17 +183,11 @@ describe('build', () => {
   });
 
   describe('skills', () => {
-    test('common skill ids are all packaged in the typescript bundle', () => {
-      const packagedSkills = path.join(__dirname, '..', 'skills', 'common');
-      expect(
-        [
-          'owasp-security-scan',
-          'aws-health-review',
-          'aws-live-health-review',
-          'aws-weekly-security-review',
-          'github-health-check'
-        ].every((skillId) => fs.existsSync(path.join(packagedSkills, skillId)))
-      ).toBe(true);
+    test('reads content for every common skill id', () => {
+      for (const skillId of COMMON_SKILL_IDS) {
+        const content = getSkillContent(skillId);
+        expect(content).toContain(`name: ${skillId}`);
+      }
     });
 
     test('reads skill content', () => {

--- a/packages/ballast-typescript/src/pre-commit-config.test.ts
+++ b/packages/ballast-typescript/src/pre-commit-config.test.ts
@@ -5,6 +5,8 @@ import YAML from 'yaml';
 type PreCommitHook = {
   id?: string;
   repo?: string;
+  entry?: string;
+  stages?: string[];
 };
 
 type PreCommitRepo = {
@@ -37,5 +39,17 @@ describe('root pre-commit config', () => {
     expect(hookIds).not.toContain('end-of-file-fixer');
     expect(hookIds).toContain('check-trailing-whitespace');
     expect(hookIds).toContain('check-end-of-file-newline');
+  });
+
+  test('runs all package and cli unit tests at pre-push', () => {
+    const config = readPreCommitConfig();
+    const hooks = config.repos.flatMap((repo) => repo.hooks ?? []);
+    const unitTestHook = hooks.find(
+      (hook) => hook.id === 'ballast-unit-tests-pre-push'
+    );
+
+    expect(unitTestHook).toBeTruthy();
+    expect(unitTestHook?.entry).toBe('scripts/run-unit-tests-pre-push.sh');
+    expect(unitTestHook?.stages).toContain('pre-push');
   });
 });

--- a/scripts/run-unit-tests-pre-push.sh
+++ b/scripts/run-unit-tests-pre-push.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export UV_CACHE_DIR="${TMPDIR:-/tmp}/ballast-uv-cache"
+mkdir -p "${UV_CACHE_DIR}"
+
+cd "${repo_root}/packages/ballast-typescript"
+pnpm test
+
+cd "${repo_root}/packages/ballast-python"
+uv run python -m unittest discover -s tests
+
+cd "${repo_root}/packages/ballast-go"
+go test ./cmd/ballast-go
+
+cd "${repo_root}/cli/ballast"
+go test ./...


### PR DESCRIPTION
## Summary

- Replaces four hardcoded string slices (`commonAgents`, `languageAgents`, `supportedAgents`, `supportedSkills`) with a structured registry in `cli/ballast/registry.go`
- The registry is now the **single source of truth** for all supported agents and skills — fixes the drift bug where `github-health-check` and other skills existed in `agents.ts` but were rejected by the Go CLI
- `packages/ballast-typescript/src/agents.ts` retains its own lists (needed by the Node backend) but now has a comment directing maintainers to `registry.go` first

## Changes

**`cli/ballast/registry.go`** (new)
- `agentEntry` / `skillEntry` structs with lifecycle fields: `Status` (`active` / `deprecated` / `removed`) and `Deprecated` note (`Since`, `Remove`, `Message`)
- Helper functions used throughout `main.go`: `activeAgentIDs`, `commonAgentIDs`, `languageAgentIDs`, `isValidAgent`, `isValidSkill`, `activeSkillIDs`, `skillDescriptionFromRegistry`, `deprecationWarningForAgent/Skill`

**`cli/ballast/main.go`**
- All hardcoded vars removed; all call sites use registry helpers
- `skillDescription` delegates to `skillDescriptionFromRegistry`
- Deprecation warnings printed to stderr at install time

**`cli/ballast/main_test.go`**
- `TestRegistryConsistency`: validates no empty/duplicate IDs, descriptions present on skills, deprecated entries have a `Deprecated` field

**`packages/ballast-typescript/src/agents.ts`**
- Sync comment added pointing to `registry.go`

## Lifecycle workflow going forward

| Action | How |
|---|---|
| Add agent/skill | New entry with `statusActive` in `registry.go`; mirror in `agents.ts` |
| Deprecate | Set `statusDeprecated` + fill `Deprecated` field; users see a warning at install |
| Remove | Set `statusRemoved`; validation rejects it; entry stays for history |

## Test plan

- [x] `go test ./...` passes
- [x] Pre-commit hooks pass
- [ ] `ballast install --skill github-health-check` no longer returns "unsupported skill selection"
- [ ] `ballast install --skill not-a-skill` still returns a clear error listing valid skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)