### PR TITLE
Improve GitHub health check security coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @markcallen

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] Tests or checks run:
+- [ ] Docs updated or not needed:
+- [ ] Generated files updated or not needed:
+
+## Agent Notes
+
+- Related issue/PRD:
+- Risk level:
+- Follow-up needed:

--- a/.github/workflows/cross-language-validate.yml
+++ b/.github/workflows/cross-language-validate.yml
@@ -8,6 +8,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Skills are reusable task guides that Ballast installs for the target AI tool alo
 - `aws-health-review`: run a weekly read-only AWS operational health baseline and append prioritized TODO follow-up
 - `aws-live-health-review`: generate a current-state AWS operational snapshot for EC2, RDS, ALB, alarms, and logs
 - `aws-weekly-security-review`: run a weekly read-only AWS security baseline review with prioritized findings
-- `github-health-check`: run a comprehensive GitHub repository health check covering CI status, open PRs, Dependabot, code coverage, GitHub Code Quality, and security alerts
+- `github-health-check`: run a comprehensive GitHub repository health check covering CI status, open PRs, Dependabot, code coverage, GitHub Code Quality findings, security feature enablement, security advisories, and alert listings
 
 ### Install a skill
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ Common skills:
 - `aws-weekly-security-review`
 - `github-health-check`
 
-`github-health-check` covers CI status, pull request hygiene, Dependabot, code coverage, GitHub Code Quality, and security checks.
+`github-health-check` covers CI status, pull request hygiene, Dependabot, code coverage, GitHub Code Quality findings, security feature enablement, security advisories, and alert listings.
 
 Guide index:
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -33,7 +33,7 @@ Ballast ships reusable skill guides alongside its agent rules.
 - Type: common skill
 - Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
 - Installed by: `--skill github-health-check` or `--all-skills`
-- Focus: CI status, pull requests, Dependabot, code coverage, GitHub Code Quality, and security checks
+- Focus: CI status, pull requests, Dependabot, code coverage, GitHub Code Quality findings, security feature enablement, security advisories, and alert listings
 
 ## Installation Targets
 

--- a/docs/skills/github-health-check.md
+++ b/docs/skills/github-health-check.md
@@ -1,6 +1,6 @@
 # `github-health-check`
 
-The `github-health-check` skill runs a comprehensive GitHub repository health audit using the `gh` CLI. It produces a structured report with status indicators and actionable items, auto-merges safe Dependabot PRs, and checks whether GitHub Code Quality is enabled.
+The `github-health-check` skill runs a comprehensive GitHub repository health audit using the `gh` CLI. It produces a structured report with status indicators and actionable items, auto-merges safe Dependabot PRs, and checks whether required GitHub security and code quality features are enabled.
 
 ## When To Use It
 
@@ -11,8 +11,11 @@ Use this skill when you want to:
 - review open pull requests and stale branches
 - merge safe Dependabot dependency updates
 - check whether GitHub Code Quality is turned on
-- check security alerts and code scanning results
+- check security policy, security advisories, and private vulnerability reporting
+- check Dependabot, code scanning, and secret scanning alerts
+- list Code Quality findings, Dependabot malware/vulnerability alerts, code scanning alerts, and secret scanning alerts
 - review branch protection and Snyk integration
+- review public/private repository best practices
 - get a prioritized list of items that need attention
 
 ## Install It
@@ -41,7 +44,9 @@ The skill should:
 2. use `PASS`, `WARN`, `FAIL`, and `ERROR` status indicators
 3. include actionable remediation guidance for each finding
 4. auto-merge Dependabot PRs that pass all required checks
-5. surface a prioritized list of items needing attention
+5. assign `HIGH` priority to missing security advisories, Dependabot alerts, code scanning alerts, secret scanning alerts, and public-repo private vulnerability reporting
+6. assign `MEDIUM` priority to missing security policy and Code Quality enablement/findings visibility
+7. surface a prioritized list of items needing attention
 
 ## Notes
 

--- a/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
@@ -281,9 +281,22 @@ gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
 
 # Private vulnerability reporting is expected only for public repos.
 if [ "$IS_PRIVATE" = "false" ]; then
-  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
-    --jq '{enabled}' 2>/dev/null || \
-    echo "Private vulnerability reporting status unavailable"
+  PVR_RESPONSE=$(gh api --include "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" 2>&1 || true)
+  PVR_STATUS=$(printf '%s\n' "$PVR_RESPONSE" | sed -n 's/^HTTP\/[0-9.]* \([0-9][0-9][0-9]\).*/\1/p' | tail -n 1)
+  case "$PVR_STATUS" in
+    200|204)
+      echo '{"enabled": true}'
+      ;;
+    404)
+      echo '{"enabled": false}'
+      ;;
+    403)
+      echo "Private vulnerability reporting status unavailable (permission denied)"
+      ;;
+    *)
+      echo "Private vulnerability reporting status unavailable"
+      ;;
+  esac
 else
   echo "Private vulnerability reporting: not required for private repositories"
 fi

--- a/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Run a comprehensive GitHub repository health check. Use this skill whenever
   the user asks to: check GitHub health, audit the repo, check CI status,
   review open PRs, merge Dependabot PRs, check code coverage, check GitHub
-  Code Quality, check security alerts, check Snyk integration, keep GitHub in
-  good shape, or any variation of "how is the repo doing". Also trigger for:
+  Code Quality, check GitHub security feature enablement, check security
+  advisories, check Dependabot alerts, check code scanning alerts, check secret
+  scanning alerts, check Snyk integration, keep GitHub in good shape, or any
+  variation of "how is the repo doing". Also trigger for:
   "check dependabot PRs", "any PRs to merge", "check branch status", "repo
   health", "GitHub status check", "what needs attention in GitHub", "tidy up
   GitHub".
@@ -13,7 +15,7 @@ description: >
 
 # GitHub Repository Health Check Skill
 
-Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether GitHub Code Quality is enabled.
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether required GitHub security and code quality features are enabled.
 
 ---
 
@@ -46,6 +48,7 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
 ```
 
 **Interpret results:**
+
 - Group runs by workflow name; show the latest run per workflow
 - Flag any workflow whose latest run concluded with `failure` or `cancelled`
 - Flag workflows that haven't run in more than 14 days
@@ -82,6 +85,7 @@ gh release list --limit 1 --json tagName,publishedAt \
 ```
 
 **Interpret results:**
+
 - If commits ahead > 20: warn that a release may be overdue
 - If last release was more than 30 days ago: note it
 - If no releases exist: note that versioned releases are not configured
@@ -110,6 +114,7 @@ gh pr list --state open --json number,title,author,isDraft,createdAt,labels,head
 ```
 
 **Report:**
+
 - Total open PRs, draft vs ready
 - PRs older than 7 days without activity (stale)
 - PRs with failing checks
@@ -131,6 +136,7 @@ For each Dependabot PR returned, apply this decision logic:
    - If only minor/patch changes → candidate for auto-merge
 
 2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+
    ```bash
    gh pr checks <PR_NUMBER> --json name,state,bucket,workflow
    ```
@@ -138,6 +144,7 @@ For each Dependabot PR returned, apply this decision logic:
 3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
 
 4. **Auto-merge if all conditions pass** (no confirmation needed):
+
    ```bash
    gh pr merge <PR_NUMBER> --squash --auto
    ```
@@ -145,6 +152,7 @@ For each Dependabot PR returned, apply this decision logic:
 5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
 
 **Example major version detection:**
+
 - "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
 - "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
 - "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
@@ -168,6 +176,7 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
 - If present: confirm coverage reporting is active
 
@@ -198,17 +207,148 @@ gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
 ```
 
 **Interpret results:**
+
 - If `security_and_analysis.code_quality.status` is `enabled`: report GitHub Code Quality as enabled
 - If the direct field is not exposed, infer likely enabled when recent `Code Quality` workflow runs or `github-code-quality[bot]` comments exist
 - If neither the direct field nor fallback signals are present: report Code Quality as not detected and recommend verifying `Settings` → `Security` → `Code quality`
 - Note that GitHub Code Quality is currently in public preview and its API surface may be incomplete or absent for some repositories
 
----
-
-## Check 6 — Security Alerts
+### Code Quality Findings
 
 ```bash
-# Count open Dependabot security alerts
+# List recent Code Quality check runs and annotations when exposed through Checks.
+HEAD_SHA=$(gh api "/repos/${OWNER}/${NAME}/commits/${DEFAULT_BRANCH}" --jq '.sha' 2>/dev/null || git rev-parse HEAD)
+gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) |
+    {id, name, status, conclusion, url: .html_url}' 2>/dev/null || true
+
+for check_id in $(gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) | .id' 2>/dev/null); do
+  gh api "/repos/${OWNER}/${NAME}/check-runs/${check_id}/annotations?per_page=100" \
+    --jq '.[] | {
+      level: .annotation_level,
+      path,
+      start_line,
+      end_line,
+      title,
+      message,
+      raw_details
+    }' 2>/dev/null || true
+done
+
+# Fallback: list recent Code Quality bot comments on PRs.
+gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-code-quality[bot]") |
+    {createdAt: .created_at, issueUrl: .issue_url, body: (.body | split("\n") | .[0:6] | join("\n")), url: .html_url}' 2>/dev/null || true
+```
+
+**Interpret results:**
+
+- List every exposed Code Quality finding with level, file, line, title/message, and URL
+- If only bot comments are available, summarize the referenced PR and include the comment URL
+- If findings cannot be listed because GitHub does not expose the data, report the feature status separately from findings visibility
+
+---
+
+## Check 6 — GitHub Security Feature Enablement
+
+Check whether required repository security features are enabled and assign the requested priority when they are missing.
+
+```bash
+# Repo visibility and security/security-and-analysis settings.
+gh repo view --json isPrivate,visibility,nameWithOwner \
+  --jq '"Repo: \(.nameWithOwner)\nVisibility: \(.visibility)\nPrivate: \(.isPrivate)"'
+
+IS_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate')
+
+gh api "/repos/${OWNER}/${NAME}" \
+  --jq '.security_and_analysis // {}' 2>/dev/null || \
+  echo "Security and analysis settings unavailable (check permissions or plan)"
+
+# Security policy: SECURITY.md in repo, .github profile, or community profile metadata.
+if [ -f SECURITY.md ] || [ -f .github/SECURITY.md ]; then
+  echo "Security policy file present locally"
+else
+  echo "Security policy file not found locally"
+fi
+gh api "/repos/${OWNER}/${NAME}/community/profile" \
+  --jq '.files.security_policy | if . then {state: "present", path: .path, url: .html_url} else {state: "missing"} end' 2>/dev/null || true
+
+# Repository security advisories capability and current advisories.
+gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
+  --jq '{accessible: true, total: length, advisories: [.[] | {ghsa_id, severity, state, summary, url: .html_url}]}' 2>/dev/null || \
+  echo "Security advisories API unavailable (may require admin/security manager access)"
+
+# Private vulnerability reporting is expected only for public repos.
+if [ "$IS_PRIVATE" = "false" ]; then
+  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
+    --jq '{enabled}' 2>/dev/null || \
+    echo "Private vulnerability reporting status unavailable"
+else
+  echo "Private vulnerability reporting: not required for private repositories"
+fi
+```
+
+**Required enablement priorities:**
+
+- `HIGH`: Security advisories must be available for maintainers/security managers and open advisories must be listed
+- `HIGH`: Private vulnerability reporting must be enabled for public repositories only
+- `HIGH`: Dependabot alerts must be enabled and queryable
+- `HIGH`: Code scanning alerts must be enabled and queryable
+- `HIGH`: Secret scanning alerts must be enabled and queryable
+- `MEDIUM`: A security policy must exist and be discoverable through `SECURITY.md` or GitHub community profile metadata
+- `MEDIUM`: GitHub Code Quality should be enabled or verified manually when the API does not expose its status
+
+**Interpret results:**
+
+- Missing `HIGH` controls go in Recommended Actions as `HIGH`
+- Missing `MEDIUM` controls go in Recommended Actions as `MEDIUM`
+- For public repos, treat missing private vulnerability reporting as `HIGH`; for private repos, report it as not applicable
+- When an API returns 403/404, distinguish "not enabled" from "not enough permission" whenever the response makes that clear
+
+---
+
+## Check 7 — Security Alerts and Findings
+
+```bash
+# Dependabot alerts: list malware separately from vulnerabilities.
+echo "--- Dependabot malware alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select(((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+echo "--- Dependabot vulnerability alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select((((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) | not) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      vulnerable_range: .security_vulnerability.vulnerable_version_range,
+      patched_versions: .security_vulnerability.first_patched_version.identifier,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+# Count open Dependabot security alerts.
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
   echo "Could not fetch Dependabot alert count (check repo permissions)"
@@ -217,26 +357,52 @@ gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
   --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
 
-# Code scanning alerts (SAST / CodeQL)
+# Code scanning alerts (SAST / CodeQL): list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
   echo "Code scanning: not enabled or no access"
 
-# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    severity: (.rule.security_severity_level // .rule.severity // "unknown"),
+    tool: .tool.name,
+    rule: .rule.id,
+    description: .rule.description,
+    path: .most_recent_instance.location.path,
+    start_line: .most_recent_instance.location.start_line,
+    state,
+    url: .html_url
+  }' 2>/dev/null || true
+
+# Secret scanning alerts: list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
   echo "Secret scanning: not enabled or no access"
+
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    secret_type,
+    secret_type_display_name,
+    state,
+    resolution,
+    created_at,
+    url: .html_url
+  }' 2>/dev/null || true
 ```
 
 **Interpret results:**
-- Open Dependabot security alerts > 0: list them with severity (critical/high first)
-- Code scanning alerts: show count and any critical/high items
-- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
-- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+- Open Dependabot malware alerts > 0: list them separately and prioritize as `CRITICAL`
+- Open Dependabot vulnerability alerts > 0: list them with severity, package, ecosystem, manifest, patched version, and URL
+- Code scanning alerts: list every open alert with severity, rule, file, line, and URL; critical/high items are `HIGH`
+- Secret scanning alerts > 0: list every open alert and flag as `CRITICAL` because leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL or another code scanning tool in GitHub security settings
 
 ---
 
-## Check 7 — Snyk Integration
+## Check 8 — Snyk Integration
 
 ```bash
 # Check for .snyk policy file
@@ -253,12 +419,13 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
 - If partially configured: note what's present and what's missing
 
 ---
 
-## Check 8 — Branch Protection Rules
+## Check 9 — Branch Protection Rules
 
 ```bash
 # Check protection rules on the default branch
@@ -286,6 +453,7 @@ except Exception as e: print('Could not parse:', e)
 ```
 
 **Flag missing protections:**
+
 - No required PR reviews: warn
 - No required status checks: warn
 - Force pushes allowed on main: warn
@@ -293,7 +461,7 @@ except Exception as e: print('Could not parse:', e)
 
 ---
 
-## Check 9 — Stale Branches
+## Check 10 — Stale Branches
 
 ```bash
 # List remote branches not merged to default branch, sorted by last commit date
@@ -322,7 +490,7 @@ echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
 
 ---
 
-## Check 10 — Repository Housekeeping
+## Check 11 — Repository Housekeeping
 
 ```bash
 # Check for essential files
@@ -345,7 +513,7 @@ gh repo view --json description,repositoryTopics \
 
 ---
 
-## Check 11 — Workflow Health Patterns
+## Check 12 — Workflow Health Patterns
 
 ```bash
 # Detect consistently failing workflows (>50% failure rate over recent runs)
@@ -356,12 +524,12 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
     runs: length,
     failures: map(select(.conclusion == "failure")) | length
   } | select(.runs >= 3) |
-  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " CONSISTENTLY FAILING" else "" end)"'
 ```
 
 ---
 
-## Check 12 — Release & Tag Health
+## Check 13 — Release & Tag Health
 
 ```bash
 # List recent releases
@@ -375,7 +543,7 @@ DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | le
 
 ---
 
-## Check 13 — Actions Permissions & Secrets Health
+## Check 14 — Actions Permissions & Secrets Health
 
 ```bash
 # Check default workflow permissions
@@ -408,6 +576,76 @@ except: pass
 
 ---
 
+## Check 15 — Public and Private Repository Best Practices
+
+Run these additional checks after determining repo visibility.
+
+```bash
+# Repository settings that affect public/private repo hygiene.
+gh repo view --json \
+  nameWithOwner,visibility,isPrivate,isArchived,hasIssuesEnabled,hasProjectsEnabled,hasWikiEnabled,description,homepageUrl,repositoryTopics,licenseInfo,defaultBranchRef \
+  --jq '{
+    repo: .nameWithOwner,
+    visibility,
+    isPrivate,
+    archived: .isArchived,
+    issues: .hasIssuesEnabled,
+    projects: .hasProjectsEnabled,
+    wiki: .hasWikiEnabled,
+    description,
+    homepage: .homepageUrl,
+    topics: [.repositoryTopics.nodes[].topic.name],
+    license: .licenseInfo.spdxId,
+    defaultBranch: .defaultBranchRef.name
+  }'
+
+# Rulesets can supplement or replace classic branch protection.
+gh api "/repos/${OWNER}/${NAME}/rulesets?per_page=100" \
+  --jq '.[] | {name, target, enforcement, conditions, rules: [.rules[].type]}' 2>/dev/null || \
+  echo "Rulesets unavailable or not configured"
+
+# Collaborators and external access. Requires admin permissions on many repos.
+gh api "/repos/${OWNER}/${NAME}/collaborators?affiliation=outside&per_page=100" \
+  --jq '.[] | {login, permissions}' 2>/dev/null || \
+  echo "Outside collaborators unavailable (check permissions) or none found"
+
+# Pull request templates and issue templates.
+for f in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md; do
+  [ -f "$f" ] && echo "OK: $f" || true
+done
+[ -d .github/ISSUE_TEMPLATE ] && find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print || echo "No issue templates found"
+
+# GitHub Actions supply-chain hygiene: flag unpinned third-party actions.
+grep -RhoE 'uses: +[^ ]+' .github/workflows 2>/dev/null | \
+  sed 's/uses: *//' | \
+  grep -vE '^\\./|@[0-9a-f]{40}$' || \
+  echo "No obviously unpinned third-party actions found"
+```
+
+**Public repo best-practice checks:**
+
+- `HIGH`: Private vulnerability reporting enabled
+- `HIGH`: Secret scanning and push protection enabled
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled on the default branch
+- `MEDIUM`: `SECURITY.md`, `LICENSE`, README, description, and topics are present
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: CODEOWNERS and PR templates exist for maintainability
+- `MEDIUM`: Third-party GitHub Actions are pinned to full commit SHAs or justified
+
+**Private repo best-practice checks:**
+
+- `HIGH`: Secret scanning and push protection enabled where the plan supports it
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled where GitHub Advanced Security or equivalent tooling is available
+- `HIGH`: Outside collaborators are reviewed and least-privilege
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: Actions default workflow permissions are read-only unless write is justified
+- `MEDIUM`: Stale secrets are rotated and unused secrets are removed
+- `MEDIUM`: CODEOWNERS, PR templates, and issue templates exist where useful for the team
+
+---
+
 ## Generate Health Report
 
 After running all checks, present findings in this structure:
@@ -436,12 +674,27 @@ After running all checks, present findings in this structure:
 
 ---
 ### Security  ✅/⚠️/❌
+- Security policy: present / missing (MEDIUM)
+- Security advisories: accessible / unavailable; open advisories listed (HIGH)
+- Private vulnerability reporting: enabled / missing / not applicable for private repos (HIGH for public repos only)
 - GitHub Code Quality: enabled / NOT DETECTED ⚠️
+- Code Quality findings: N open/listed or unavailable
 - Dependabot alerts: N open (X critical, Y high)
+- Dependabot malware alerts: N open/listed
+- Dependabot vulnerability alerts: N open/listed
 - Code scanning (CodeQL): enabled/NOT ENABLED
-- Secret scanning: N open alerts
+- Code scanning alerts: N open/listed
+- Secret scanning: N open alerts/listed
 - Snyk: configured / NOT CONFIGURED ⚠️
 - Branch protection on main: summary of rules
+
+---
+### GitHub Best Practices
+- Public/private repo checks: list missing high/medium controls
+- Actions permissions: read-only / write / unavailable
+- Rulesets or branch protection: configured / missing
+- Outside collaborators: N or unavailable
+- Unpinned third-party Actions: list or "none found"
 
 ---
 ### Code Coverage  ✅/⚠️

--- a/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
@@ -281,9 +281,22 @@ gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
 
 # Private vulnerability reporting is expected only for public repos.
 if [ "$IS_PRIVATE" = "false" ]; then
-  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
-    --jq '{enabled}' 2>/dev/null || \
-    echo "Private vulnerability reporting status unavailable"
+  PVR_RESPONSE=$(gh api --include "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" 2>&1 || true)
+  PVR_STATUS=$(printf '%s\n' "$PVR_RESPONSE" | sed -n 's/^HTTP\/[0-9.]* \([0-9][0-9][0-9]\).*/\1/p' | tail -n 1)
+  case "$PVR_STATUS" in
+    200|204)
+      echo '{"enabled": true}'
+      ;;
+    404)
+      echo '{"enabled": false}'
+      ;;
+    403)
+      echo "Private vulnerability reporting status unavailable (permission denied)"
+      ;;
+    *)
+      echo "Private vulnerability reporting status unavailable"
+      ;;
+  esac
 else
   echo "Private vulnerability reporting: not required for private repositories"
 fi

--- a/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-python/ballast/skills/common/github-health-check/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Run a comprehensive GitHub repository health check. Use this skill whenever
   the user asks to: check GitHub health, audit the repo, check CI status,
   review open PRs, merge Dependabot PRs, check code coverage, check GitHub
-  Code Quality, check security alerts, check Snyk integration, keep GitHub in
-  good shape, or any variation of "how is the repo doing". Also trigger for:
+  Code Quality, check GitHub security feature enablement, check security
+  advisories, check Dependabot alerts, check code scanning alerts, check secret
+  scanning alerts, check Snyk integration, keep GitHub in good shape, or any
+  variation of "how is the repo doing". Also trigger for:
   "check dependabot PRs", "any PRs to merge", "check branch status", "repo
   health", "GitHub status check", "what needs attention in GitHub", "tidy up
   GitHub".
@@ -13,7 +15,7 @@ description: >
 
 # GitHub Repository Health Check Skill
 
-Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether GitHub Code Quality is enabled.
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether required GitHub security and code quality features are enabled.
 
 ---
 
@@ -46,6 +48,7 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
 ```
 
 **Interpret results:**
+
 - Group runs by workflow name; show the latest run per workflow
 - Flag any workflow whose latest run concluded with `failure` or `cancelled`
 - Flag workflows that haven't run in more than 14 days
@@ -82,6 +85,7 @@ gh release list --limit 1 --json tagName,publishedAt \
 ```
 
 **Interpret results:**
+
 - If commits ahead > 20: warn that a release may be overdue
 - If last release was more than 30 days ago: note it
 - If no releases exist: note that versioned releases are not configured
@@ -110,6 +114,7 @@ gh pr list --state open --json number,title,author,isDraft,createdAt,labels,head
 ```
 
 **Report:**
+
 - Total open PRs, draft vs ready
 - PRs older than 7 days without activity (stale)
 - PRs with failing checks
@@ -131,6 +136,7 @@ For each Dependabot PR returned, apply this decision logic:
    - If only minor/patch changes → candidate for auto-merge
 
 2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+
    ```bash
    gh pr checks <PR_NUMBER> --json name,state,bucket,workflow
    ```
@@ -138,6 +144,7 @@ For each Dependabot PR returned, apply this decision logic:
 3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
 
 4. **Auto-merge if all conditions pass** (no confirmation needed):
+
    ```bash
    gh pr merge <PR_NUMBER> --squash --auto
    ```
@@ -145,6 +152,7 @@ For each Dependabot PR returned, apply this decision logic:
 5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
 
 **Example major version detection:**
+
 - "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
 - "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
 - "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
@@ -168,6 +176,7 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
 - If present: confirm coverage reporting is active
 
@@ -198,17 +207,148 @@ gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
 ```
 
 **Interpret results:**
+
 - If `security_and_analysis.code_quality.status` is `enabled`: report GitHub Code Quality as enabled
 - If the direct field is not exposed, infer likely enabled when recent `Code Quality` workflow runs or `github-code-quality[bot]` comments exist
 - If neither the direct field nor fallback signals are present: report Code Quality as not detected and recommend verifying `Settings` → `Security` → `Code quality`
 - Note that GitHub Code Quality is currently in public preview and its API surface may be incomplete or absent for some repositories
 
----
-
-## Check 6 — Security Alerts
+### Code Quality Findings
 
 ```bash
-# Count open Dependabot security alerts
+# List recent Code Quality check runs and annotations when exposed through Checks.
+HEAD_SHA=$(gh api "/repos/${OWNER}/${NAME}/commits/${DEFAULT_BRANCH}" --jq '.sha' 2>/dev/null || git rev-parse HEAD)
+gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) |
+    {id, name, status, conclusion, url: .html_url}' 2>/dev/null || true
+
+for check_id in $(gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) | .id' 2>/dev/null); do
+  gh api "/repos/${OWNER}/${NAME}/check-runs/${check_id}/annotations?per_page=100" \
+    --jq '.[] | {
+      level: .annotation_level,
+      path,
+      start_line,
+      end_line,
+      title,
+      message,
+      raw_details
+    }' 2>/dev/null || true
+done
+
+# Fallback: list recent Code Quality bot comments on PRs.
+gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-code-quality[bot]") |
+    {createdAt: .created_at, issueUrl: .issue_url, body: (.body | split("\n") | .[0:6] | join("\n")), url: .html_url}' 2>/dev/null || true
+```
+
+**Interpret results:**
+
+- List every exposed Code Quality finding with level, file, line, title/message, and URL
+- If only bot comments are available, summarize the referenced PR and include the comment URL
+- If findings cannot be listed because GitHub does not expose the data, report the feature status separately from findings visibility
+
+---
+
+## Check 6 — GitHub Security Feature Enablement
+
+Check whether required repository security features are enabled and assign the requested priority when they are missing.
+
+```bash
+# Repo visibility and security/security-and-analysis settings.
+gh repo view --json isPrivate,visibility,nameWithOwner \
+  --jq '"Repo: \(.nameWithOwner)\nVisibility: \(.visibility)\nPrivate: \(.isPrivate)"'
+
+IS_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate')
+
+gh api "/repos/${OWNER}/${NAME}" \
+  --jq '.security_and_analysis // {}' 2>/dev/null || \
+  echo "Security and analysis settings unavailable (check permissions or plan)"
+
+# Security policy: SECURITY.md in repo, .github profile, or community profile metadata.
+if [ -f SECURITY.md ] || [ -f .github/SECURITY.md ]; then
+  echo "Security policy file present locally"
+else
+  echo "Security policy file not found locally"
+fi
+gh api "/repos/${OWNER}/${NAME}/community/profile" \
+  --jq '.files.security_policy | if . then {state: "present", path: .path, url: .html_url} else {state: "missing"} end' 2>/dev/null || true
+
+# Repository security advisories capability and current advisories.
+gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
+  --jq '{accessible: true, total: length, advisories: [.[] | {ghsa_id, severity, state, summary, url: .html_url}]}' 2>/dev/null || \
+  echo "Security advisories API unavailable (may require admin/security manager access)"
+
+# Private vulnerability reporting is expected only for public repos.
+if [ "$IS_PRIVATE" = "false" ]; then
+  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
+    --jq '{enabled}' 2>/dev/null || \
+    echo "Private vulnerability reporting status unavailable"
+else
+  echo "Private vulnerability reporting: not required for private repositories"
+fi
+```
+
+**Required enablement priorities:**
+
+- `HIGH`: Security advisories must be available for maintainers/security managers and open advisories must be listed
+- `HIGH`: Private vulnerability reporting must be enabled for public repositories only
+- `HIGH`: Dependabot alerts must be enabled and queryable
+- `HIGH`: Code scanning alerts must be enabled and queryable
+- `HIGH`: Secret scanning alerts must be enabled and queryable
+- `MEDIUM`: A security policy must exist and be discoverable through `SECURITY.md` or GitHub community profile metadata
+- `MEDIUM`: GitHub Code Quality should be enabled or verified manually when the API does not expose its status
+
+**Interpret results:**
+
+- Missing `HIGH` controls go in Recommended Actions as `HIGH`
+- Missing `MEDIUM` controls go in Recommended Actions as `MEDIUM`
+- For public repos, treat missing private vulnerability reporting as `HIGH`; for private repos, report it as not applicable
+- When an API returns 403/404, distinguish "not enabled" from "not enough permission" whenever the response makes that clear
+
+---
+
+## Check 7 — Security Alerts and Findings
+
+```bash
+# Dependabot alerts: list malware separately from vulnerabilities.
+echo "--- Dependabot malware alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select(((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+echo "--- Dependabot vulnerability alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select((((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) | not) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      vulnerable_range: .security_vulnerability.vulnerable_version_range,
+      patched_versions: .security_vulnerability.first_patched_version.identifier,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+# Count open Dependabot security alerts.
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
   echo "Could not fetch Dependabot alert count (check repo permissions)"
@@ -217,26 +357,52 @@ gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
   --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
 
-# Code scanning alerts (SAST / CodeQL)
+# Code scanning alerts (SAST / CodeQL): list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
   echo "Code scanning: not enabled or no access"
 
-# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    severity: (.rule.security_severity_level // .rule.severity // "unknown"),
+    tool: .tool.name,
+    rule: .rule.id,
+    description: .rule.description,
+    path: .most_recent_instance.location.path,
+    start_line: .most_recent_instance.location.start_line,
+    state,
+    url: .html_url
+  }' 2>/dev/null || true
+
+# Secret scanning alerts: list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
   echo "Secret scanning: not enabled or no access"
+
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    secret_type,
+    secret_type_display_name,
+    state,
+    resolution,
+    created_at,
+    url: .html_url
+  }' 2>/dev/null || true
 ```
 
 **Interpret results:**
-- Open Dependabot security alerts > 0: list them with severity (critical/high first)
-- Code scanning alerts: show count and any critical/high items
-- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
-- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+- Open Dependabot malware alerts > 0: list them separately and prioritize as `CRITICAL`
+- Open Dependabot vulnerability alerts > 0: list them with severity, package, ecosystem, manifest, patched version, and URL
+- Code scanning alerts: list every open alert with severity, rule, file, line, and URL; critical/high items are `HIGH`
+- Secret scanning alerts > 0: list every open alert and flag as `CRITICAL` because leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL or another code scanning tool in GitHub security settings
 
 ---
 
-## Check 7 — Snyk Integration
+## Check 8 — Snyk Integration
 
 ```bash
 # Check for .snyk policy file
@@ -253,12 +419,13 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
 - If partially configured: note what's present and what's missing
 
 ---
 
-## Check 8 — Branch Protection Rules
+## Check 9 — Branch Protection Rules
 
 ```bash
 # Check protection rules on the default branch
@@ -286,6 +453,7 @@ except Exception as e: print('Could not parse:', e)
 ```
 
 **Flag missing protections:**
+
 - No required PR reviews: warn
 - No required status checks: warn
 - Force pushes allowed on main: warn
@@ -293,7 +461,7 @@ except Exception as e: print('Could not parse:', e)
 
 ---
 
-## Check 9 — Stale Branches
+## Check 10 — Stale Branches
 
 ```bash
 # List remote branches not merged to default branch, sorted by last commit date
@@ -322,7 +490,7 @@ echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
 
 ---
 
-## Check 10 — Repository Housekeeping
+## Check 11 — Repository Housekeeping
 
 ```bash
 # Check for essential files
@@ -345,7 +513,7 @@ gh repo view --json description,repositoryTopics \
 
 ---
 
-## Check 11 — Workflow Health Patterns
+## Check 12 — Workflow Health Patterns
 
 ```bash
 # Detect consistently failing workflows (>50% failure rate over recent runs)
@@ -356,12 +524,12 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
     runs: length,
     failures: map(select(.conclusion == "failure")) | length
   } | select(.runs >= 3) |
-  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " CONSISTENTLY FAILING" else "" end)"'
 ```
 
 ---
 
-## Check 12 — Release & Tag Health
+## Check 13 — Release & Tag Health
 
 ```bash
 # List recent releases
@@ -375,7 +543,7 @@ DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | le
 
 ---
 
-## Check 13 — Actions Permissions & Secrets Health
+## Check 14 — Actions Permissions & Secrets Health
 
 ```bash
 # Check default workflow permissions
@@ -408,6 +576,76 @@ except: pass
 
 ---
 
+## Check 15 — Public and Private Repository Best Practices
+
+Run these additional checks after determining repo visibility.
+
+```bash
+# Repository settings that affect public/private repo hygiene.
+gh repo view --json \
+  nameWithOwner,visibility,isPrivate,isArchived,hasIssuesEnabled,hasProjectsEnabled,hasWikiEnabled,description,homepageUrl,repositoryTopics,licenseInfo,defaultBranchRef \
+  --jq '{
+    repo: .nameWithOwner,
+    visibility,
+    isPrivate,
+    archived: .isArchived,
+    issues: .hasIssuesEnabled,
+    projects: .hasProjectsEnabled,
+    wiki: .hasWikiEnabled,
+    description,
+    homepage: .homepageUrl,
+    topics: [.repositoryTopics.nodes[].topic.name],
+    license: .licenseInfo.spdxId,
+    defaultBranch: .defaultBranchRef.name
+  }'
+
+# Rulesets can supplement or replace classic branch protection.
+gh api "/repos/${OWNER}/${NAME}/rulesets?per_page=100" \
+  --jq '.[] | {name, target, enforcement, conditions, rules: [.rules[].type]}' 2>/dev/null || \
+  echo "Rulesets unavailable or not configured"
+
+# Collaborators and external access. Requires admin permissions on many repos.
+gh api "/repos/${OWNER}/${NAME}/collaborators?affiliation=outside&per_page=100" \
+  --jq '.[] | {login, permissions}' 2>/dev/null || \
+  echo "Outside collaborators unavailable (check permissions) or none found"
+
+# Pull request templates and issue templates.
+for f in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md; do
+  [ -f "$f" ] && echo "OK: $f" || true
+done
+[ -d .github/ISSUE_TEMPLATE ] && find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print || echo "No issue templates found"
+
+# GitHub Actions supply-chain hygiene: flag unpinned third-party actions.
+grep -RhoE 'uses: +[^ ]+' .github/workflows 2>/dev/null | \
+  sed 's/uses: *//' | \
+  grep -vE '^\\./|@[0-9a-f]{40}$' || \
+  echo "No obviously unpinned third-party actions found"
+```
+
+**Public repo best-practice checks:**
+
+- `HIGH`: Private vulnerability reporting enabled
+- `HIGH`: Secret scanning and push protection enabled
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled on the default branch
+- `MEDIUM`: `SECURITY.md`, `LICENSE`, README, description, and topics are present
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: CODEOWNERS and PR templates exist for maintainability
+- `MEDIUM`: Third-party GitHub Actions are pinned to full commit SHAs or justified
+
+**Private repo best-practice checks:**
+
+- `HIGH`: Secret scanning and push protection enabled where the plan supports it
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled where GitHub Advanced Security or equivalent tooling is available
+- `HIGH`: Outside collaborators are reviewed and least-privilege
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: Actions default workflow permissions are read-only unless write is justified
+- `MEDIUM`: Stale secrets are rotated and unused secrets are removed
+- `MEDIUM`: CODEOWNERS, PR templates, and issue templates exist where useful for the team
+
+---
+
 ## Generate Health Report
 
 After running all checks, present findings in this structure:
@@ -436,12 +674,27 @@ After running all checks, present findings in this structure:
 
 ---
 ### Security  ✅/⚠️/❌
+- Security policy: present / missing (MEDIUM)
+- Security advisories: accessible / unavailable; open advisories listed (HIGH)
+- Private vulnerability reporting: enabled / missing / not applicable for private repos (HIGH for public repos only)
 - GitHub Code Quality: enabled / NOT DETECTED ⚠️
+- Code Quality findings: N open/listed or unavailable
 - Dependabot alerts: N open (X critical, Y high)
+- Dependabot malware alerts: N open/listed
+- Dependabot vulnerability alerts: N open/listed
 - Code scanning (CodeQL): enabled/NOT ENABLED
-- Secret scanning: N open alerts
+- Code scanning alerts: N open/listed
+- Secret scanning: N open alerts/listed
 - Snyk: configured / NOT CONFIGURED ⚠️
 - Branch protection on main: summary of rules
+
+---
+### GitHub Best Practices
+- Public/private repo checks: list missing high/medium controls
+- Actions permissions: read-only / write / unavailable
+- Rulesets or branch protection: configured / missing
+- Outside collaborators: N or unavailable
+- Unpinned third-party Actions: list or "none found"
 
 ---
 ### Code Coverage  ✅/⚠️

--- a/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
@@ -3,16 +3,19 @@ name: github-health-check
 description: >
   Run a comprehensive GitHub repository health check. Use this skill whenever
   the user asks to: check GitHub health, audit the repo, check CI status,
-  review open PRs, merge Dependabot PRs, check code coverage, check security
-  alerts, check Snyk integration, keep GitHub in good shape, or any variation
-  of "how is the repo doing". Also trigger for: "check dependabot PRs",
-  "any PRs to merge", "check branch status", "repo health", "GitHub status
-  check", "what needs attention in GitHub", "tidy up GitHub".
+  review open PRs, merge Dependabot PRs, check code coverage, check GitHub
+  Code Quality, check GitHub security feature enablement, check security
+  advisories, check Dependabot alerts, check code scanning alerts, check secret
+  scanning alerts, check Snyk integration, keep GitHub in good shape, or any
+  variation of "how is the repo doing". Also trigger for:
+  "check dependabot PRs", "any PRs to merge", "check branch status", "repo
+  health", "GitHub status check", "what needs attention in GitHub", "tidy up
+  GitHub".
 ---
 
 # GitHub Repository Health Check Skill
 
-Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs.
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether required GitHub security and code quality features are enabled.
 
 ---
 
@@ -135,7 +138,7 @@ For each Dependabot PR returned, apply this decision logic:
 2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
 
    ```bash
-   gh pr checks <PR_NUMBER> --json name,state,conclusion
+   gh pr checks <PR_NUMBER> --json name,state,bucket,workflow
    ```
 
 3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
@@ -179,10 +182,173 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 
 ---
 
-## Check 5 — Security Alerts
+## Check 5 — GitHub Code Quality
 
 ```bash
-# Count open Dependabot security alerts
+# Try the direct repo feature status first. GitHub may not expose this field
+# yet for all plans / repos / API versions, so treat missing data as inconclusive.
+if code_quality_status="$(gh api "/repos/${OWNER}/${NAME}" \
+  --jq '.security_and_analysis.code_quality.status // "not_exposed"' 2>/dev/null)" \
+  && [ -n "$code_quality_status" ]; then
+  echo "Code Quality API status: $code_quality_status"
+else
+  echo "Code Quality API status: unavailable"
+fi
+
+# Look for the dynamic workflow GitHub creates when Code Quality is enabled.
+gh run list --workflow "Code Quality" --limit 10 \
+  --json status,conclusion,createdAt,url \
+  --jq '.[] | {status, conclusion, createdAt, url}' 2>/dev/null || true
+
+# Look for repository comments from the Code Quality bot on pull requests.
+gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-code-quality[bot]") |
+    {createdAt: .created_at, url: .html_url}' 2>/dev/null || true
+```
+
+**Interpret results:**
+
+- If `security_and_analysis.code_quality.status` is `enabled`: report GitHub Code Quality as enabled
+- If the direct field is not exposed, infer likely enabled when recent `Code Quality` workflow runs or `github-code-quality[bot]` comments exist
+- If neither the direct field nor fallback signals are present: report Code Quality as not detected and recommend verifying `Settings` → `Security` → `Code quality`
+- Note that GitHub Code Quality is currently in public preview and its API surface may be incomplete or absent for some repositories
+
+### Code Quality Findings
+
+```bash
+# List recent Code Quality check runs and annotations when exposed through Checks.
+HEAD_SHA=$(gh api "/repos/${OWNER}/${NAME}/commits/${DEFAULT_BRANCH}" --jq '.sha' 2>/dev/null || git rev-parse HEAD)
+gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) |
+    {id, name, status, conclusion, url: .html_url}' 2>/dev/null || true
+
+for check_id in $(gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) | .id' 2>/dev/null); do
+  gh api "/repos/${OWNER}/${NAME}/check-runs/${check_id}/annotations?per_page=100" \
+    --jq '.[] | {
+      level: .annotation_level,
+      path,
+      start_line,
+      end_line,
+      title,
+      message,
+      raw_details
+    }' 2>/dev/null || true
+done
+
+# Fallback: list recent Code Quality bot comments on PRs.
+gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-code-quality[bot]") |
+    {createdAt: .created_at, issueUrl: .issue_url, body: (.body | split("\n") | .[0:6] | join("\n")), url: .html_url}' 2>/dev/null || true
+```
+
+**Interpret results:**
+
+- List every exposed Code Quality finding with level, file, line, title/message, and URL
+- If only bot comments are available, summarize the referenced PR and include the comment URL
+- If findings cannot be listed because GitHub does not expose the data, report the feature status separately from findings visibility
+
+---
+
+## Check 6 — GitHub Security Feature Enablement
+
+Check whether required repository security features are enabled and assign the requested priority when they are missing.
+
+```bash
+# Repo visibility and security/security-and-analysis settings.
+gh repo view --json isPrivate,visibility,nameWithOwner \
+  --jq '"Repo: \(.nameWithOwner)\nVisibility: \(.visibility)\nPrivate: \(.isPrivate)"'
+
+IS_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate')
+
+gh api "/repos/${OWNER}/${NAME}" \
+  --jq '.security_and_analysis // {}' 2>/dev/null || \
+  echo "Security and analysis settings unavailable (check permissions or plan)"
+
+# Security policy: SECURITY.md in repo, .github profile, or community profile metadata.
+if [ -f SECURITY.md ] || [ -f .github/SECURITY.md ]; then
+  echo "Security policy file present locally"
+else
+  echo "Security policy file not found locally"
+fi
+gh api "/repos/${OWNER}/${NAME}/community/profile" \
+  --jq '.files.security_policy | if . then {state: "present", path: .path, url: .html_url} else {state: "missing"} end' 2>/dev/null || true
+
+# Repository security advisories capability and current advisories.
+gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
+  --jq '{accessible: true, total: length, advisories: [.[] | {ghsa_id, severity, state, summary, url: .html_url}]}' 2>/dev/null || \
+  echo "Security advisories API unavailable (may require admin/security manager access)"
+
+# Private vulnerability reporting is expected only for public repos.
+if [ "$IS_PRIVATE" = "false" ]; then
+  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
+    --jq '{enabled}' 2>/dev/null || \
+    echo "Private vulnerability reporting status unavailable"
+else
+  echo "Private vulnerability reporting: not required for private repositories"
+fi
+```
+
+**Required enablement priorities:**
+
+- `HIGH`: Security advisories must be available for maintainers/security managers and open advisories must be listed
+- `HIGH`: Private vulnerability reporting must be enabled for public repositories only
+- `HIGH`: Dependabot alerts must be enabled and queryable
+- `HIGH`: Code scanning alerts must be enabled and queryable
+- `HIGH`: Secret scanning alerts must be enabled and queryable
+- `MEDIUM`: A security policy must exist and be discoverable through `SECURITY.md` or GitHub community profile metadata
+- `MEDIUM`: GitHub Code Quality should be enabled or verified manually when the API does not expose its status
+
+**Interpret results:**
+
+- Missing `HIGH` controls go in Recommended Actions as `HIGH`
+- Missing `MEDIUM` controls go in Recommended Actions as `MEDIUM`
+- For public repos, treat missing private vulnerability reporting as `HIGH`; for private repos, report it as not applicable
+- When an API returns 403/404, distinguish "not enabled" from "not enough permission" whenever the response makes that clear
+
+---
+
+## Check 7 — Security Alerts and Findings
+
+```bash
+# Dependabot alerts: list malware separately from vulnerabilities.
+echo "--- Dependabot malware alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select(((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+echo "--- Dependabot vulnerability alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select((((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) | not) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      vulnerable_range: .security_vulnerability.vulnerable_version_range,
+      patched_versions: .security_vulnerability.first_patched_version.identifier,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+# Count open Dependabot security alerts.
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
   echo "Could not fetch Dependabot alert count (check repo permissions)"
@@ -191,27 +357,52 @@ gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
   --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
 
-# Code scanning alerts (SAST / CodeQL)
+# Code scanning alerts (SAST / CodeQL): list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
   echo "Code scanning: not enabled or no access"
 
-# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    severity: (.rule.security_severity_level // .rule.severity // "unknown"),
+    tool: .tool.name,
+    rule: .rule.id,
+    description: .rule.description,
+    path: .most_recent_instance.location.path,
+    start_line: .most_recent_instance.location.start_line,
+    state,
+    url: .html_url
+  }' 2>/dev/null || true
+
+# Secret scanning alerts: list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
   echo "Secret scanning: not enabled or no access"
+
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    secret_type,
+    secret_type_display_name,
+    state,
+    resolution,
+    created_at,
+    url: .html_url
+  }' 2>/dev/null || true
 ```
 
 **Interpret results:**
 
-- Open Dependabot security alerts > 0: list them with severity (critical/high first)
-- Code scanning alerts: show count and any critical/high items
-- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
-- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+- Open Dependabot malware alerts > 0: list them separately and prioritize as `CRITICAL`
+- Open Dependabot vulnerability alerts > 0: list them with severity, package, ecosystem, manifest, patched version, and URL
+- Code scanning alerts: list every open alert with severity, rule, file, line, and URL; critical/high items are `HIGH`
+- Secret scanning alerts > 0: list every open alert and flag as `CRITICAL` because leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL or another code scanning tool in GitHub security settings
 
 ---
 
-## Check 6 — Snyk Integration
+## Check 8 — Snyk Integration
 
 ```bash
 # Check for .snyk policy file
@@ -234,7 +425,7 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 
 ---
 
-## Check 7 — Branch Protection Rules
+## Check 9 — Branch Protection Rules
 
 ```bash
 # Check protection rules on the default branch
@@ -270,7 +461,7 @@ except Exception as e: print('Could not parse:', e)
 
 ---
 
-## Check 8 — Stale Branches
+## Check 10 — Stale Branches
 
 ```bash
 # List remote branches not merged to default branch, sorted by last commit date
@@ -299,7 +490,7 @@ echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
 
 ---
 
-## Check 9 — Repository Housekeeping
+## Check 11 — Repository Housekeeping
 
 ```bash
 # Check for essential files
@@ -322,7 +513,7 @@ gh repo view --json description,repositoryTopics \
 
 ---
 
-## Check 10 — Workflow Health Patterns
+## Check 12 — Workflow Health Patterns
 
 ```bash
 # Detect consistently failing workflows (>50% failure rate over recent runs)
@@ -333,12 +524,12 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
     runs: length,
     failures: map(select(.conclusion == "failure")) | length
   } | select(.runs >= 3) |
-  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " CONSISTENTLY FAILING" else "" end)"'
 ```
 
 ---
 
-## Check 11 — Release & Tag Health
+## Check 13 — Release & Tag Health
 
 ```bash
 # List recent releases
@@ -352,7 +543,7 @@ DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | le
 
 ---
 
-## Check 12 — Actions Permissions & Secrets Health
+## Check 14 — Actions Permissions & Secrets Health
 
 ```bash
 # Check default workflow permissions
@@ -385,6 +576,76 @@ except: pass
 
 ---
 
+## Check 15 — Public and Private Repository Best Practices
+
+Run these additional checks after determining repo visibility.
+
+```bash
+# Repository settings that affect public/private repo hygiene.
+gh repo view --json \
+  nameWithOwner,visibility,isPrivate,isArchived,hasIssuesEnabled,hasProjectsEnabled,hasWikiEnabled,description,homepageUrl,repositoryTopics,licenseInfo,defaultBranchRef \
+  --jq '{
+    repo: .nameWithOwner,
+    visibility,
+    isPrivate,
+    archived: .isArchived,
+    issues: .hasIssuesEnabled,
+    projects: .hasProjectsEnabled,
+    wiki: .hasWikiEnabled,
+    description,
+    homepage: .homepageUrl,
+    topics: [.repositoryTopics.nodes[].topic.name],
+    license: .licenseInfo.spdxId,
+    defaultBranch: .defaultBranchRef.name
+  }'
+
+# Rulesets can supplement or replace classic branch protection.
+gh api "/repos/${OWNER}/${NAME}/rulesets?per_page=100" \
+  --jq '.[] | {name, target, enforcement, conditions, rules: [.rules[].type]}' 2>/dev/null || \
+  echo "Rulesets unavailable or not configured"
+
+# Collaborators and external access. Requires admin permissions on many repos.
+gh api "/repos/${OWNER}/${NAME}/collaborators?affiliation=outside&per_page=100" \
+  --jq '.[] | {login, permissions}' 2>/dev/null || \
+  echo "Outside collaborators unavailable (check permissions) or none found"
+
+# Pull request templates and issue templates.
+for f in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md; do
+  [ -f "$f" ] && echo "OK: $f" || true
+done
+[ -d .github/ISSUE_TEMPLATE ] && find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print || echo "No issue templates found"
+
+# GitHub Actions supply-chain hygiene: flag unpinned third-party actions.
+grep -RhoE 'uses: +[^ ]+' .github/workflows 2>/dev/null | \
+  sed 's/uses: *//' | \
+  grep -vE '^\\./|@[0-9a-f]{40}$' || \
+  echo "No obviously unpinned third-party actions found"
+```
+
+**Public repo best-practice checks:**
+
+- `HIGH`: Private vulnerability reporting enabled
+- `HIGH`: Secret scanning and push protection enabled
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled on the default branch
+- `MEDIUM`: `SECURITY.md`, `LICENSE`, README, description, and topics are present
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: CODEOWNERS and PR templates exist for maintainability
+- `MEDIUM`: Third-party GitHub Actions are pinned to full commit SHAs or justified
+
+**Private repo best-practice checks:**
+
+- `HIGH`: Secret scanning and push protection enabled where the plan supports it
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled where GitHub Advanced Security or equivalent tooling is available
+- `HIGH`: Outside collaborators are reviewed and least-privilege
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: Actions default workflow permissions are read-only unless write is justified
+- `MEDIUM`: Stale secrets are rotated and unused secrets are removed
+- `MEDIUM`: CODEOWNERS, PR templates, and issue templates exist where useful for the team
+
+---
+
 ## Generate Health Report
 
 After running all checks, present findings in this structure:
@@ -413,11 +674,27 @@ After running all checks, present findings in this structure:
 
 ---
 ### Security  ✅/⚠️/❌
+- Security policy: present / missing (MEDIUM)
+- Security advisories: accessible / unavailable; open advisories listed (HIGH)
+- Private vulnerability reporting: enabled / missing / not applicable for private repos (HIGH for public repos only)
+- GitHub Code Quality: enabled / NOT DETECTED ⚠️
+- Code Quality findings: N open/listed or unavailable
 - Dependabot alerts: N open (X critical, Y high)
+- Dependabot malware alerts: N open/listed
+- Dependabot vulnerability alerts: N open/listed
 - Code scanning (CodeQL): enabled/NOT ENABLED
-- Secret scanning: N open alerts
+- Code scanning alerts: N open/listed
+- Secret scanning: N open alerts/listed
 - Snyk: configured / NOT CONFIGURED ⚠️
 - Branch protection on main: summary of rules
+
+---
+### GitHub Best Practices
+- Public/private repo checks: list missing high/medium controls
+- Actions permissions: read-only / write / unavailable
+- Rulesets or branch protection: configured / missing
+- Outside collaborators: N or unavailable
+- Unpinned third-party Actions: list or "none found"
 
 ---
 ### Code Coverage  ✅/⚠️

--- a/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
+++ b/packages/ballast-typescript/skills/common/github-health-check/SKILL.md
@@ -281,9 +281,22 @@ gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
 
 # Private vulnerability reporting is expected only for public repos.
 if [ "$IS_PRIVATE" = "false" ]; then
-  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
-    --jq '{enabled}' 2>/dev/null || \
-    echo "Private vulnerability reporting status unavailable"
+  PVR_RESPONSE=$(gh api --include "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" 2>&1 || true)
+  PVR_STATUS=$(printf '%s\n' "$PVR_RESPONSE" | sed -n 's/^HTTP\/[0-9.]* \([0-9][0-9][0-9]\).*/\1/p' | tail -n 1)
+  case "$PVR_STATUS" in
+    200|204)
+      echo '{"enabled": true}'
+      ;;
+    404)
+      echo '{"enabled": false}'
+      ;;
+    403)
+      echo "Private vulnerability reporting status unavailable (permission denied)"
+      ;;
+    *)
+      echo "Private vulnerability reporting status unavailable"
+      ;;
+  esac
 else
   echo "Private vulnerability reporting: not required for private repositories"
 fi

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -207,6 +207,16 @@ describe('build', () => {
       const content = getSkillContent('github-health-check');
       expect(content).toContain('name: github-health-check');
       expect(content).toContain('# GitHub Repository Health Check Skill');
+      expect(content).toContain(
+        '## Check 6 — GitHub Security Feature Enablement'
+      );
+      expect(content).toContain(
+        '`HIGH`: Private vulnerability reporting must be enabled for public repositories only'
+      );
+      expect(content).toContain('--- Dependabot malware alerts ---');
+      expect(content).toContain(
+        '## Check 15 — Public and Private Repository Best Practices'
+      );
     });
 
     test('builds cursor skill format', () => {

--- a/skills/common/github-health-check/SKILL.md
+++ b/skills/common/github-health-check/SKILL.md
@@ -281,9 +281,22 @@ gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
 
 # Private vulnerability reporting is expected only for public repos.
 if [ "$IS_PRIVATE" = "false" ]; then
-  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
-    --jq '{enabled}' 2>/dev/null || \
-    echo "Private vulnerability reporting status unavailable"
+  PVR_RESPONSE=$(gh api --include "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" 2>&1 || true)
+  PVR_STATUS=$(printf '%s\n' "$PVR_RESPONSE" | sed -n 's/^HTTP\/[0-9.]* \([0-9][0-9][0-9]\).*/\1/p' | tail -n 1)
+  case "$PVR_STATUS" in
+    200|204)
+      echo '{"enabled": true}'
+      ;;
+    404)
+      echo '{"enabled": false}'
+      ;;
+    403)
+      echo "Private vulnerability reporting status unavailable (permission denied)"
+      ;;
+    *)
+      echo "Private vulnerability reporting status unavailable"
+      ;;
+  esac
 else
   echo "Private vulnerability reporting: not required for private repositories"
 fi

--- a/skills/common/github-health-check/SKILL.md
+++ b/skills/common/github-health-check/SKILL.md
@@ -4,8 +4,10 @@ description: >
   Run a comprehensive GitHub repository health check. Use this skill whenever
   the user asks to: check GitHub health, audit the repo, check CI status,
   review open PRs, merge Dependabot PRs, check code coverage, check GitHub
-  Code Quality, check security alerts, check Snyk integration, keep GitHub in
-  good shape, or any variation of "how is the repo doing". Also trigger for:
+  Code Quality, check GitHub security feature enablement, check security
+  advisories, check Dependabot alerts, check code scanning alerts, check secret
+  scanning alerts, check Snyk integration, keep GitHub in good shape, or any
+  variation of "how is the repo doing". Also trigger for:
   "check dependabot PRs", "any PRs to merge", "check branch status", "repo
   health", "GitHub status check", "what needs attention in GitHub", "tidy up
   GitHub".
@@ -13,7 +15,7 @@ description: >
 
 # GitHub Repository Health Check Skill
 
-Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether GitHub Code Quality is enabled.
+Runs a comprehensive health audit of the current GitHub repository using the `gh` CLI. Produces a structured report with status indicators and actionable items. Auto-merges safe Dependabot PRs and checks whether required GitHub security and code quality features are enabled.
 
 ---
 
@@ -46,6 +48,7 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
 ```
 
 **Interpret results:**
+
 - Group runs by workflow name; show the latest run per workflow
 - Flag any workflow whose latest run concluded with `failure` or `cancelled`
 - Flag workflows that haven't run in more than 14 days
@@ -82,6 +85,7 @@ gh release list --limit 1 --json tagName,publishedAt \
 ```
 
 **Interpret results:**
+
 - If commits ahead > 20: warn that a release may be overdue
 - If last release was more than 30 days ago: note it
 - If no releases exist: note that versioned releases are not configured
@@ -110,6 +114,7 @@ gh pr list --state open --json number,title,author,isDraft,createdAt,labels,head
 ```
 
 **Report:**
+
 - Total open PRs, draft vs ready
 - PRs older than 7 days without activity (stale)
 - PRs with failing checks
@@ -131,6 +136,7 @@ For each Dependabot PR returned, apply this decision logic:
    - If only minor/patch changes → candidate for auto-merge
 
 2. **Check CI status**: all checks must be `SUCCESS` (no failures, no pending)
+
    ```bash
    gh pr checks <PR_NUMBER> --json name,state,bucket,workflow
    ```
@@ -138,6 +144,7 @@ For each Dependabot PR returned, apply this decision logic:
 3. **Verify not a draft** and **mergeable** state is not `CONFLICTING`
 
 4. **Auto-merge if all conditions pass** (no confirmation needed):
+
    ```bash
    gh pr merge <PR_NUMBER> --squash --auto
    ```
@@ -145,6 +152,7 @@ For each Dependabot PR returned, apply this decision logic:
 5. **Report each decision**: merged / skipped (major) / skipped (CI failing) / skipped (conflicts)
 
 **Example major version detection:**
+
 - "Bump eslint from 8.57.0 to 9.0.0" → major (8→9) → SKIP
 - "Bump typescript from 5.3.3 to 5.4.0" → minor → merge
 - "Bump lodash from 4.17.20 to 4.17.21" → patch → merge
@@ -168,6 +176,7 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no codecov config AND no codecov in workflows AND no badge: **WARN** — Codecov does not appear to be configured. Recommend adding the `codecov/codecov-action` to CI workflows.
 - If present: confirm coverage reporting is active
 
@@ -198,17 +207,148 @@ gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
 ```
 
 **Interpret results:**
+
 - If `security_and_analysis.code_quality.status` is `enabled`: report GitHub Code Quality as enabled
 - If the direct field is not exposed, infer likely enabled when recent `Code Quality` workflow runs or `github-code-quality[bot]` comments exist
 - If neither the direct field nor fallback signals are present: report Code Quality as not detected and recommend verifying `Settings` → `Security` → `Code quality`
 - Note that GitHub Code Quality is currently in public preview and its API surface may be incomplete or absent for some repositories
 
----
-
-## Check 6 — Security Alerts
+### Code Quality Findings
 
 ```bash
-# Count open Dependabot security alerts
+# List recent Code Quality check runs and annotations when exposed through Checks.
+HEAD_SHA=$(gh api "/repos/${OWNER}/${NAME}/commits/${DEFAULT_BRANCH}" --jq '.sha' 2>/dev/null || git rev-parse HEAD)
+gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) |
+    {id, name, status, conclusion, url: .html_url}' 2>/dev/null || true
+
+for check_id in $(gh api "/repos/${OWNER}/${NAME}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+  --jq '.check_runs[] | select((.name | ascii_downcase | contains("code quality")) or (.app.slug == "github-code-quality")) | .id' 2>/dev/null); do
+  gh api "/repos/${OWNER}/${NAME}/check-runs/${check_id}/annotations?per_page=100" \
+    --jq '.[] | {
+      level: .annotation_level,
+      path,
+      start_line,
+      end_line,
+      title,
+      message,
+      raw_details
+    }' 2>/dev/null || true
+done
+
+# Fallback: list recent Code Quality bot comments on PRs.
+gh api "/repos/${OWNER}/${NAME}/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "github-code-quality[bot]") |
+    {createdAt: .created_at, issueUrl: .issue_url, body: (.body | split("\n") | .[0:6] | join("\n")), url: .html_url}' 2>/dev/null || true
+```
+
+**Interpret results:**
+
+- List every exposed Code Quality finding with level, file, line, title/message, and URL
+- If only bot comments are available, summarize the referenced PR and include the comment URL
+- If findings cannot be listed because GitHub does not expose the data, report the feature status separately from findings visibility
+
+---
+
+## Check 6 — GitHub Security Feature Enablement
+
+Check whether required repository security features are enabled and assign the requested priority when they are missing.
+
+```bash
+# Repo visibility and security/security-and-analysis settings.
+gh repo view --json isPrivate,visibility,nameWithOwner \
+  --jq '"Repo: \(.nameWithOwner)\nVisibility: \(.visibility)\nPrivate: \(.isPrivate)"'
+
+IS_PRIVATE=$(gh repo view --json isPrivate --jq '.isPrivate')
+
+gh api "/repos/${OWNER}/${NAME}" \
+  --jq '.security_and_analysis // {}' 2>/dev/null || \
+  echo "Security and analysis settings unavailable (check permissions or plan)"
+
+# Security policy: SECURITY.md in repo, .github profile, or community profile metadata.
+if [ -f SECURITY.md ] || [ -f .github/SECURITY.md ]; then
+  echo "Security policy file present locally"
+else
+  echo "Security policy file not found locally"
+fi
+gh api "/repos/${OWNER}/${NAME}/community/profile" \
+  --jq '.files.security_policy | if . then {state: "present", path: .path, url: .html_url} else {state: "missing"} end' 2>/dev/null || true
+
+# Repository security advisories capability and current advisories.
+gh api "/repos/${OWNER}/${NAME}/security-advisories?per_page=100" \
+  --jq '{accessible: true, total: length, advisories: [.[] | {ghsa_id, severity, state, summary, url: .html_url}]}' 2>/dev/null || \
+  echo "Security advisories API unavailable (may require admin/security manager access)"
+
+# Private vulnerability reporting is expected only for public repos.
+if [ "$IS_PRIVATE" = "false" ]; then
+  gh api "/repos/${OWNER}/${NAME}/private-vulnerability-reporting" \
+    --jq '{enabled}' 2>/dev/null || \
+    echo "Private vulnerability reporting status unavailable"
+else
+  echo "Private vulnerability reporting: not required for private repositories"
+fi
+```
+
+**Required enablement priorities:**
+
+- `HIGH`: Security advisories must be available for maintainers/security managers and open advisories must be listed
+- `HIGH`: Private vulnerability reporting must be enabled for public repositories only
+- `HIGH`: Dependabot alerts must be enabled and queryable
+- `HIGH`: Code scanning alerts must be enabled and queryable
+- `HIGH`: Secret scanning alerts must be enabled and queryable
+- `MEDIUM`: A security policy must exist and be discoverable through `SECURITY.md` or GitHub community profile metadata
+- `MEDIUM`: GitHub Code Quality should be enabled or verified manually when the API does not expose its status
+
+**Interpret results:**
+
+- Missing `HIGH` controls go in Recommended Actions as `HIGH`
+- Missing `MEDIUM` controls go in Recommended Actions as `MEDIUM`
+- For public repos, treat missing private vulnerability reporting as `HIGH`; for private repos, report it as not applicable
+- When an API returns 403/404, distinguish "not enabled" from "not enough permission" whenever the response makes that clear
+
+---
+
+## Check 7 — Security Alerts and Findings
+
+```bash
+# Dependabot alerts: list malware separately from vulnerabilities.
+echo "--- Dependabot malware alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select(((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+echo "--- Dependabot vulnerability alerts ---"
+gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
+  --jq '.[] |
+    select((((.security_advisory.cwes // []) | map(.cwe_id) | join(" ") | ascii_downcase | contains("malware")) or
+      (.security_advisory.summary | ascii_downcase | contains("malware")) or
+      (.security_advisory.description // "" | ascii_downcase | contains("malware"))) | not) |
+    {
+      number,
+      severity: .security_advisory.severity,
+      package: .dependency.package.name,
+      ecosystem: .dependency.package.ecosystem,
+      manifest: .dependency.manifest_path,
+      vulnerable_range: .security_vulnerability.vulnerable_version_range,
+      patched_versions: .security_vulnerability.first_patched_version.identifier,
+      summary: .security_advisory.summary,
+      ghsa_id: .security_advisory.ghsa_id,
+      url: .html_url
+    }' 2>/dev/null || true
+
+# Count open Dependabot security alerts.
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open Dependabot alerts: {}" || \
   echo "Could not fetch Dependabot alert count (check repo permissions)"
@@ -217,26 +357,52 @@ gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&per_page=100" \
 gh api "/repos/${OWNER}/${NAME}/dependabot/alerts?state=open&sort=severity&direction=desc&per_page=10" \
   --jq '.[] | "[\(.security_advisory.severity | ascii_upcase)] \(.security_advisory.summary) — \(.dependency.package.name)"' 2>/dev/null || true
 
-# Code scanning alerts (SAST / CodeQL)
+# Code scanning alerts (SAST / CodeQL): list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open code scanning alerts: {}" || \
   echo "Code scanning: not enabled or no access"
 
-# Secret scanning alerts
+gh api "/repos/${OWNER}/${NAME}/code-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    severity: (.rule.security_severity_level // .rule.severity // "unknown"),
+    tool: .tool.name,
+    rule: .rule.id,
+    description: .rule.description,
+    path: .most_recent_instance.location.path,
+    start_line: .most_recent_instance.location.start_line,
+    state,
+    url: .html_url
+  }' 2>/dev/null || true
+
+# Secret scanning alerts: list all open alerts.
 gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
   --jq 'length' 2>/dev/null | xargs -I{} echo "Open secret scanning alerts: {}" || \
   echo "Secret scanning: not enabled or no access"
+
+gh api "/repos/${OWNER}/${NAME}/secret-scanning/alerts?state=open&per_page=100" \
+  --jq '.[] | {
+    number,
+    secret_type,
+    secret_type_display_name,
+    state,
+    resolution,
+    created_at,
+    url: .html_url
+  }' 2>/dev/null || true
 ```
 
 **Interpret results:**
-- Open Dependabot security alerts > 0: list them with severity (critical/high first)
-- Code scanning alerts: show count and any critical/high items
-- Secret scanning alerts > 0: flag as **CRITICAL** — leaked secrets need immediate rotation
-- If code scanning is not enabled: recommend enabling CodeQL in GitHub Advanced Security
+
+- Open Dependabot malware alerts > 0: list them separately and prioritize as `CRITICAL`
+- Open Dependabot vulnerability alerts > 0: list them with severity, package, ecosystem, manifest, patched version, and URL
+- Code scanning alerts: list every open alert with severity, rule, file, line, and URL; critical/high items are `HIGH`
+- Secret scanning alerts > 0: list every open alert and flag as `CRITICAL` because leaked secrets need immediate rotation
+- If code scanning is not enabled: recommend enabling CodeQL or another code scanning tool in GitHub security settings
 
 ---
 
-## Check 7 — Snyk Integration
+## Check 8 — Snyk Integration
 
 ```bash
 # Check for .snyk policy file
@@ -253,12 +419,13 @@ gh api "/repos/${OWNER}/${NAME}/actions/secrets" --jq '.secrets[].name' 2>/dev/n
 ```
 
 **Interpret results:**
+
 - If no `.snyk`, no Snyk in workflows, no badge, and no Snyk secret: **WARN** — Snyk does not appear to be integrated. Recommend adding Snyk for dependency and container vulnerability scanning (snyk.io).
 - If partially configured: note what's present and what's missing
 
 ---
 
-## Check 8 — Branch Protection Rules
+## Check 9 — Branch Protection Rules
 
 ```bash
 # Check protection rules on the default branch
@@ -286,6 +453,7 @@ except Exception as e: print('Could not parse:', e)
 ```
 
 **Flag missing protections:**
+
 - No required PR reviews: warn
 - No required status checks: warn
 - Force pushes allowed on main: warn
@@ -293,7 +461,7 @@ except Exception as e: print('Could not parse:', e)
 
 ---
 
-## Check 9 — Stale Branches
+## Check 10 — Stale Branches
 
 ```bash
 # List remote branches not merged to default branch, sorted by last commit date
@@ -322,7 +490,7 @@ echo "Stale branches (30+ days, unmerged): $STALE_COUNT"
 
 ---
 
-## Check 10 — Repository Housekeeping
+## Check 11 — Repository Housekeeping
 
 ```bash
 # Check for essential files
@@ -345,7 +513,7 @@ gh repo view --json description,repositoryTopics \
 
 ---
 
-## Check 11 — Workflow Health Patterns
+## Check 12 — Workflow Health Patterns
 
 ```bash
 # Detect consistently failing workflows (>50% failure rate over recent runs)
@@ -356,12 +524,12 @@ gh run list --branch "$DEFAULT_BRANCH" --limit 50 \
     runs: length,
     failures: map(select(.conclusion == "failure")) | length
   } | select(.runs >= 3) |
-  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " ⚠️ CONSISTENTLY FAILING" else "" end)"'
+  "\(.workflow): \(.failures)/\(.runs) recent runs failed\(if (.failures / .runs) > 0.5 then " CONSISTENTLY FAILING" else "" end)"'
 ```
 
 ---
 
-## Check 12 — Release & Tag Health
+## Check 13 — Release & Tag Health
 
 ```bash
 # List recent releases
@@ -375,7 +543,7 @@ DRAFT_COUNT=$(gh release list --json isDraft --jq '[.[] | select(.isDraft)] | le
 
 ---
 
-## Check 13 — Actions Permissions & Secrets Health
+## Check 14 — Actions Permissions & Secrets Health
 
 ```bash
 # Check default workflow permissions
@@ -408,6 +576,76 @@ except: pass
 
 ---
 
+## Check 15 — Public and Private Repository Best Practices
+
+Run these additional checks after determining repo visibility.
+
+```bash
+# Repository settings that affect public/private repo hygiene.
+gh repo view --json \
+  nameWithOwner,visibility,isPrivate,isArchived,hasIssuesEnabled,hasProjectsEnabled,hasWikiEnabled,description,homepageUrl,repositoryTopics,licenseInfo,defaultBranchRef \
+  --jq '{
+    repo: .nameWithOwner,
+    visibility,
+    isPrivate,
+    archived: .isArchived,
+    issues: .hasIssuesEnabled,
+    projects: .hasProjectsEnabled,
+    wiki: .hasWikiEnabled,
+    description,
+    homepage: .homepageUrl,
+    topics: [.repositoryTopics.nodes[].topic.name],
+    license: .licenseInfo.spdxId,
+    defaultBranch: .defaultBranchRef.name
+  }'
+
+# Rulesets can supplement or replace classic branch protection.
+gh api "/repos/${OWNER}/${NAME}/rulesets?per_page=100" \
+  --jq '.[] | {name, target, enforcement, conditions, rules: [.rules[].type]}' 2>/dev/null || \
+  echo "Rulesets unavailable or not configured"
+
+# Collaborators and external access. Requires admin permissions on many repos.
+gh api "/repos/${OWNER}/${NAME}/collaborators?affiliation=outside&per_page=100" \
+  --jq '.[] | {login, permissions}' 2>/dev/null || \
+  echo "Outside collaborators unavailable (check permissions) or none found"
+
+# Pull request templates and issue templates.
+for f in .github/pull_request_template.md .github/PULL_REQUEST_TEMPLATE.md; do
+  [ -f "$f" ] && echo "OK: $f" || true
+done
+[ -d .github/ISSUE_TEMPLATE ] && find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print || echo "No issue templates found"
+
+# GitHub Actions supply-chain hygiene: flag unpinned third-party actions.
+grep -RhoE 'uses: +[^ ]+' .github/workflows 2>/dev/null | \
+  sed 's/uses: *//' | \
+  grep -vE '^\\./|@[0-9a-f]{40}$' || \
+  echo "No obviously unpinned third-party actions found"
+```
+
+**Public repo best-practice checks:**
+
+- `HIGH`: Private vulnerability reporting enabled
+- `HIGH`: Secret scanning and push protection enabled
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled on the default branch
+- `MEDIUM`: `SECURITY.md`, `LICENSE`, README, description, and topics are present
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: CODEOWNERS and PR templates exist for maintainability
+- `MEDIUM`: Third-party GitHub Actions are pinned to full commit SHAs or justified
+
+**Private repo best-practice checks:**
+
+- `HIGH`: Secret scanning and push protection enabled where the plan supports it
+- `HIGH`: Dependabot alerts and security updates enabled
+- `HIGH`: Code scanning enabled where GitHub Advanced Security or equivalent tooling is available
+- `HIGH`: Outside collaborators are reviewed and least-privilege
+- `MEDIUM`: Branch protection or rulesets require reviews and status checks before merge
+- `MEDIUM`: Actions default workflow permissions are read-only unless write is justified
+- `MEDIUM`: Stale secrets are rotated and unused secrets are removed
+- `MEDIUM`: CODEOWNERS, PR templates, and issue templates exist where useful for the team
+
+---
+
 ## Generate Health Report
 
 After running all checks, present findings in this structure:
@@ -436,12 +674,27 @@ After running all checks, present findings in this structure:
 
 ---
 ### Security  ✅/⚠️/❌
+- Security policy: present / missing (MEDIUM)
+- Security advisories: accessible / unavailable; open advisories listed (HIGH)
+- Private vulnerability reporting: enabled / missing / not applicable for private repos (HIGH for public repos only)
 - GitHub Code Quality: enabled / NOT DETECTED ⚠️
+- Code Quality findings: N open/listed or unavailable
 - Dependabot alerts: N open (X critical, Y high)
+- Dependabot malware alerts: N open/listed
+- Dependabot vulnerability alerts: N open/listed
 - Code scanning (CodeQL): enabled/NOT ENABLED
-- Secret scanning: N open alerts
+- Code scanning alerts: N open/listed
+- Secret scanning: N open alerts/listed
 - Snyk: configured / NOT CONFIGURED ⚠️
 - Branch protection on main: summary of rules
+
+---
+### GitHub Best Practices
+- Public/private repo checks: list missing high/medium controls
+- Actions permissions: read-only / write / unavailable
+- Rulesets or branch protection: configured / missing
+- Outside collaborators: N or unavailable
+- Unpinned third-party Actions: list or "none found"
 
 ---
 ### Code Coverage  ✅/⚠️


### PR DESCRIPTION
## Summary
- Expand the github-health-check skill with explicit GitHub security feature enablement priorities.
- Add listing checks for Code Quality findings, Dependabot malware/vulnerability alerts, code scanning alerts, and secret scanning alerts.
- Add public/private repository best-practice checks.
- Add CODEOWNERS and an AI-agent-oriented pull request template.

## Validation
- pnpm --filter @everydaydevopsio/ballast run test -- build.test.ts
- pnpm --dir packages/ballast-typescript exec prettier --check ../../README.md ../../docs/README.md ../../docs/skills/README.md ../../docs/skills/github-health-check.md ../../skills/common/github-health-check/SKILL.md skills/common/github-health-check/SKILL.md ../ballast-python/ballast/skills/common/github-health-check/SKILL.md ../ballast-go/cmd/ballast-go/skills/common/github-health-check/SKILL.md src/build.test.ts
- pnpm run build
- commit hooks and pre-push unit tests passed

## Notes
- Repo has no root PRD.md, so no PRD section was updated.
- During push, GitHub reported 4 default-branch Dependabot vulnerabilities. Earlier gh API checks for open Dependabot alerts returned 0, so this should be rechecked in the Security UI or with refreshed API permissions.