### PR TITLE
Require coverage in testing rules

### DIFF
--- a/.claude/rules/go/go-testing.md
+++ b/.claude/rules/go/go-testing.md
@@ -9,10 +9,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI

--- a/.claude/rules/python/python-testing.md
+++ b/.claude/rules/python/python-testing.md
@@ -8,11 +8,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 
 ## Commands
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`

--- a/.codex/rules/go/go-testing.md
+++ b/.codex/rules/go/go-testing.md
@@ -9,10 +9,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI

--- a/.codex/rules/python/python-testing.md
+++ b/.codex/rules/python/python-testing.md
@@ -8,11 +8,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 
 ## Commands
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`

--- a/agents/go/testing/content.md
+++ b/agents/go/testing/content.md
@@ -4,17 +4,19 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
 
 ## Smoke and End-to-End Testing

--- a/agents/go/testing/content.md
+++ b/agents/go/testing/content.md
@@ -16,7 +16,7 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 - `go test ./...`
 - `go test ./... -cover`
-- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
 
 ## Smoke and End-to-End Testing

--- a/agents/python/testing/content.md
+++ b/agents/python/testing/content.md
@@ -15,7 +15,7 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
-- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
 
 ## Smoke and End-to-End Testing

--- a/agents/python/testing/content.md
+++ b/agents/python/testing/content.md
@@ -3,8 +3,8 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
 6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
@@ -15,6 +15,7 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
 
 ## Smoke and End-to-End Testing

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -10,7 +10,7 @@ The **testing** agent sets up and maintains test workflows for TypeScript, Pytho
   - Coverage thresholds, CI test steps, smoke tests, and optional E2E for runnable apps
 - **Python**
   - pytest for test execution
-  - pytest-cov for coverage reporting and enforced coverage test commands
+  - pytest-cov for coverage reporting and fail-under thresholds
   - Smoke tests and optional E2E for runnable apps
 - **Go**
   - `go test ./...` baseline

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -10,11 +10,11 @@ The **testing** agent sets up and maintains test workflows for TypeScript, Pytho
   - Coverage thresholds, CI test steps, smoke tests, and optional E2E for runnable apps
 - **Python**
   - pytest for test execution
-  - pytest-cov for coverage reporting
+  - pytest-cov for coverage reporting and enforced coverage test commands
   - Smoke tests and optional E2E for runnable apps
 - **Go**
   - `go test ./...` baseline
-  - Coverage checks via `go test ./... -cover`
+  - Coverage checks as part of the default test workflow, including CI coverage gates
   - Smoke tests and optional E2E for runnable apps
 - **Ansible**
   - `ansible-playbook --syntax-check` baseline

--- a/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
@@ -4,10 +4,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
@@ -12,4 +12,4 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 - `go test ./...`
 - `go test ./... -cover`
-- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
@@ -3,11 +3,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 
 ## Commands
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`

--- a/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
@@ -11,4 +11,4 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
-- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`

--- a/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
@@ -4,10 +4,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
@@ -12,4 +12,4 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 - `go test ./...`
 - `go test ./... -cover`
-- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
@@ -3,11 +3,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 
 ## Commands
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`

--- a/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
@@ -11,4 +11,4 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
-- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`

--- a/packages/ballast-python/ballast/agents/go/testing/content.md
+++ b/packages/ballast-python/ballast/agents/go/testing/content.md
@@ -4,10 +4,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 1. Use `go test` as the baseline test runner.
 2. Add table-driven tests for core logic.
-3. Include coverage checks in CI.
-4. Keep tests deterministic and isolated.
+3. Make coverage part of the default test workflow, not an optional follow-up check.
+4. Include coverage checks in CI and fail when coverage requirements are not met.
+5. Keep tests deterministic and isolated.
 
 ## Commands
 
 - `go test ./...`
 - `go test ./... -cover`
+- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-python/ballast/agents/go/testing/content.md
+++ b/packages/ballast-python/ballast/agents/go/testing/content.md
@@ -12,4 +12,4 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 
 - `go test ./...`
 - `go test ./... -cover`
-- add or document a dedicated coverage gate such as `go test ./... -coverprofile=coverage.out` plus a threshold check in CI
+- Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI

--- a/packages/ballast-python/ballast/agents/python/testing/content.md
+++ b/packages/ballast-python/ballast/agents/python/testing/content.md
@@ -3,11 +3,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 ## Your Responsibilities
 
 1. Configure pytest with clear test discovery.
-2. Add coverage reporting via pytest-cov.
-3. Provide fast local test commands and CI test steps.
+2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
+3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
 4. Encourage deterministic unit tests and minimal flaky integration tests.
 
 ## Commands
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
+- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`

--- a/packages/ballast-python/ballast/agents/python/testing/content.md
+++ b/packages/ballast-python/ballast/agents/python/testing/content.md
@@ -11,4 +11,4 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 
 - `pytest`
 - `pytest --cov=. --cov-report=term-missing`
-- add or document a dedicated coverage command such as `pytest --cov=. --cov-report=term-missing --cov-fail-under=80`
+- Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`


### PR DESCRIPTION
## Summary
- make Python testing rules require coverage as part of the default test workflow
- make Go testing rules require coverage gates instead of only optional CI checks
- update the testing agent guide to reflect the same coverage expectations

## Testing
- pre-commit hooks
- pre-push unit tests for cli and language packages
