### PR TITLE
Improve doctor config visibility and JS detection warnings

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,41 @@
+# Product Requirements
+
+## Ballast Doctor Config Visibility
+
+### Problem
+
+Operators use `ballast doctor` to inspect the effective Ballast state for a repository, but the current report omits the saved `languages` and `paths` from `.rulesrc.json`. This makes it hard to confirm which language profiles Ballast considers installed in monorepos or mixed-language repos.
+
+### Requirements
+
+1. `ballast doctor` must display configured `languages` when `.rulesrc.json` contains them.
+2. `ballast doctor` must display configured `paths` when `.rulesrc.json` contains them.
+3. The change must apply consistently across the TypeScript, Python, Go, and wrapper CLIs.
+4. Existing `doctor` output for targets, agents, skills, installed CLIs, and recommendations must remain intact.
+
+### Acceptance Criteria
+
+1. Given a `.rulesrc.json` with `languages`, `ballast doctor` prints a `- languages: ...` line in the `Config:` section.
+2. Given a `.rulesrc.json` with `paths`, `ballast doctor` prints a `- paths: ...` line in the `Config:` section.
+3. Given a `.rulesrc.json` without `languages` or `paths`, `ballast doctor` does not print empty placeholder lines for those fields.
+4. Automated tests cover the new output in each CLI implementation that renders `doctor` output.
+
+## JavaScript Detection Warning
+
+### Problem
+
+Some repositories contain browser or Node.js components that are still JavaScript-first and therefore do not produce a reliable TypeScript profile for Ballast. This can hide real application components from Ballast's language/profile reporting, especially in mixed-language repos.
+
+### Requirements
+
+1. The `ballast` wrapper must warn when it detects a real `package.json`-based JavaScript component or app without a `tsconfig.json`.
+2. The warning must apply in both single-language detection and monorepo planning paths.
+3. The warning must tell the operator to convert the component to TypeScript or add `tsconfig.json` so Ballast can track it as a TypeScript profile.
+4. The warning must not trigger for placeholder `package.json` files that do not look like an app or component.
+
+### Acceptance Criteria
+
+1. Given a repo with `package.json` containing app/component signals and no `tsconfig.json`, calling the wrapper detection path emits a warning on stderr.
+2. Given a mixed-language repo where monorepo planning detects non-TypeScript profiles but the root still contains a JavaScript app/component, the wrapper emits the same warning on stderr.
+3. Given a repo with `tsconfig.json`, the warning is not emitted.
+4. Smoke coverage must exercise at least one single-language JavaScript package case and one mixed-language non-TypeScript monorepo case that emits the warning.

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"slices"
+	"sort"
 	"strings"
 )
 
@@ -734,7 +735,39 @@ func printDoctorSummary(root string, selectedLanguage language, fix bool) {
 	if len(config.Skills) > 0 {
 		fmt.Printf("- skills: %s\n", strings.Join(config.Skills, ", "))
 	}
+	if len(config.Languages) > 0 {
+		fmt.Printf("- languages: %s\n", strings.Join(config.Languages, ", "))
+	}
+	if formattedPaths := formatDoctorConfigPaths(config.Languages, config.Paths); formattedPaths != "" {
+		fmt.Printf("- paths: %s\n", formattedPaths)
+	}
 	fmt.Println()
+}
+
+func formatDoctorConfigPaths(languages []string, paths map[string][]string) string {
+	orderedKeys := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, language := range languages {
+		if len(paths[language]) == 0 {
+			continue
+		}
+		orderedKeys = append(orderedKeys, language)
+		seen[language] = true
+	}
+	remaining := make([]string, 0, len(paths))
+	for language, values := range paths {
+		if seen[language] || len(values) == 0 {
+			continue
+		}
+		remaining = append(remaining, language)
+	}
+	sort.Strings(remaining)
+	orderedKeys = append(orderedKeys, remaining...)
+	entries := make([]string, 0, len(orderedKeys))
+	for _, language := range orderedKeys {
+		entries = append(entries, fmt.Sprintf("%s=%s", language, strings.Join(paths[language], ",")))
+	}
+	return strings.Join(entries, "; ")
 }
 
 func parseDoctorFix(args []string) (bool, bool, error) {
@@ -1371,6 +1404,74 @@ func cloneEnvMap(env map[string]string) map[string]string {
 	return cloned
 }
 
+type packageJSONMetadata struct {
+	Scripts              map[string]any `json:"scripts"`
+	Dependencies         map[string]any `json:"dependencies"`
+	DevDependencies      map[string]any `json:"devDependencies"`
+	PeerDependencies     map[string]any `json:"peerDependencies"`
+	OptionalDependencies map[string]any `json:"optionalDependencies"`
+	Main                 string         `json:"main"`
+	Module               string         `json:"module"`
+	Browser              any            `json:"browser"`
+	Bin                  any            `json:"bin"`
+	Exports              any            `json:"exports"`
+}
+
+func javascriptComponentWarning(root string) string {
+	if fileExists(filepath.Join(root, "tsconfig.json")) {
+		return ""
+	}
+
+	packageJSONPath := filepath.Join(root, "package.json")
+	if !fileExists(packageJSONPath) {
+		return ""
+	}
+
+	content, err := os.ReadFile(packageJSONPath)
+	if err != nil {
+		return ""
+	}
+
+	var metadata packageJSONMetadata
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		return ""
+	}
+
+	if !looksLikeJavaScriptComponent(metadata) {
+		return ""
+	}
+
+	return "detected a JavaScript package.json-based component or app without tsconfig.json; convert it to TypeScript or add tsconfig.json so Ballast can track it as a TypeScript profile."
+}
+
+func looksLikeJavaScriptComponent(metadata packageJSONMetadata) bool {
+	if len(metadata.Scripts) > 0 {
+		return true
+	}
+	if len(metadata.Dependencies) > 0 ||
+		len(metadata.DevDependencies) > 0 ||
+		len(metadata.PeerDependencies) > 0 ||
+		len(metadata.OptionalDependencies) > 0 {
+		return true
+	}
+	if strings.TrimSpace(metadata.Main) != "" || strings.TrimSpace(metadata.Module) != "" {
+		return true
+	}
+	if metadata.Browser != nil || metadata.Bin != nil || metadata.Exports != nil {
+		return true
+	}
+	return false
+}
+
+func profilesIncludeLanguage(profiles []repoProfile, target language) bool {
+	for _, profile := range profiles {
+		if profile.Language == target {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if len(args) == 0 || args[0] != "install" {
 		return nil, nil
@@ -1399,6 +1500,9 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 
 	if len(profiles) < 2 {
 		return nil, nil
+	}
+	if warning := javascriptComponentWarning(root); warning != "" && !profilesIncludeLanguage(profiles, langTypeScript) {
+		fmt.Fprintln(os.Stderr, "warning:", warning)
 	}
 
 	installTargets := findFlagValues(args, "--target", "-t")
@@ -2531,6 +2635,10 @@ func hasRootMarker(dir string) bool {
 }
 
 func detectLanguage(root string) language {
+	if warning := javascriptComponentWarning(root); warning != "" {
+		fmt.Fprintln(os.Stderr, "warning:", warning)
+	}
+
 	scores := map[language]int{
 		langTypeScript: 0,
 		langPython:     0,

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -113,7 +113,16 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"5.0.2","target":"claude","agents":["local-dev"]}`)
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "target":"claude",
+  "agents":["local-dev"],
+  "languages":["typescript","ansible"],
+  "paths":{
+    "typescript":["apps/web"],
+    "ansible":["infra/ansible"]
+  }
+}`)
 
 	output := captureStdout(t, func() {
 		withWorkingDir(t, root, func() {
@@ -134,6 +143,12 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 	if !strings.Contains(output, "ballastVersion: 5.0.2") {
 		t.Fatalf("expected config version in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "languages: typescript, ansible") {
+		t.Fatalf("expected config languages in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "paths: typescript=apps/web; ansible=infra/ansible") {
+		t.Fatalf("expected config paths in doctor output, got %q", output)
 	}
 }
 
@@ -1653,6 +1668,62 @@ func TestDetectLanguageSupportsTerraformRulesConfig(t *testing.T) {
 	}
 }
 
+func TestDetectLanguageWarnsForJavaScriptPackageWithoutTsconfig(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), `{
+  "name": "novnc-desktop",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  }
+}`)
+
+	stderr := captureStderr(t, func() {
+		got := detectLanguage(root)
+		if got != langTypeScript {
+			t.Fatalf("expected typescript detection from package.json, got %q", got)
+		}
+	})
+
+	if !strings.Contains(stderr, "JavaScript package.json-based component or app") {
+		t.Fatalf("expected JavaScript conversion warning, got %q", stderr)
+	}
+}
+
+func TestResolveMonorepoPlanWarnsForJavaScriptRootWithoutTypeScriptProfile(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "package.json"), `{
+  "name": "novnc-desktop",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  }
+}`)
+	mustWriteFile(t, filepath.Join(root, "ansible.cfg"), "[defaults]\n")
+	mustWriteFile(t, filepath.Join(root, "infra", "terraform", "versions.tf"), "terraform {}\n")
+	mustWriteFile(t, filepath.Join(root, "infra", "terraform", ".terraform-version"), "1.8.5\n")
+
+	stderr := captureStderr(t, func() {
+		plan, err := resolveMonorepoPlan(root, []string{"install", "--target", "cursor", "--all"})
+		if err != nil {
+			t.Fatalf("resolveMonorepoPlan returned error: %v", err)
+		}
+		if plan == nil {
+			t.Fatal("expected monorepo plan, got nil")
+		}
+	})
+
+	if !strings.Contains(stderr, "JavaScript package.json-based component or app") {
+		t.Fatalf("expected JavaScript conversion warning, got %q", stderr)
+	}
+}
+
 func TestResolveBackendCommandAddsAnsibleLanguageFlag(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "ansible.cfg"), "[defaults]\n")
@@ -3002,6 +3073,45 @@ func captureStdout(t *testing.T, fn func()) string {
 	wg.Wait()
 	if copyErr != nil {
 		t.Fatalf("read stdout: %v", copyErr)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close reader: %v", err)
+	}
+
+	return buf.String()
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+
+	originalStderr := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+
+	os.Stderr = writer
+	t.Cleanup(func() {
+		os.Stderr = originalStderr
+	})
+
+	var buf bytes.Buffer
+	var copyErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, copyErr = io.Copy(&buf, reader)
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	wg.Wait()
+	if copyErr != nil {
+		t.Fatalf("read stderr: %v", copyErr)
 	}
 	if err := reader.Close(); err != nil {
 		t.Fatalf("close reader: %v", err)

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -555,6 +555,12 @@ func buildDoctorReport(currentCLI, currentVersion string, configPath string, con
 		if len(config.Skills) > 0 {
 			lines = append(lines, fmt.Sprintf("- skills: %s", strings.Join(config.Skills, ", ")))
 		}
+		if len(config.Languages) > 0 {
+			lines = append(lines, fmt.Sprintf("- languages: %s", strings.Join(config.Languages, ", ")))
+		}
+		if formattedPaths := formatDoctorConfigPaths(config.Languages, config.Paths); formattedPaths != "" {
+			lines = append(lines, fmt.Sprintf("- paths: %s", formattedPaths))
+		}
 		if configVersion == "" || compareVersions(configVersion, targetVersion) < 0 {
 			recommendations = append(
 				recommendations,
@@ -573,6 +579,32 @@ func buildDoctorReport(currentCLI, currentVersion string, configPath string, con
 	}
 
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func formatDoctorConfigPaths(languages []string, paths map[string][]string) string {
+	orderedKeys := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, language := range languages {
+		if len(paths[language]) == 0 {
+			continue
+		}
+		orderedKeys = append(orderedKeys, language)
+		seen[language] = true
+	}
+	remaining := make([]string, 0, len(paths))
+	for language, values := range paths {
+		if seen[language] || len(values) == 0 {
+			continue
+		}
+		remaining = append(remaining, language)
+	}
+	sort.Strings(remaining)
+	orderedKeys = append(orderedKeys, remaining...)
+	entries := make([]string, 0, len(orderedKeys))
+	for _, language := range orderedKeys {
+		entries = append(entries, fmt.Sprintf("%s=%s", language, strings.Join(paths[language], ",")))
+	}
+	return strings.Join(entries, "; ")
 }
 
 func runDoctor() int {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -123,6 +123,11 @@ func TestBuildDoctorReportRecommendsUpgrades(t *testing.T) {
 			Agents:         []string{"linting", "testing"},
 			Skills:         []string{"owasp-security-scan"},
 			BallastVersion: "5.0.1",
+			Languages:      []string{"typescript", "ansible"},
+			Paths: map[string][]string{
+				"typescript": {"apps/web"},
+				"ansible":    {"infra/ansible"},
+			},
 		},
 		[]installedCLIStatus{
 			{Name: "ballast-typescript", Version: "5.0.2", Path: "/tmp/ballast-typescript"},
@@ -139,6 +144,12 @@ func TestBuildDoctorReportRecommendsUpgrades(t *testing.T) {
 	}
 	if !strings.Contains(output, "- skills: owasp-security-scan") {
 		t.Fatalf("expected skills in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "- languages: typescript, ansible") {
+		t.Fatalf("expected languages in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "- paths: typescript=apps/web; ansible=infra/ansible") {
+		t.Fatalf("expected paths in doctor output, got %q", output)
 	}
 }
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -254,6 +254,20 @@ def load_config(root: Path, language: str) -> dict[str, object] | None:
                 if isinstance(ballast_version_value, str)
                 else None
             ),
+            "languages": [
+                item for item in data.get("languages", []) if isinstance(item, str)
+            ]
+            if isinstance(data.get("languages"), list)
+            else [],
+            "paths": {
+                key: value
+                for key, value in data.get("paths", {}).items()
+                if isinstance(key, str)
+                and isinstance(value, list)
+                and all(isinstance(item, str) for item in value)
+            }
+            if isinstance(data.get("paths"), dict)
+            else {},
         }
     except Exception:
         return None
@@ -449,6 +463,8 @@ def build_doctor_report(
         targets = config.get("targets")
         agents = config.get("agents")
         skills = config.get("skills")
+        languages = config.get("languages")
+        paths = config.get("paths")
         if isinstance(targets, list) and all(
             isinstance(target, str) for target in targets
         ):
@@ -457,6 +473,27 @@ def build_doctor_report(
             lines.append(f"- agents: {', '.join(agents)}")
         if isinstance(skills, list) and all(isinstance(skill, str) for skill in skills):
             lines.append(f"- skills: {', '.join(skills)}")
+        if isinstance(languages, list) and all(
+            isinstance(language, str) for language in languages
+        ):
+            lines.append(f"- languages: {', '.join(languages)}")
+        if (
+            isinstance(languages, list)
+            and all(isinstance(language, str) for language in languages)
+            and isinstance(paths, dict)
+        ):
+            formatted_paths = _format_config_paths(
+                languages,
+                {
+                    key: value
+                    for key, value in paths.items()
+                    if isinstance(key, str)
+                    and isinstance(value, list)
+                    and all(isinstance(item, str) for item in value)
+                },
+            )
+            if formatted_paths:
+                lines.append(f"- paths: {formatted_paths}")
 
     lines.extend(["", "Recommendations:"])
     if recommendations:
@@ -464,6 +501,21 @@ def build_doctor_report(
     else:
         lines.append("- No action needed.")
     return "\n".join(lines) + "\n"
+
+
+def _format_config_paths(
+    languages: list[str], paths: dict[str, list[str]]
+) -> str | None:
+    ordered_keys = [
+        *[language for language in languages if language in paths],
+        *sorted(key for key in paths if key not in languages),
+    ]
+    entries = [
+        f"{key}={','.join(paths[key])}"
+        for key in ordered_keys
+        if isinstance(paths.get(key), list) and paths[key]
+    ]
+    return "; ".join(entries) if entries else None
 
 
 def run_doctor() -> int:

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -25,6 +25,11 @@ class PatchInstallTests(unittest.TestCase):
                 "agents": ["linting", "testing"],
                 "skills": ["owasp-security-scan"],
                 "ballastVersion": "5.0.1",
+                "languages": ["typescript", "ansible"],
+                "paths": {
+                    "typescript": ["apps/web"],
+                    "ansible": ["infra/ansible"],
+                },
             },
             [
                 {
@@ -51,6 +56,8 @@ class PatchInstallTests(unittest.TestCase):
         )
         self.assertIn("- targets: cursor", output)
         self.assertIn("- skills: owasp-security-scan", output)
+        self.assertIn("- languages: typescript, ansible", output)
+        self.assertIn("- paths: typescript=apps/web; ansible=infra/ansible", output)
 
     def test_parser_top_level_help_flag_exits_zero(self) -> None:
         with self.assertRaises(SystemExit) as exc:

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -10,6 +10,8 @@ describe('doctor', () => {
       ['cursor'],
       ['linting', 'testing'],
       [],
+      [],
+      {},
       [
         {
           name: 'ballast-typescript',
@@ -46,6 +48,11 @@ describe('doctor', () => {
       ['cursor'],
       ['linting'],
       ['owasp-security-scan'],
+      ['typescript', 'ansible'],
+      {
+        typescript: ['apps/web'],
+        ansible: ['infra/ansible']
+      },
       [
         {
           name: 'ballast-typescript',
@@ -66,6 +73,10 @@ describe('doctor', () => {
     expect(output).toContain('- targets: cursor');
     expect(output).toContain('Recommendations:');
     expect(output).toContain('- skills: owasp-security-scan');
+    expect(output).toContain('- languages: typescript, ansible');
+    expect(output).toContain(
+      '- paths: typescript=apps/web; ansible=infra/ansible'
+    );
     expect(output).toContain('- No action needed.');
   });
 });

--- a/packages/ballast-typescript/src/doctor.ts
+++ b/packages/ballast-typescript/src/doctor.ts
@@ -17,6 +17,8 @@ export interface DoctorReport {
   configTargets: string[];
   configAgents: string[];
   configSkills: string[];
+  configLanguages: string[];
+  configPaths: Record<string, string[]>;
   installed: InstalledCliStatus[];
   recommendations: string[];
 }
@@ -94,6 +96,8 @@ export function buildDoctorReport(
   configTargets: string[],
   configAgents: string[],
   configSkills: string[],
+  configLanguages: string[],
+  configPaths: Record<string, string[]>,
   installed: InstalledCliStatus[]
 ): DoctorReport {
   const targetVersion = latestVersion([
@@ -145,9 +149,30 @@ export function buildDoctorReport(
     configTargets,
     configAgents,
     configSkills,
+    configLanguages,
+    configPaths,
     installed,
     recommendations
   };
+}
+
+function formatConfigPaths(
+  languages: string[],
+  paths: Record<string, string[]>
+): string | null {
+  const orderedKeys = [
+    ...languages.filter((language) => Array.isArray(paths[language])),
+    ...Object.keys(paths)
+      .filter((language) => !languages.includes(language))
+      .sort()
+  ];
+  const entries = orderedKeys.flatMap((language) => {
+    const values = paths[language];
+    return Array.isArray(values) && values.length > 0
+      ? [`${language}=${values.join(',')}`]
+      : [];
+  });
+  return entries.length > 0 ? entries.join('; ') : null;
 }
 
 export function formatDoctorReport(report: DoctorReport): string {
@@ -181,6 +206,16 @@ export function formatDoctorReport(report: DoctorReport): string {
     if (report.configSkills.length > 0) {
       lines.push(`- skills: ${report.configSkills.join(', ')}`);
     }
+    if (report.configLanguages.length > 0) {
+      lines.push(`- languages: ${report.configLanguages.join(', ')}`);
+    }
+    const formattedPaths = formatConfigPaths(
+      report.configLanguages,
+      report.configPaths
+    );
+    if (formattedPaths) {
+      lines.push(`- paths: ${formattedPaths}`);
+    }
   }
 
   lines.push('', 'Recommendations:');
@@ -207,6 +242,8 @@ export function runDoctor(): number {
     config?.targets ?? [],
     config?.agents ?? [],
     config?.skills ?? [],
+    config?.languages ?? [],
+    config?.paths ?? {},
     CLI_NAMES.map((name) => detectInstalledCli(name))
   );
   process.stdout.write(formatDoctorReport(report));

--- a/scripts/smoke-wrapper-monorepo.sh
+++ b/scripts/smoke-wrapper-monorepo.sh
@@ -129,6 +129,11 @@ verify_refresh_preserves_removed_target() {
   ! grep -q '"codex"' "${monorepo}/.rulesrc.json"
 }
 
+verify_warning_output() {
+  local output="$1"
+  grep -Fq "JavaScript package.json-based component or app" <<<"${output}"
+}
+
 run_wrapper_language_smoke() {
   local project="${WORKDIR}/ballast-wrapper-python"
 
@@ -142,6 +147,79 @@ run_wrapper_language_smoke() {
 
   test -f "${project}/.codex/rules/python-linting.md"
   grep -q '"codex"' "${project}/.rulesrc.json"
+}
+
+run_wrapper_javascript_warning_smoke() {
+  local project="${WORKDIR}/ballast-wrapper-javascript-warning"
+
+  mkdir -p "${project}"
+  cat > "${project}/package.json" <<'EOF'
+{
+  "name": "ballast-wrapper-javascript-warning",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0",
+    "playwright": "^1.45.0"
+  }
+}
+EOF
+  cat > "${project}/playwright.config.mjs" <<'EOF'
+export default {};
+EOF
+
+  local output
+  output="$(
+    cd "${project}" &&
+    ballast install --target codex --agent linting --yes 2>&1
+  )"
+
+  verify_warning_output "${output}"
+  test -f "${project}/.codex/rules/typescript-linting.md"
+}
+
+run_wrapper_mixed_warning_smoke() {
+  local project="${WORKDIR}/ballast-wrapper-mixed-warning"
+
+  mkdir -p "${project}/infra/terraform"
+  cat > "${project}/package.json" <<'EOF'
+{
+  "name": "ballast-wrapper-mixed-warning",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0",
+    "playwright": "^1.45.0"
+  }
+}
+EOF
+  cat > "${project}/playwright.config.mjs" <<'EOF'
+export default {};
+EOF
+  cat > "${project}/ansible.cfg" <<'EOF'
+[defaults]
+inventory = hosts.ini
+EOF
+  cat > "${project}/infra/terraform/.terraform-version" <<'EOF'
+1.8.5
+EOF
+  cat > "${project}/infra/terraform/versions.tf" <<'EOF'
+terraform {}
+EOF
+
+  local output
+  output="$(
+    cd "${project}" &&
+    ballast install --target codex --all --yes 2>&1
+  )"
+
+  verify_warning_output "${output}"
+  grep -q '"ansible"' "${project}/.rulesrc.json"
+  grep -q '"terraform"' "${project}/.rulesrc.json"
 }
 
 main() {
@@ -180,6 +258,8 @@ main() {
 
   verify_refresh_preserves_removed_target "${monorepo}"
   run_wrapper_language_smoke
+  run_wrapper_javascript_warning_smoke
+  run_wrapper_mixed_warning_smoke
 
   echo "Ballast wrapper monorepo smoke test passed."
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [x] Confirm the operator-visible behavior gap in `ballast doctor`.
+- [x] Identify the governing requirements for the CLI output change.
+- [x] Add failing tests for `languages` and `paths` in `doctor` output.
+- [x] Implement the minimal reporting change across CLIs.
+- [x] Run targeted tests and capture evidence.
+- [x] Document the `novnc-desktop` language-detection root cause and recommended fix.
+- [x] Add wrapper tests for JavaScript package warnings.
+- [x] Implement JavaScript package warning logic in single-language and monorepo detection.
+- [x] Add smoke coverage for JavaScript package warnings.
+- [ ] File a GitHub issue for integration-test framework detection and Playwright guidance. Blocked here by GitHub token permissions and network access.


### PR DESCRIPTION
## Summary

- `ballast doctor` now displays `languages` and `paths` from `.rulesrc.json` when present, making it easier to confirm which language profiles are configured in monorepos and mixed-language repos
- The `ballast` wrapper CLI now emits a warning when it detects a `package.json`-based JavaScript component without a `tsconfig.json`, guiding operators to convert to TypeScript or add `tsconfig.json`
- New tests added across the TypeScript, Python, Go, and wrapper CLI implementations to cover both features
- Smoke coverage added via `scripts/smoke-wrapper-monorepo.sh` for JavaScript detection warning cases

## Test plan

- [ ] Run `pnpm test` in `packages/ballast-typescript` — doctor tests for `languages`/`paths` output pass
- [ ] Run `go test ./...` in `cli/ballast` — doctor and JS detection warning tests pass
- [ ] Run `go test ./...` in `packages/ballast-go` — doctor config visibility tests pass
- [ ] Run `pytest` in `packages/ballast-python` — doctor config visibility tests pass
- [ ] Run `bash scripts/smoke-wrapper-monorepo.sh` — JS detection warning smoke cases pass
- [ ] Manually run `ballast doctor` against a repo with `languages`/`paths` in `.rulesrc.json` and confirm the new lines appear
- [ ] Manually run `ballast` against a repo with `package.json` but no `tsconfig.json` and confirm the warning appears on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)