### PR TITLE
feat: add ballast update command for Homebrew CLI upgrades

### DIFF
--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -190,7 +190,7 @@ func run(args []string) int {
 		return runUpgrade(selectedLanguage, forwardedArgs[1:])
 	}
 	if len(forwardedArgs) > 0 && forwardedArgs[0] == "update" {
-		return runUpdate()
+		return runUpdate(forwardedArgs[1:])
 	}
 
 	if hasVersionFlag(forwardedArgs) {
@@ -348,7 +348,7 @@ func printUsage() {
 	fmt.Println("  install-cli Install or upgrade backend CLIs (latest by default, or a specific --version)")
 	fmt.Println("  doctor      Check local Ballast CLI versions and .rulesrc.json metadata (`--fix` installs/upgrades CLIs and refreshes config; add `--patch` with `--fix` to merge backend file updates during refresh)")
 	fmt.Println("  upgrade     Rewrite .rulesrc.json to the running ballast version and sync backend CLIs (`--patch` and `--force` forward to the backend refresh)")
-	fmt.Println("  update      Upgrade the ballast CLI itself via Homebrew (`brew update && brew upgrade ballast`)")
+	fmt.Println("  update      Upgrade the ballast CLI itself via Homebrew (`brew update && brew upgrade ...`)")
 	fmt.Println("  help        Show help for ballast")
 	fmt.Println("  version     Print the ballast wrapper version")
 	fmt.Println()
@@ -576,7 +576,11 @@ func runDoctor(selectedLanguage language, args []string) int {
 	return 0
 }
 
-func runUpdate() int {
+func runUpdate(args []string) int {
+	if len(args) > 0 {
+		fmt.Printf("unknown update option: %s\n", args[0])
+		return 1
+	}
 	if !detectBrewInstall() {
 		fmt.Println("ballast update is only supported for Homebrew installations.")
 		fmt.Println("To upgrade a non-Homebrew install, download the latest release from GitHub.")

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -189,6 +189,9 @@ func run(args []string) int {
 	if len(forwardedArgs) > 0 && forwardedArgs[0] == "upgrade" {
 		return runUpgrade(selectedLanguage, forwardedArgs[1:])
 	}
+	if len(forwardedArgs) > 0 && forwardedArgs[0] == "update" {
+		return runUpdate()
+	}
 
 	if hasVersionFlag(forwardedArgs) {
 		printVersion()
@@ -345,6 +348,7 @@ func printUsage() {
 	fmt.Println("  install-cli Install or upgrade backend CLIs (latest by default, or a specific --version)")
 	fmt.Println("  doctor      Check local Ballast CLI versions and .rulesrc.json metadata (`--fix` installs/upgrades CLIs and refreshes config; add `--patch` with `--fix` to merge backend file updates during refresh)")
 	fmt.Println("  upgrade     Rewrite .rulesrc.json to the running ballast version and sync backend CLIs (`--patch` and `--force` forward to the backend refresh)")
+	fmt.Println("  update      Upgrade the ballast CLI itself via Homebrew (`brew update && brew upgrade ballast`)")
 	fmt.Println("  help        Show help for ballast")
 	fmt.Println("  version     Print the ballast wrapper version")
 	fmt.Println()
@@ -364,6 +368,7 @@ func printUsage() {
 	fmt.Println("  ballast install-cli --language python")
 	fmt.Println("  ballast doctor")
 	fmt.Println("  ballast doctor --fix")
+	fmt.Println("  ballast update")
 	fmt.Println("  ballast upgrade")
 	fmt.Println("  ballast upgrade --patch")
 	fmt.Println("  ballast upgrade --force")
@@ -571,26 +576,31 @@ func runDoctor(selectedLanguage language, args []string) int {
 	return 0
 }
 
+func runUpdate() int {
+	if !detectBrewInstall() {
+		fmt.Println("ballast update is only supported for Homebrew installations.")
+		fmt.Println("To upgrade a non-Homebrew install, download the latest release from GitHub.")
+		return 1
+	}
+	fmt.Println("Updating Homebrew...")
+	if err := runCommandFunc("brew", []string{"update"}); err != nil {
+		fmt.Printf("brew update failed: %v\n", err)
+		return 1
+	}
+	fmt.Println("Upgrading ballast via Homebrew...")
+	if err := runCommandFunc("brew", brewUpgradeArgs()); err != nil {
+		fmt.Printf("brew upgrade failed: %v\n", err)
+		return 1
+	}
+	fmt.Println("ballast upgraded. Run `ballast upgrade` to update .rulesrc.json and sync backend CLIs.")
+	return 0
+}
+
 func runUpgrade(selectedLanguage language, args []string) int {
 	patch, force, err := parseUpgradeOptions(args)
 	if err != nil {
 		fmt.Println(err)
 		return 1
-	}
-
-	if detectBrewInstall() {
-		fmt.Println("Updating Homebrew...")
-		if err := runCommandFunc("brew", []string{"update"}); err != nil {
-			fmt.Printf("brew update failed: %v\n", err)
-			return 1
-		}
-		fmt.Println("Upgrading ballast via Homebrew...")
-		if err := runCommandFunc("brew", brewUpgradeArgs()); err != nil {
-			fmt.Printf("brew upgrade failed: %v\n", err)
-			return 1
-		}
-		fmt.Println("ballast was upgraded via Homebrew. Please rerun `ballast upgrade` to update .rulesrc.json and finish syncing with the new version.")
-		return 0
 	}
 
 	root := findProjectRoot("")

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -707,26 +707,18 @@ func TestDetectBrewInstallReturnsTrueWhenExeUnderPrefix(t *testing.T) {
 	}
 }
 
-func TestRunUpgradeRunsBrewWhenBrewInstalled(t *testing.T) {
+func TestRunUpdateRunsBrewWhenBrewInstalled(t *testing.T) {
 	originalRun := runCommandFunc
-	originalEnsure := ensureInstalledFunc
-	originalExec := execToolFunc
-	originalVersion := version
 	originalLookPath := execLookPathFunc
 	originalOutput := runCommandOutputFunc
 	originalExe := osExecutableFunc
 	t.Cleanup(func() {
 		runCommandFunc = originalRun
-		ensureInstalledFunc = originalEnsure
-		execToolFunc = originalExec
-		version = originalVersion
 		execLookPathFunc = originalLookPath
 		runCommandOutputFunc = originalOutput
 		osExecutableFunc = originalExe
 	})
-	version = "5.0.6"
 
-	// Simulate a brew installation
 	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
 		return "/opt/homebrew", nil
@@ -738,27 +730,11 @@ func TestRunUpgradeRunsBrewWhenBrewInstalled(t *testing.T) {
 		commands = append(commands, append([]string{name}, args...))
 		return nil
 	}
-	ensureInstalledFunc = func(tool toolConfig) error { return nil }
-	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
-		return 0, nil
+
+	exitCode := run([]string{"update"})
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
-
-	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
-	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
-  "ballastVersion":"5.0.5",
-  "target":"claude",
-  "agents":["local-dev"],
-  "languages":["typescript"],
-  "paths":{"typescript":["."]}
-}`)
-
-	withWorkingDir(t, root, func() {
-		exitCode := run([]string{"upgrade"})
-		if exitCode != 0 {
-			t.Fatalf("expected exit code 0, got %d", exitCode)
-		}
-	})
 
 	if len(commands) < 2 {
 		t.Fatalf("expected at least 2 commands (brew update + brew upgrade), got %v", commands)
@@ -774,7 +750,130 @@ func TestRunUpgradeRunsBrewWhenBrewInstalled(t *testing.T) {
 	}
 }
 
-func TestRunUpgradeSkipsBrewWhenNotBrewInstalled(t *testing.T) {
+func TestRunUpdateFailsWhenNotBrewInstalled(t *testing.T) {
+	originalLookPath := execLookPathFunc
+	t.Cleanup(func() { execLookPathFunc = originalLookPath })
+
+	execLookPathFunc = func(file string) (string, error) {
+		return "", errors.New("not found")
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "only supported for Homebrew installations") {
+		t.Fatalf("expected non-brew message, got %q", output)
+	}
+}
+
+func TestRunUpdateFailsWhenBrewUpdateFails(t *testing.T) {
+	originalRun := runCommandFunc
+	originalLookPath := execLookPathFunc
+	originalOutput := runCommandOutputFunc
+	originalExe := osExecutableFunc
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		execLookPathFunc = originalLookPath
+		runCommandOutputFunc = originalOutput
+		osExecutableFunc = originalExe
+	})
+
+	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "/opt/homebrew", nil
+	}
+	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
+	runCommandFunc = func(name string, args []string) error {
+		if name == "brew" && len(args) > 0 && args[0] == "update" {
+			return errors.New("brew update error")
+		}
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "brew update failed") {
+		t.Fatalf("expected brew update failure message, got %q", output)
+	}
+}
+
+func TestRunUpdateFailsWhenBrewUpgradeFails(t *testing.T) {
+	originalRun := runCommandFunc
+	originalLookPath := execLookPathFunc
+	originalOutput := runCommandOutputFunc
+	originalExe := osExecutableFunc
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		execLookPathFunc = originalLookPath
+		runCommandOutputFunc = originalOutput
+		osExecutableFunc = originalExe
+	})
+
+	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "/opt/homebrew", nil
+	}
+	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
+	runCommandFunc = func(name string, args []string) error {
+		if name == "brew" && len(args) > 0 && args[0] == "upgrade" {
+			return errors.New("brew upgrade error")
+		}
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "brew upgrade failed") {
+		t.Fatalf("expected brew upgrade failure message, got %q", output)
+	}
+}
+
+func TestRunUpdateSuccessMessage(t *testing.T) {
+	originalRun := runCommandFunc
+	originalLookPath := execLookPathFunc
+	originalOutput := runCommandOutputFunc
+	originalExe := osExecutableFunc
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		execLookPathFunc = originalLookPath
+		runCommandOutputFunc = originalOutput
+		osExecutableFunc = originalExe
+	})
+
+	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "/opt/homebrew", nil
+	}
+	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
+	runCommandFunc = func(name string, args []string) error { return nil }
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "ballast upgrade") {
+		t.Fatalf("expected post-update hint to run ballast upgrade, got %q", output)
+	}
+}
+
+func TestRunUpgradeDoesNotRunBrew(t *testing.T) {
 	originalRun := runCommandFunc
 	originalEnsure := ensureInstalledFunc
 	originalExec := execToolFunc
@@ -789,10 +888,8 @@ func TestRunUpgradeSkipsBrewWhenNotBrewInstalled(t *testing.T) {
 	})
 	version = "5.0.6"
 
-	// Simulate no brew installation
-	execLookPathFunc = func(file string) (string, error) {
-		return "", errors.New("not found")
-	}
+	// Even when brew is on PATH, upgrade should not invoke brew
+	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
 
 	var commands [][]string
 	runCommandFunc = func(name string, args []string) error {
@@ -823,117 +920,8 @@ func TestRunUpgradeSkipsBrewWhenNotBrewInstalled(t *testing.T) {
 
 	for _, cmd := range commands {
 		if cmd[0] == "brew" {
-			t.Fatalf("expected no brew commands when not brew-installed, got %v", cmd)
+			t.Fatalf("expected no brew commands from upgrade, got %v", cmd)
 		}
-	}
-}
-
-func TestRunUpgradeFailsWhenBrewUpdateFails(t *testing.T) {
-	originalRun := runCommandFunc
-	originalLookPath := execLookPathFunc
-	originalOutput := runCommandOutputFunc
-	originalExe := osExecutableFunc
-	t.Cleanup(func() {
-		runCommandFunc = originalRun
-		execLookPathFunc = originalLookPath
-		runCommandOutputFunc = originalOutput
-		osExecutableFunc = originalExe
-	})
-
-	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
-	runCommandOutputFunc = func(name string, args []string) (string, error) {
-		return "/opt/homebrew", nil
-	}
-	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
-	runCommandFunc = func(name string, args []string) error {
-		if name == "brew" && len(args) > 0 && args[0] == "update" {
-			return errors.New("brew update error")
-		}
-		return nil
-	}
-
-	output := captureStdout(t, func() {
-		withWorkingDir(t, t.TempDir(), func() {
-			exitCode := run([]string{"upgrade"})
-			if exitCode != 1 {
-				t.Fatalf("expected exit code 1, got %d", exitCode)
-			}
-		})
-	})
-
-	if !strings.Contains(output, "brew update failed") {
-		t.Fatalf("expected brew update failure message, got %q", output)
-	}
-}
-
-func TestRunUpgradeFailsWhenBrewUpgradeFails(t *testing.T) {
-	originalRun := runCommandFunc
-	originalLookPath := execLookPathFunc
-	originalOutput := runCommandOutputFunc
-	originalExe := osExecutableFunc
-	t.Cleanup(func() {
-		runCommandFunc = originalRun
-		execLookPathFunc = originalLookPath
-		runCommandOutputFunc = originalOutput
-		osExecutableFunc = originalExe
-	})
-
-	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
-	runCommandOutputFunc = func(name string, args []string) (string, error) {
-		return "/opt/homebrew", nil
-	}
-	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
-	runCommandFunc = func(name string, args []string) error {
-		if name == "brew" && len(args) > 0 && args[0] == "upgrade" {
-			return errors.New("brew upgrade error")
-		}
-		return nil
-	}
-
-	output := captureStdout(t, func() {
-		withWorkingDir(t, t.TempDir(), func() {
-			exitCode := run([]string{"upgrade"})
-			if exitCode != 1 {
-				t.Fatalf("expected exit code 1, got %d", exitCode)
-			}
-		})
-	})
-
-	if !strings.Contains(output, "brew upgrade failed") {
-		t.Fatalf("expected brew upgrade failure message, got %q", output)
-	}
-}
-
-func TestRunUpgradeSuccessMessageWhenBrewInstalled(t *testing.T) {
-	originalRun := runCommandFunc
-	originalLookPath := execLookPathFunc
-	originalOutput := runCommandOutputFunc
-	originalExe := osExecutableFunc
-	t.Cleanup(func() {
-		runCommandFunc = originalRun
-		execLookPathFunc = originalLookPath
-		runCommandOutputFunc = originalOutput
-		osExecutableFunc = originalExe
-	})
-
-	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
-	runCommandOutputFunc = func(name string, args []string) (string, error) {
-		return "/opt/homebrew", nil
-	}
-	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
-	runCommandFunc = func(name string, args []string) error { return nil }
-
-	output := captureStdout(t, func() {
-		withWorkingDir(t, t.TempDir(), func() {
-			exitCode := run([]string{"upgrade"})
-			if exitCode != 0 {
-				t.Fatalf("expected exit code 0, got %d", exitCode)
-			}
-		})
-	})
-
-	if !strings.Contains(output, "Please rerun") {
-		t.Fatalf("expected rerun message after brew upgrade, got %q", output)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -770,6 +770,31 @@ func TestRunUpdateFailsWhenNotBrewInstalled(t *testing.T) {
 	}
 }
 
+func TestRunUpdateRejectsUnknownOption(t *testing.T) {
+	originalRun := runCommandFunc
+	t.Cleanup(func() { runCommandFunc = originalRun })
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update", "--bogus"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "unknown update option: --bogus") {
+		t.Fatalf("expected update option error, got %q", output)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("expected no commands to run for invalid update args, got %v", commands)
+	}
+}
+
 func TestRunUpdateFailsWhenBrewUpdateFails(t *testing.T) {
 	originalRun := runCommandFunc
 	originalLookPath := execLookPathFunc


### PR DESCRIPTION
## Summary

Fixes the separation of concerns from #134 where brew self-upgrade logic was incorrectly placed inside \`ballast upgrade\`.

- \`ballast upgrade\` — rewrites \`.rulesrc.json\` to the running version and syncs backend CLIs (no brew involvement)
- \`ballast update\` — new command that runs \`brew update && brew upgrade ballast\`, then instructs the user to run \`ballast upgrade\` to finish syncing config under the new binary
- \`ballast update\` returns exit code 1 with a clear message when run outside a Homebrew installation

## Changes

- Moved brew detection + upgrade logic out of \`runUpgrade\` into a new \`runUpdate\` function
- Wired \`update\` as a top-level command in the dispatcher
- Added \`update\` to help text and examples
- Updated all tests: brew tests now target \`ballast update\`; added \`TestRunUpgradeDoesNotRunBrew\` to confirm \`ballast upgrade\` never calls brew

## Test plan

- [ ] \`ballast update\` on a Homebrew install runs \`brew update\` then \`brew upgrade ballast\` and exits 0
- [ ] \`ballast update\` on a non-Homebrew install exits 1 with a clear error message
- [ ] \`ballast upgrade\` no longer invokes brew under any circumstances
- [ ] \`ballast help\` shows both \`upgrade\` and \`update\` with correct descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)