### PR TITLE
chore(ci): align Node workflows with package support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '24.x'
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [22.x, 24.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- remove unsupported Node 18 and Node 20 entries from the test workflow matrix
- update the publish workflow bump-and-tag job from Node 20 to Node 24
- keep GitHub Actions Node versions aligned with the repo's declared Node >=22 support

## Testing
- pre-commit hooks
- pre-push hooks