### PR TITLE
Restrict workflow permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typescript-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   typescript-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit read-only contents permissions to lint and test workflows
- keep workflow permissions scoped to the minimum needed for checkout/read access

## Verification
- pre-push hooks passed: whitespace, EOF newline, YAML checks, yamllint, secret/private-key checks, merge-conflict check, and unit test hook