### PR TITLE
Fix support file sync with .rulesrc.json

### DIFF
--- a/.rulesrc.json
+++ b/.rulesrc.json
@@ -17,9 +17,10 @@
     "testing"
   ],
   "skills": [
-    "owasp-security-scan"
+    "owasp-security-scan",
+    "github-health-check"
   ],
-  "ballastVersion": "5.6.8",
+  "ballastVersion": "5.7.0",
   "languages": [
     "typescript",
     "python",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,33 +78,6 @@ Created by Ballast. Do not edit this section.
 
 Read and follow these rule files in `.codex/rules/` when they apply:
 
-- `.codex/rules/common/local-dev-badges.md` — Rules for common/local-dev-badges
-- `.codex/rules/common/local-dev-env.md` — Rules for common/local-dev-env
-- `.codex/rules/common/local-dev-license.md` — Rules for common/local-dev-license
-- `.codex/rules/common/local-dev-mcp.md` — Rules for common/local-dev-mcp
-- `.codex/rules/common/docs.md` — Rules for common/docs
-- `.codex/rules/common/cicd.md` — Rules for common/cicd
-- `.codex/rules/common/observability.md` — Rules for common/observability
-- `.codex/rules/common/publishing-libraries.md` — Rules for common/publishing-libraries
-- `.codex/rules/common/publishing-sdks.md` — Rules for common/publishing-sdks
-- `.codex/rules/common/publishing-apps.md` — Rules for common/publishing-apps
-- `.codex/rules/common/git-hooks.md` — Rules for common/git-hooks
-- `.codex/rules/typescript/typescript-linting.md` — Rules for typescript/linting
-- `.codex/rules/typescript/typescript-logging.md` — Rules for typescript/logging
-- `.codex/rules/typescript/typescript-testing.md` — Rules for typescript/testing
-- `.codex/rules/python/python-linting.md` — Rules for python/linting
-- `.codex/rules/python/python-logging.md` — Rules for python/logging
-- `.codex/rules/python/python-testing.md` — Rules for python/testing
-- `.codex/rules/go/go-linting.md` — Rules for go/linting
-- `.codex/rules/go/go-logging.md` — Rules for go/logging
-- `.codex/rules/go/go-testing.md` — Rules for go/testing
-- `.codex/rules/ansible/ansible-linting.md` — Rules for ansible/linting
-- `.codex/rules/ansible/ansible-logging.md` — Rules for ansible/logging
-- `.codex/rules/ansible/ansible-testing.md` — Rules for ansible/testing
-- `.codex/rules/terraform/terraform-linting.md` — Rules for terraform/linting
-- `.codex/rules/terraform/terraform-logging.md` — Rules for terraform/logging
-- `.codex/rules/terraform/terraform-testing.md` — Rules for terraform/testing
-
 ## Installed skills
 
 Created by Ballast. Do not edit this section.
@@ -112,4 +85,5 @@ Created by Ballast. Do not edit this section.
 Read and use these skill files in `.codex/rules/` when they are relevant:
 
 - `.codex/rules/owasp-security-scan.md` — run an OWASP-aligned security audit across Go, TypeScript, and Python projects
+- `.codex/rules/github-health-check.md` — run a comprehensive GitHub repository health check covering CI status, branch hygiene, and repo configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,33 +29,6 @@ Created by Ballast. Do not edit this section.
 
 Read and follow these rule files in `.claude/rules/` when they apply:
 
-- `.claude/rules/common/local-dev-badges.md` — Rules for common/local-dev-badges
-- `.claude/rules/common/local-dev-env.md` — Rules for common/local-dev-env
-- `.claude/rules/common/local-dev-license.md` — Rules for common/local-dev-license
-- `.claude/rules/common/local-dev-mcp.md` — Rules for common/local-dev-mcp
-- `.claude/rules/common/docs.md` — Rules for common/docs
-- `.claude/rules/common/cicd.md` — Rules for common/cicd
-- `.claude/rules/common/observability.md` — Rules for common/observability
-- `.claude/rules/common/publishing-libraries.md` — Rules for common/publishing-libraries
-- `.claude/rules/common/publishing-sdks.md` — Rules for common/publishing-sdks
-- `.claude/rules/common/publishing-apps.md` — Rules for common/publishing-apps
-- `.claude/rules/common/git-hooks.md` — Rules for common/git-hooks
-- `.claude/rules/typescript/typescript-linting.md` — Rules for typescript/linting
-- `.claude/rules/typescript/typescript-logging.md` — Rules for typescript/logging
-- `.claude/rules/typescript/typescript-testing.md` — Rules for typescript/testing
-- `.claude/rules/python/python-linting.md` — Rules for python/linting
-- `.claude/rules/python/python-logging.md` — Rules for python/logging
-- `.claude/rules/python/python-testing.md` — Rules for python/testing
-- `.claude/rules/go/go-linting.md` — Rules for go/linting
-- `.claude/rules/go/go-logging.md` — Rules for go/logging
-- `.claude/rules/go/go-testing.md` — Rules for go/testing
-- `.claude/rules/ansible/ansible-linting.md` — Rules for ansible/linting
-- `.claude/rules/ansible/ansible-logging.md` — Rules for ansible/logging
-- `.claude/rules/ansible/ansible-testing.md` — Rules for ansible/testing
-- `.claude/rules/terraform/terraform-linting.md` — Rules for terraform/linting
-- `.claude/rules/terraform/terraform-logging.md` — Rules for terraform/logging
-- `.claude/rules/terraform/terraform-testing.md` — Rules for terraform/testing
-
 ## Installed skills
 
 Created by Ballast. Do not edit this section.
@@ -63,4 +36,5 @@ Created by Ballast. Do not edit this section.
 Read and use these skill files in `.claude/skills/` when they are relevant:
 
 - `.claude/skills/owasp-security-scan.skill` — run an OWASP-aligned security audit across Go, TypeScript, and Python projects
+- `.claude/skills/github-health-check.skill` — run a comprehensive GitHub repository health check covering CI status, branch hygiene, and repo configuration
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1361,9 +1361,11 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if err := validateSelectedTargets(savedTargets); err != nil {
 		return nil, err
 	}
-	if !explicitAgentSelection && !explicitSkillSelection && config != nil {
+	if !explicitAgentSelection && config != nil {
 		installAgents = slices.Clone(config.Agents)
-		installSkills = slices.Clone(config.Skills)
+		if !explicitSkillSelection {
+			installSkills = slices.Clone(config.Skills)
+		}
 	}
 	cleanupOnly := len(removeTargets) > 0 && len(requestedTargets) == 0 && !explicitAgentSelection && !explicitSkillSelection
 	if !cleanupOnly && (len(requestedTargets) == 0 || ((len(installAgents) == 0 && !installAll) && (len(installSkills) == 0 && !installAllSkills))) {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -1495,15 +1495,24 @@ func TestResolveMonorepoPlanSkillOnlyInstallPreservesConfigAgents(t *testing.T) 
 	if plan == nil {
 		t.Fatal("expected monorepo plan, got nil")
 	}
-	if len(plan.Invocations) != 1 {
-		t.Fatalf("expected a single common invocation for skill-only install, got %#v", plan.Invocations)
+	if len(plan.Invocations) != 3 {
+		t.Fatalf("expected common and per-language invocations, got %#v", plan.Invocations)
 	}
-	got := strings.Join(plan.Invocations[0].Args, " ")
-	if !strings.Contains(got, "--skill owasp-security-scan") {
-		t.Fatalf("expected explicit skill selection, got %q", got)
+	commonArgs := strings.Join(plan.Invocations[0].Args, " ")
+	if !strings.Contains(commonArgs, "--agent local-dev") || !strings.Contains(commonArgs, "--skill owasp-security-scan") {
+		t.Fatalf("expected common invocation to keep configured common agents and requested skill, got %q", commonArgs)
 	}
-	if strings.Contains(got, "--agent") {
-		t.Fatalf("expected configured agents not to be inherited, got %q", got)
+	languageArgs := []string{
+		strings.Join(plan.Invocations[1].Args, " "),
+		strings.Join(plan.Invocations[2].Args, " "),
+	}
+	for _, got := range languageArgs {
+		if !strings.Contains(got, "--agent linting") {
+			t.Fatalf("expected language invocation to keep configured language agents, got %q", got)
+		}
+		if strings.Contains(got, "--skill") {
+			t.Fatalf("expected language invocation to omit skill flags, got %q", got)
+		}
 	}
 	if !reflect.DeepEqual(plan.Config.Agents, []string{"local-dev", "linting"}) {
 		t.Fatalf("expected saved config to preserve existing agents, got %#v", plan.Config.Agents)
@@ -1595,6 +1604,51 @@ func TestResolveMonorepoPlanAgentOnlyInstallRejectsInvalidPersistedSkills(t *tes
 	}
 	if !strings.Contains(err.Error(), "unsupported skill selection") {
 		t.Fatalf("expected unsupported skill error, got %v", err)
+	}
+}
+
+func TestResolveMonorepoPlanSkillOnlyInstallRetainsConfiguredAgents(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["claude", "codex"],
+  "agents": ["local-dev", "linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["typescript", "python"],
+  "paths": {
+    "typescript": ["apps/frontend"],
+    "python": ["services/api"]
+  }
+}`)
+
+	plan, err := resolveMonorepoPlan(root, []string{
+		"install",
+		"--target", "claude,codex",
+		"--skill", "github-health-check",
+		"--patch",
+		"--yes",
+	})
+	if err != nil {
+		t.Fatalf("resolveMonorepoPlan returned error: %v", err)
+	}
+	if plan == nil {
+		t.Fatal("expected monorepo plan, got nil")
+	}
+	if len(plan.Invocations) == 0 {
+		t.Fatal("expected backend invocations")
+	}
+	combinedArgs := make([]string, 0, len(plan.Invocations))
+	for _, invocation := range plan.Invocations {
+		combinedArgs = append(combinedArgs, strings.Join(invocation.Args, " "))
+	}
+	joined := strings.Join(combinedArgs, "\n")
+	if !strings.Contains(joined, "--agent local-dev") || !strings.Contains(joined, "--agent linting") {
+		t.Fatalf("expected configured agents in skill-only invocations, got %q", joined)
+	}
+	if !strings.Contains(joined, "--skill github-health-check") {
+		t.Fatalf("expected requested skill in invocation, got %q", joined)
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -48,6 +48,18 @@ func withImplicitAgents(agents []string) []string {
 	return resolved
 }
 
+func uniqueStrings(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 //go:embed agents/**
 var embeddedAgentsFS embed.FS
 
@@ -694,6 +706,8 @@ func install(opts installOptions) installResult {
 		supportAgents = withImplicitAgents(config.Agents)
 		supportSkills = slices.Clone(config.Skills)
 	}
+	supportAgents = uniqueStrings(supportAgents)
+	supportSkills = uniqueStrings(supportSkills)
 
 	for _, target := range targets {
 		processed := map[string]struct{}{}

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -688,6 +688,13 @@ func install(opts installOptions) installResult {
 		}
 	}
 
+	supportAgents := slices.Clone(opts.agents)
+	supportSkills := slices.Clone(opts.skills)
+	if config := loadConfig(opts.projectRoot, opts.language); config != nil {
+		supportAgents = withImplicitAgents(config.Agents)
+		supportSkills = slices.Clone(config.Skills)
+	}
+
 	for _, target := range targets {
 		processed := map[string]struct{}{}
 		processedSkills := map[string]struct{}{}
@@ -819,8 +826,7 @@ func install(opts installOptions) installResult {
 					result.skippedSupportFiles = append(result.skippedSupportFiles, agentsPath)
 				}
 			} else {
-				ids := sortedKeys(processed)
-				content, err := buildCodexAgentsMD(ids, sortedKeys(processedSkills), opts.language)
+				content, err := buildCodexAgentsMD(supportAgents, supportSkills, opts.language)
 				if err != nil {
 					result.errors = append(result.errors, agentError{agent: "codex", err: err.Error()})
 				} else {
@@ -850,8 +856,7 @@ func install(opts installOptions) installResult {
 					result.skippedSupportFiles = append(result.skippedSupportFiles, claudePath)
 				}
 			} else {
-				ids := sortedKeys(processed)
-				content, err := buildClaudeMD(ids, sortedKeys(processedSkills), opts.language)
+				content, err := buildClaudeMD(supportAgents, supportSkills, opts.language)
 				if err != nil {
 					result.errors = append(result.errors, agentError{agent: "claude", err: err.Error()})
 				} else {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -1042,6 +1042,55 @@ Keep my custom rule text.
 	}
 }
 
+func TestSkillOnlyPatchKeepsCodexRuleReferencesFromRulesrc(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := saveConfig(tmpDir, "go", rulesConfig{
+		Targets: []string{"codex"},
+		Agents:  []string{"linting"},
+		Skills:  []string{"owasp-security-scan"},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	agentsMD := filepath.Join(tmpDir, "AGENTS.md")
+	initial, err := buildCodexAgentsMD([]string{"linting"}, []string{"owasp-security-scan"}, "go")
+	if err != nil {
+		t.Fatalf("build AGENTS.md: %v", err)
+	}
+	if err := os.WriteFile(agentsMD, []byte(initial), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"codex"},
+		agents:      []string{},
+		skills:      []string{"owasp-security-scan", "github-health-check"},
+		language:    "go",
+		force:       false,
+		patch:       true,
+		saveConfig:  false,
+	})
+	if len(result.errors) > 0 {
+		t.Fatalf("unexpected install errors: %+v", result.errors)
+	}
+
+	content, err := os.ReadFile(agentsMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "`.codex/rules/go-linting.md`") {
+		t.Fatalf("expected config-backed agent entry to remain: %s", text)
+	}
+	if !strings.Contains(text, "`.codex/rules/owasp-security-scan.md`") {
+		t.Fatalf("expected saved skill entry to remain: %s", text)
+	}
+	if strings.Contains(text, "`.codex/rules/github-health-check.md`") {
+		t.Fatalf("expected unsaved skill entry to stay absent: %s", text)
+	}
+}
+
 func TestInstallPatchUpdatesClaudeMDSectionOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	rulePath := filepath.Join(tmpDir, ".claude", "rules", "go-linting.md")

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1459,6 +1459,18 @@ def install(
     if persist:
         save_config(root, language, target, agents, skills)
 
+    config_for_support_files = load_config(root, language)
+    support_agents = with_implicit_agents(
+        config_for_support_files.get("agents", agents)
+        if config_for_support_files
+        else agents
+    )
+    support_skills = (
+        config_for_support_files.get("skills", skills)
+        if config_for_support_files
+        else skills
+    )
+
     for agent in agents:
         if not is_valid_agent(agent, language):
             result.errors.append((agent, "Unknown agent"))
@@ -1527,7 +1539,7 @@ def install(
             result.skipped_support_files.append(str(claude_md))
         else:
             try:
-                content = build_claude_md(processed_agents, processed_skills, language)
+                content = build_claude_md(support_agents, support_skills, language)
                 next_content = (
                     patch_codex_agents_md(
                         claude_md.read_text(encoding="utf-8"), content
@@ -1548,7 +1560,7 @@ def install(
             result.skipped_support_files.append(str(gemini_md))
         else:
             try:
-                content = build_gemini_md(processed_agents, processed_skills, language)
+                content = build_gemini_md(support_agents, support_skills, language)
                 next_content = (
                     patch_codex_agents_md(
                         gemini_md.read_text(encoding="utf-8"), content
@@ -1564,7 +1576,7 @@ def install(
         if not agents_md.exists():
             try:
                 agents_md.write_text(
-                    build_codex_agents_md(processed_agents, processed_skills, language),
+                    build_codex_agents_md(support_agents, support_skills, language),
                     encoding="utf-8",
                 )
                 result.installed_support_files.append(str(agents_md))
@@ -1578,7 +1590,7 @@ def install(
         else:
             try:
                 content = build_codex_agents_md(
-                    processed_agents, processed_skills, language
+                    support_agents, support_skills, language
                 )
                 next_content = (
                     patch_codex_agents_md(

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -686,6 +686,40 @@ Read and follow these rule files in `.codex/rules/` when they apply:
             self.assertIn("`.codex/rules/python-linting.md`", agents_md)
             self.assertNotIn("`.codex/rules/old.md`", agents_md)
 
+    def test_skill_only_patch_keeps_codex_rule_references_from_rulesrc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            cli.save_config(
+                root,
+                "python",
+                "codex",
+                ["linting"],
+                ["owasp-security-scan"],
+            )
+            (root / "AGENTS.md").write_text(
+                cli.build_codex_agents_md(
+                    ["linting"], ["owasp-security-scan"], "python"
+                ),
+                encoding="utf-8",
+            )
+
+            result = cli.install(
+                root,
+                "codex",
+                [],
+                ["owasp-security-scan", "github-health-check"],
+                "python",
+                False,
+                True,
+                False,
+            )
+
+            self.assertEqual(result.errors, [])
+            agents_md = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("`.codex/rules/python-linting.md`", agents_md)
+            self.assertIn("`.codex/rules/owasp-security-scan.md`", agents_md)
+            self.assertNotIn("`.codex/rules/github-health-check.md`", agents_md)
+
     def test_patch_updates_claude_md_section_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -3,7 +3,12 @@ import path from 'path';
 import os from 'os';
 import readline from 'readline';
 import { install, resolveTargetAndAgents, runInstall } from './install';
-import { getClaudeMdPath, getDestination, getGeminiMdPath } from './build';
+import {
+  buildCodexAgentsMd,
+  getClaudeMdPath,
+  getDestination,
+  getGeminiMdPath
+} from './build';
 import { findProjectRoot, saveConfig, loadConfig } from './config';
 import { BALLAST_VERSION } from './version';
 
@@ -1294,6 +1299,40 @@ Read and follow these rule files in \`.codex/rules/\` when they apply:
         expect(agentsMd).toContain('Keep this section.');
         expect(agentsMd).toContain('`.codex/rules/typescript-linting.md`');
         expect(agentsMd).not.toContain('`.codex/rules/old.md`');
+      });
+
+      test('codex patch keeps rules in AGENTS.md for config-backed skill-only updates', () => {
+        saveConfig(
+          {
+            targets: ['codex'],
+            agents: ['linting'],
+            skills: ['owasp-security-scan']
+          },
+          tmpDir
+        );
+        fs.writeFileSync(
+          path.join(tmpDir, 'AGENTS.md'),
+          buildCodexAgentsMd(['linting'], ['owasp-security-scan'])
+        );
+
+        const result = install({
+          projectRoot: tmpDir,
+          target: 'codex',
+          agents: [],
+          skills: ['owasp-security-scan', 'github-health-check'],
+          patch: true,
+          force: false,
+          saveConfig: false
+        });
+
+        expect(result.errors).toHaveLength(0);
+        const agentsMd = fs.readFileSync(
+          path.join(tmpDir, 'AGENTS.md'),
+          'utf8'
+        );
+        expect(agentsMd).toContain('`.codex/rules/typescript-linting.md`');
+        expect(agentsMd).toContain('`.codex/rules/owasp-security-scan.md`');
+        expect(agentsMd).not.toContain('`.codex/rules/github-health-check.md`');
       });
 
       test('written path matches getDestination for each target', () => {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -354,9 +354,16 @@ function resolveSupportFileSelections(
   fallbackSkills: string[]
 ): { agents: string[]; skills: string[] } {
   const config = loadConfig(projectRoot, language);
+  const rawAgents = config == null ? fallbackAgents : config.agents;
+  const rawSkills =
+    config == null
+      ? fallbackSkills
+      : 'skills' in config
+        ? (config.skills ?? [])
+        : [];
   return {
-    agents: withImplicitAgents(config?.agents ?? fallbackAgents),
-    skills: config?.skills ?? fallbackSkills
+    agents: [...new Set(withImplicitAgents(rawAgents))],
+    skills: [...new Set(rawSkills)]
   };
 }
 

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -347,6 +347,19 @@ export interface InstallResult {
   errors: Array<{ agent: string; error: string }>;
 }
 
+function resolveSupportFileSelections(
+  projectRoot: string,
+  language: Language,
+  fallbackAgents: string[],
+  fallbackSkills: string[]
+): { agents: string[]; skills: string[] } {
+  const config = loadConfig(projectRoot, language);
+  return {
+    agents: withImplicitAgents(config?.agents ?? fallbackAgents),
+    skills: config?.skills ?? fallbackSkills
+  };
+}
+
 /**
  * Deep-merge skill claude-settings.json into .claude/settings.json.
  * Only merges known safe keys (permissions.allow). Creates the file if absent.
@@ -472,6 +485,12 @@ export function install(options: InstallOptions): InstallResult {
     );
   }
   const hookMode = resolveTsHookMode(projectRoot, language);
+  const supportSelections = resolveSupportFileSelections(
+    projectRoot,
+    language,
+    effectiveAgents,
+    skills
+  );
 
   for (const agentId of effectiveAgents) {
     if (!isValidAgent(agentId, language)) {
@@ -588,8 +607,8 @@ export function install(options: InstallOptions): InstallResult {
     } else {
       try {
         const content = buildClaudeMd(
-          Array.from(processedAgentIds),
-          Array.from(processedSkillIds),
+          supportSelections.agents,
+          supportSelections.skills,
           language
         );
         const nextContent =
@@ -616,8 +635,8 @@ export function install(options: InstallOptions): InstallResult {
     } else {
       try {
         const content = buildGeminiMd(
-          Array.from(processedAgentIds),
-          Array.from(processedSkillIds),
+          supportSelections.agents,
+          supportSelections.skills,
           language
         );
         const nextContent =
@@ -637,8 +656,8 @@ export function install(options: InstallOptions): InstallResult {
     if (!fs.existsSync(agentsMdPath)) {
       try {
         const agentsContent = buildCodexAgentsMd(
-          Array.from(processedAgentIds),
-          Array.from(processedSkillIds),
+          supportSelections.agents,
+          supportSelections.skills,
           language
         );
         fs.writeFileSync(agentsMdPath, agentsContent, 'utf8');
@@ -659,8 +678,8 @@ export function install(options: InstallOptions): InstallResult {
     } else {
       try {
         const content = buildCodexAgentsMd(
-          Array.from(processedAgentIds),
-          Array.from(processedSkillIds),
+          supportSelections.agents,
+          supportSelections.skills,
           language
         );
         const nextContent =

--- a/scripts/smoke-wrapper-monorepo.sh
+++ b/scripts/smoke-wrapper-monorepo.sh
@@ -100,6 +100,15 @@ verify_skills() {
   test -f "${monorepo}/.codex/rules/owasp-security-scan.md"
 }
 
+verify_skill_patch_keeps_support_rules() {
+  local monorepo="$1"
+
+  grep -q '`.claude/rules/typescript/typescript-linting.md`' "${monorepo}/CLAUDE.md"
+  grep -q '`.claude/skills/github-health-check.skill`' "${monorepo}/CLAUDE.md"
+  grep -q '`.codex/rules/typescript/typescript-linting.md`' "${monorepo}/AGENTS.md"
+  grep -q '`.codex/rules/github-health-check.md`' "${monorepo}/AGENTS.md"
+}
+
 verify_codex_removed() {
   local monorepo="$1"
 
@@ -141,7 +150,7 @@ main() {
 
   (
     cd "${monorepo}"
-    ballast install --target cursor --target claude,opencode --target codex --all --all-skills --yes
+    ballast install --target cursor --target claude,opencode --target codex --all --skill owasp-security-scan --yes
   )
 
   verify_common_rules "${monorepo}"
@@ -149,6 +158,13 @@ main() {
   verify_rulesrc "${monorepo}"
   verify_support_files "${monorepo}"
   verify_skills "${monorepo}"
+
+  (
+    cd "${monorepo}"
+    ballast install --target claude --target codex --skill github-health-check --patch --yes
+  )
+
+  verify_skill_patch_keeps_support_rules "${monorepo}"
 
   (
     cd "${monorepo}"


### PR DESCRIPTION
## Summary
- keep AGENTS.md, CLAUDE.md, and backend support files sourced from persisted `.rulesrc.json` state instead of the current write set
- preserve configured agents in monorepo skill-only installs so wrapper patch runs keep rule references intact
- add TypeScript, Python, Go, wrapper unit regressions and wrapper smoke coverage for the skill-only patch path

## Verification
- `pnpm test -- --runInBand packages/ballast-typescript/src/install.test.ts`
- `python3 -m unittest packages.ballast-python.tests.test_cli.PatchInstallTests.test_skill_only_patch_keeps_codex_rule_references_from_rulesrc packages.ballast-python.tests.test_cli.PatchInstallTests.test_patch_updates_codex_agents_md_section_only`
- `go test .` (in `cli/ballast`)
- `go test ./cmd/ballast-go` (in `packages/ballast-go`)

## Notes
- repo-root `PRD.md` is not present in this checkout, so there was no governing PRD section to link for this bug fix.