### PR TITLE
feat: add tasks agent with task system MCP setup and TODO tracking

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -98,6 +98,34 @@ jobs:
       - name: Run skills smoke test
         run: ./scripts/smoke-skills.sh "$GITHUB_WORKSPACE"
 
+  tasks-smoke:
+    name: tasks-smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout ballast repo
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.27.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ballast-typescript
+        run: pnpm run build
+
+      - name: Run tasks smoke test
+        run: ./scripts/smoke-tasks.sh "$GITHUB_WORKSPACE"
+
   config-persistence-smoke:
     name: config-persistence-smoke
     runs-on: ubuntu-latest

--- a/agents/common/local-dev/content-mcp.md
+++ b/agents/common/local-dev/content-mcp.md
@@ -1,64 +1,7 @@
-# Optional: GitHub and Issues MCP Servers
+# Local Development: MCP Configuration
 
-When the user has **GitHub MCP** and/or **issues MCP** (Jira, Linear, or GitHub Issues) servers enabled, use them to support local development workflow and context.
+Task system MCP configuration (GitHub Issues, Jira, Linear) is now handled by the `tasks` agent rule.
 
-## When to Use This Rule
+To set up MCP for your task system, add the `tasks` agent to your `.rulesrc.json` and re-run `ballast install`.
 
-- The user asks for a summary of open work (PRs, issues, Jira/Linear items).
-- The user wants to correlate code changes with tickets or PRs.
-- The user is starting work and needs context from assigned or in-progress items.
-
-## GitHub MCP
-
-If the **GitHub MCP** server is available:
-
-- **Pull requests**: List or summarize open PRs for the current repo (or org). Help the user triage, review, or land PRs.
-- **Repos and orgs**: Use repo/org context when the user asks about “my PRs” or “our open PRs.”
-- **Branches and commits**: When relevant to local dev, use GitHub MCP to check branch status, CI status, or linked issues.
-
-Do not assume the server is present; only use it when it is configured and the user’s request fits (e.g. “summarize my PRs”, “what’s open in this repo?”).
-
-## Issues MCP (Jira / Linear / GitHub Issues)
-
-If an **issues MCP** server is available (Jira, Linear, or GitHub Issues):
-
-- **Assigned work**: When the user asks “what am I working on?” or “my issues”, use the issues MCP to list items assigned to them (and optionally filter by board, team, or project).
-- **Sprint / cycle / milestone**: For Jira (board/sprint) or Linear (team/cycle), summarize current sprint or cycle work when the user asks.
-- **Correlation with code**: When the user mentions a ticket ID (e.g. `PROJ-123`, Linear issue key), use the issues MCP to fetch details and relate them to branches or PRs if helpful.
-
-Configuration (e.g. which board, team, or filters) is typically stored in project docs (e.g. `CLAUDE.md`, `AGENTS.md`) or a config file (e.g. `work_summary` YAML). Prefer not to overwrite that config; use it to scope queries.
-
-## Scope
-
-- **Optional**: This rule applies only when the corresponding MCP servers are enabled. Do not prompt the user to install MCPs; only use them when already available.
-- **Local-dev focus**: Use these MCPs to support _local development_ context (what to work on next, PR/issue context while coding), not as a general “work summary” agent. Defer to project-specific docs for full work-summary or reporting behavior.
-- **Documentation**: If you add or change how MCPs are used, suggest updating README or runbooks (e.g. “Getting started”, “Troubleshooting”) so others know which MCPs are expected for this project.
-
-## Configuration Reference
-
-Projects may document MCP usage in a structure like:
-
-```yaml
-work_summary:
-  mcp_tools:
-    github: github
-    jira: jira # optional
-    linear: linear # optional
-  sources:
-    pull_requests: true
-    github_issues:
-      enabled: false
-      scope: { mode: repos, orgs: [], repos: [] }
-      filters: { assigned_to_me: true, labels: [] }
-    jira:
-      enabled: false
-      board: ''
-      only_assigned_to_me: true
-    linear:
-      enabled: false
-      team: ''
-      view: cycle
-      only_assigned_to_me: true
-```
-
-Respect such configuration when querying; use it to scope lists (e.g. “assigned to me”, specific board/team) rather than inventing defaults.
+Once the `tasks` agent is installed, ask your AI assistant: "set up my task system MCP" and it will walk you through configuration for your platform (Claude Code, Cursor, Codex, or OpenCode).

--- a/agents/common/local-dev/templates/claude-header-mcp.md
+++ b/agents/common/local-dev/templates/claude-header-mcp.md
@@ -1,5 +1,5 @@
-# Local Development: GitHub and Issues MCP (Optional)
+# Local Development: MCP Configuration
 
-Use GitHub MCP and/or issues MCP (Jira, Linear, GitHub Issues) when available to support local development context. Only apply when these MCP servers are enabled.
+Task system MCP configuration is now handled by the `tasks` agent rule. Add the `tasks` agent and re-run `ballast install`.
 
 ---

--- a/agents/common/local-dev/templates/codex-header-mcp.md
+++ b/agents/common/local-dev/templates/codex-header-mcp.md
@@ -1,7 +1,7 @@
-# Local Development: GitHub and Issues MCP (Optional)
+# Local Development: MCP Configuration
 
 These rules are intended for Codex (CLI and app).
 
-Use GitHub MCP and/or issues MCP (Jira, Linear, GitHub Issues) when available to support local development context. Only apply when these MCP servers are enabled.
+Task system MCP configuration is now handled by the `tasks` agent rule. Add the `tasks` agent and re-run `ballast install`.
 
 ---

--- a/agents/common/tasks/content-task-system.md
+++ b/agents/common/tasks/content-task-system.md
@@ -1,0 +1,106 @@
+# Task System Integration Rules
+
+These rules define how to use {{taskSystem}} as the system of record for work items and how to set up the required MCP server.
+
+---
+You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
+
+## Configured Task System
+
+This repository uses **{{taskSystem}}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+
+## MCP Server Setup
+
+When the user says any of the following, run the MCP setup check below:
+- "set up my task system MCP"
+- "check my MCP setup"
+- "configure MCP for {{taskSystem}}"
+- "is my MCP configured"
+
+### MCP Setup Check Procedure
+
+1. Ask the user which AI platform they are using: Claude Code, Cursor, Codex, or OpenCode.
+2. Check whether the correct MCP server for **{{taskSystem}}** is already configured for that platform (see platform-specific paths below).
+3. If it is configured and the user can connect, confirm success and stop.
+4. If it is not configured or the connection fails, walk the user through the setup steps for their platform.
+
+### MCP Server per Task System
+
+**GitHub Issues** (`github`):
+- MCP server: `@modelcontextprotocol/server-github`
+- Requires a GitHub personal access token with `repo` scope.
+- The token should be set as `GITHUB_PERSONAL_ACCESS_TOKEN` in the platform config.
+
+**Jira** (`jira`):
+- MCP server: `@modelcontextprotocol/server-atlassian` or a compatible Jira MCP server.
+- Requires a Jira API token and your Atlassian base URL.
+- Set `JIRA_API_TOKEN` and `JIRA_BASE_URL` in the platform config.
+
+**Linear** (`linear`):
+- MCP server: `@linear/mcp-server` or `@modelcontextprotocol/server-linear`.
+- Requires a Linear API key.
+- Set `LINEAR_API_KEY` in the platform config.
+
+### Platform Setup Steps
+
+**Claude Code:**
+- MCP servers are configured in `~/.claude/settings.json` under the `mcpServers` key.
+- Add the server entry and restart Claude Code.
+- Verify with `/mcp` in the Claude Code CLI.
+
+**Cursor:**
+- MCP servers are configured in `.cursor/mcp.json` at the project root or in Cursor's global settings.
+- Add the server entry and reload the window.
+
+**Codex:**
+- MCP servers are configured per the OpenAI Codex CLI docs; check `~/.codex/config.json` or the equivalent config file.
+- Add the server entry and restart the CLI session.
+
+**OpenCode:**
+- MCP servers are configured in `~/.config/opencode/config.json` under `mcp`.
+- Add the server entry and restart OpenCode.
+
+### Example Claude Code Config (`~/.claude/settings.json`)
+
+For GitHub:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-token>"
+      }
+    }
+  }
+}
+```
+
+For Linear:
+```json
+{
+  "mcpServers": {
+    "linear": {
+      "command": "npx",
+      "args": ["-y", "@linear/mcp-server"],
+      "env": {
+        "LINEAR_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+## Using {{taskSystem}} for Work Items
+
+- Create issues/tickets in **{{taskSystem}}** for any planned work, bugs, or follow-up items that extend beyond the current branch.
+- When starting a new piece of work, check **{{taskSystem}}** first for an existing issue to link against.
+- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/TODO.md`.
+- Reference issue IDs in commit messages and PR descriptions so work is traceable.
+
+## Important Notes
+
+- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- If the MCP server is unavailable, fall back to using the **{{taskSystem}}** web UI and link issues manually in PR descriptions.
+- Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/agents/common/tasks/content-todo.md
+++ b/agents/common/tasks/content-todo.md
@@ -1,0 +1,69 @@
+# Branch-Local TODO Tracking Rules
+
+These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+
+---
+You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+
+## What `tasks/TODO.md` Is For
+
+`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+- Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
+- Deferred decisions or follow-up questions for the current branch.
+- Small cleanup items that should happen before the PR is done.
+
+`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+
+## When to Add Items Here vs. Create a Ticket Immediately
+
+Add to `tasks/TODO.md` when:
+- The item is small and likely to be resolved within the current branch.
+- The item is a reminder for yourself mid-implementation.
+- You are not sure yet whether it warrants a tracked issue.
+
+Create a ticket in the configured task system immediately when:
+- The item is clearly out of scope for the current branch.
+- The item would block another team member or another piece of work.
+- The item is a bug that could affect users now or after release.
+- You know you will not resolve it in this branch.
+
+## File Format
+
+Keep `tasks/TODO.md` as a simple markdown checklist:
+
+```markdown
+# TODO
+
+- [ ] Add input validation to the config parser
+- [ ] Follow up: confirm rate limit behavior with the API team
+- [x] Write tests for the new agent content path
+```
+
+Mark items done with `[x]` as you complete them. Leave unchecked items visible so they are not forgotten.
+
+## Before Creating a PR
+
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+
+If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
+
+1. **Resolve it now** — implement or address it before the PR is opened.
+2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
+3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+
+Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
+
+## After Triage
+
+Once all items are resolved, the `tasks/TODO.md` file may be:
+- Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
+- Cleared to an empty checklist if there are no remaining items worth keeping.
+
+Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+
+## Important Notes
+
+- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
+- Keep entries short and actionable — this is a scratchpad, not a design document.
+- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.

--- a/agents/common/tasks/templates/claude-header-task-system.md
+++ b/agents/common/tasks/templates/claude-header-task-system.md
@@ -1,0 +1,5 @@
+# Task System Integration
+
+Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+
+---

--- a/agents/common/tasks/templates/claude-header-todo.md
+++ b/agents/common/tasks/templates/claude-header-todo.md
@@ -1,0 +1,5 @@
+# Branch-Local TODO Tracking
+
+Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+
+---

--- a/agents/common/tasks/templates/codex-header-task-system.md
+++ b/agents/common/tasks/templates/codex-header-task-system.md
@@ -1,0 +1,7 @@
+# Task System Integration
+
+These rules are intended for Codex (CLI and app).
+
+Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+
+---

--- a/agents/common/tasks/templates/codex-header-todo.md
+++ b/agents/common/tasks/templates/codex-header-todo.md
@@ -1,0 +1,7 @@
+# Branch-Local TODO Tracking
+
+These rules are intended for Codex (CLI and app).
+
+Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+
+---

--- a/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -1,0 +1,8 @@
+---
+description: 'Task system integration - use {{taskSystem}} for work items and configure the MCP server'
+alwaysApply: false
+globs:
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+  - 'tasks/TODO.md'
+---

--- a/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
+++ b/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
@@ -1,0 +1,8 @@
+---
+description: 'Branch-local TODO tracking - manage tasks/TODO.md and triage before PR'
+alwaysApply: false
+globs:
+  - 'tasks/TODO.md'
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+---

--- a/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
+++ b/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
@@ -1,0 +1,17 @@
+---
+description: Task system integration - use {{taskSystem}} for work items and configure the MCP server
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
+++ b/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
@@ -1,0 +1,17 @@
+---
+description: Branch-local TODO tracking - manage tasks/TODO.md and triage before PR
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/cli/ballast/registry.go
+++ b/cli/ballast/registry.go
@@ -59,6 +59,7 @@ var agentRegistry = []agentEntry{
 	{ID: "observability", Kind: kindCommon, Status: statusActive},
 	{ID: "publishing", Kind: kindCommon, Status: statusActive},
 	{ID: "git-hooks", Kind: kindCommon, Status: statusActive},
+	{ID: "tasks", Kind: kindCommon, Status: statusActive},
 
 	// Language agents — installed once per language sub-project.
 	{ID: "linting", Kind: kindLanguage, Status: statusActive},

--- a/packages/ballast-typescript/src/agents.test.ts
+++ b/packages/ballast-typescript/src/agents.test.ts
@@ -22,6 +22,7 @@ describe('agents', () => {
       expect(listAgents()).toContain('observability');
       expect(listAgents()).toContain('publishing');
       expect(listAgents()).toContain('git-hooks');
+      expect(listAgents()).toContain('tasks');
       expect(listAgents()).toContain('testing');
     });
   });
@@ -48,6 +49,7 @@ describe('agents', () => {
       expect(isValidAgent('observability')).toBe(true);
       expect(isValidAgent('publishing')).toBe(true);
       expect(isValidAgent('git-hooks')).toBe(true);
+      expect(isValidAgent('tasks')).toBe(true);
       expect(isValidAgent('testing')).toBe(true);
     });
 

--- a/packages/ballast-typescript/src/agents.ts
+++ b/packages/ballast-typescript/src/agents.ts
@@ -57,7 +57,8 @@ export const COMMON_AGENT_IDS = [
   'cicd',
   'observability',
   'publishing',
-  'git-hooks'
+  'git-hooks',
+  'tasks'
 ] as const;
 export const LANGUAGE_AGENT_IDS = ['linting', 'logging', 'testing'] as const;
 export const AGENT_IDS = [...COMMON_AGENT_IDS, ...LANGUAGE_AGENT_IDS] as const;

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -537,6 +537,22 @@ alwaysApply: false
         /Unknown target/
       );
     });
+
+    test('tasks task-system with variables resolves {{taskSystem}} in templates', () => {
+      for (const target of ['cursor', 'claude', 'opencode', 'codex'] as const) {
+        const result = buildContent(
+          'tasks',
+          target,
+          'task-system',
+          'typescript',
+          {
+            variables: { taskSystem: 'jira' }
+          }
+        );
+        expect(result).not.toContain('{{taskSystem}}');
+        expect(result).toContain('jira');
+      }
+    });
   });
 
   describe('getDestination', () => {

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -88,9 +88,37 @@ describe('build', () => {
 
     test('returns mcp content for local-dev with ruleSuffix mcp', () => {
       const content = getContent('local-dev', 'mcp');
-      expect(content).toContain('GitHub MCP');
-      expect(content).toContain('Jira');
-      expect(content).toContain('Linear');
+      expect(content).toContain('tasks');
+      expect(content).toContain('ballast install');
+    });
+
+    test('returns tasks task-system content with default variable substitution', () => {
+      const content = getContent('tasks', 'task-system', 'typescript', {
+        variables: { taskSystem: 'github' }
+      });
+      expect(content).toContain('github');
+      expect(content).toContain('MCP Server Setup');
+      expect(content).not.toContain('{{taskSystem}}');
+    });
+
+    test('returns tasks task-system content with linear substituted', () => {
+      const content = getContent('tasks', 'task-system', 'typescript', {
+        variables: { taskSystem: 'linear' }
+      });
+      expect(content).toContain('linear');
+      expect(content).not.toContain('{{taskSystem}}');
+    });
+
+    test('returns tasks todo content', () => {
+      const content = getContent('tasks', 'todo');
+      expect(content).toContain('tasks/TODO.md');
+      expect(content).toContain('triage');
+      expect(content).not.toContain('{{taskSystem}}');
+    });
+
+    test('returns tasks task-system content unsubstituted when no variables', () => {
+      const content = getContent('tasks', 'task-system');
+      expect(content).toContain('{{taskSystem}}');
     });
 
     test('returns docs content', () => {

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -21,6 +21,7 @@ type HookMode = 'standalone' | 'monorepo';
 
 interface BuildOptions {
   hookMode?: HookMode;
+  variables?: Record<string, string>;
 }
 
 interface SkillEntry {
@@ -270,12 +271,13 @@ export function getContent(
   if (!fs.existsSync(file)) {
     throw new Error(`Agent "${agentId}" has no ${basename}`);
   }
-  return applyHookGuidance(
-    fs.readFileSync(file, 'utf8'),
-    agentId,
-    language,
-    options
-  );
+  let raw = fs.readFileSync(file, 'utf8');
+  if (options?.variables) {
+    for (const [key, value] of Object.entries(options.variables)) {
+      raw = raw.replaceAll(`{{${key}}}`, value);
+    }
+  }
+  return applyHookGuidance(raw, agentId, language, options);
 }
 
 /**

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -871,20 +871,32 @@ export function buildContent(
   language: Language = 'typescript',
   options?: BuildOptions
 ): string {
+  let result: string;
   switch (target) {
     case 'cursor':
-      return buildCursorFormat(agentId, ruleSuffix, language, options);
+      result = buildCursorFormat(agentId, ruleSuffix, language, options);
+      break;
     case 'claude':
-      return buildClaudeFormat(agentId, ruleSuffix, language, options);
+      result = buildClaudeFormat(agentId, ruleSuffix, language, options);
+      break;
     case 'gemini':
-      return buildGeminiFormat(agentId, ruleSuffix, language, options);
+      result = buildGeminiFormat(agentId, ruleSuffix, language, options);
+      break;
     case 'opencode':
-      return buildOpenCodeFormat(agentId, ruleSuffix, language, options);
+      result = buildOpenCodeFormat(agentId, ruleSuffix, language, options);
+      break;
     case 'codex':
-      return buildCodexFormat(agentId, ruleSuffix, language, options);
+      result = buildCodexFormat(agentId, ruleSuffix, language, options);
+      break;
     default:
       throw new Error(`Unknown target: ${target}`);
   }
+  if (options?.variables) {
+    for (const [key, value] of Object.entries(options.variables)) {
+      result = result.replaceAll(`{{${key}}}`, value);
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/ballast-typescript/src/cli.test.ts
+++ b/packages/ballast-typescript/src/cli.test.ts
@@ -45,7 +45,8 @@ describe('parseArgs', () => {
       allSkills: false,
       force: false,
       patch: false,
-      yes: false
+      yes: false,
+      taskSystem: ''
     });
   });
 
@@ -68,7 +69,8 @@ describe('parseArgs', () => {
       allSkills: true,
       force: false,
       patch: false,
-      yes: false
+      yes: false,
+      taskSystem: ''
     });
   });
 
@@ -94,7 +96,36 @@ describe('parseArgs', () => {
       allSkills: false,
       force: false,
       patch: false,
-      yes: false
+      yes: false,
+      taskSystem: ''
+    });
+  });
+
+  test('parses --task-system flag', () => {
+    expect(
+      parseArgs([
+        'node',
+        'ballast-typescript',
+        'install',
+        '--target',
+        'cursor',
+        '--agent',
+        'tasks',
+        '--task-system',
+        'jira',
+        '--yes'
+      ])
+    ).toEqual({
+      targets: ['cursor'],
+      agents: ['tasks'],
+      skills: [],
+      language: 'typescript',
+      all: false,
+      allSkills: false,
+      force: false,
+      patch: false,
+      yes: true,
+      taskSystem: 'jira'
     });
   });
 });

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -4,6 +4,7 @@ import { runInstall } from './install';
 import { LANGUAGES, Language, AGENT_IDS, SKILL_IDS } from './agents';
 import { runDoctor } from './doctor';
 import { BALLAST_VERSION } from './version';
+import { TASK_SYSTEMS } from './config';
 
 export interface CliOptions {
   targets: string[];
@@ -15,6 +16,7 @@ export interface CliOptions {
   force: boolean;
   patch: boolean;
   yes: boolean;
+  taskSystem: string;
 }
 
 export type ParseArgsResult =
@@ -42,7 +44,8 @@ export function parseArgs(argv: string[]): ParseArgsResult {
     allSkills: false,
     force: false,
     patch: false,
-    yes: false
+    yes: false,
+    taskSystem: ''
   };
   let i = 0;
   while (i < args.length) {
@@ -108,6 +111,12 @@ export function parseArgs(argv: string[]): ParseArgsResult {
       i++;
       continue;
     }
+    if (arg === '--task-system') {
+      const value = args[++i];
+      if (value) options.taskSystem = value.trim().toLowerCase();
+      i++;
+      continue;
+    }
     if (arg === '--help' || arg === '-h') {
       return { help: true };
     }
@@ -138,6 +147,7 @@ Options:
   --skill, -s <skills>      Skill(s) to install (comma-separated); run 'list' to see available skills
   --all                     Install all agents
   --all-skills              Install all skills
+  --task-system <system>    Task system for the tasks agent: ${TASK_SYSTEMS.join(', ')} (default: github)
   --force, -f               Overwrite existing rule files
   --patch, -p               Merge upstream rule updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
@@ -225,7 +235,8 @@ export async function main(): Promise<void> {
     language: cliOptions.language as Language,
     targets: cliOptions.targets,
     agents: cliOptions.agents.length > 0 ? cliOptions.agents : undefined,
-    skills: cliOptions.skills.length > 0 ? cliOptions.skills : undefined
+    skills: cliOptions.skills.length > 0 ? cliOptions.skills : undefined,
+    taskSystem: cliOptions.taskSystem || undefined
   };
 
   const exitCode = await runInstall(normalizedOptions);

--- a/packages/ballast-typescript/src/config.test.ts
+++ b/packages/ballast-typescript/src/config.test.ts
@@ -8,7 +8,9 @@ import {
   isCiMode,
   RULESRC_FILENAME,
   getLegacyRulesrcFilename,
-  parseTargets
+  parseTargets,
+  TASK_SYSTEMS,
+  DEFAULT_TASK_SYSTEM
 } from './config';
 import { BALLAST_VERSION } from './version';
 
@@ -233,6 +235,64 @@ describe('config', () => {
       );
       expect(parsed.targets).toEqual(['cursor', 'claude']);
       expect(parsed.target).toBeUndefined();
+    });
+  });
+
+  describe('taskSystem', () => {
+    test('TASK_SYSTEMS contains github, jira, linear', () => {
+      expect(TASK_SYSTEMS).toContain('github');
+      expect(TASK_SYSTEMS).toContain('jira');
+      expect(TASK_SYSTEMS).toContain('linear');
+    });
+
+    test('DEFAULT_TASK_SYSTEM is github', () => {
+      expect(DEFAULT_TASK_SYSTEM).toBe('github');
+    });
+
+    test('saves and loads taskSystem', () => {
+      saveConfig(
+        {
+          targets: ['claude'],
+          agents: ['tasks'],
+          ballastVersion: BALLAST_VERSION,
+          taskSystem: 'linear'
+        },
+        tmpDir
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.taskSystem).toBe('linear');
+    });
+
+    test('loads config without taskSystem field', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, RULESRC_FILENAME),
+        JSON.stringify({ targets: ['claude'], agents: ['local-dev'] })
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.taskSystem).toBeUndefined();
+    });
+
+    test('ignores invalid taskSystem value', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, RULESRC_FILENAME),
+        JSON.stringify({
+          targets: ['claude'],
+          agents: ['tasks'],
+          taskSystem: 'notion'
+        })
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.taskSystem).toBeUndefined();
+    });
+
+    test('preserves existing taskSystem when saving without one', () => {
+      saveConfig(
+        { targets: ['claude'], agents: ['tasks'], taskSystem: 'jira' },
+        tmpDir
+      );
+      saveConfig({ targets: ['cursor'], agents: ['tasks'] }, tmpDir);
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.taskSystem).toBe('jira');
     });
   });
 

--- a/packages/ballast-typescript/src/config.ts
+++ b/packages/ballast-typescript/src/config.ts
@@ -5,8 +5,11 @@ import { LANGUAGES } from './agents';
 const RULESRC_FILENAME = '.rulesrc.json';
 const LEGACY_TYPESCRIPT_RULESRC_FILENAME = '.rulesrc.ts.json';
 const TARGETS = ['cursor', 'claude', 'opencode', 'codex', 'gemini'] as const;
+export const TASK_SYSTEMS = ['github', 'jira', 'linear'] as const;
+export const DEFAULT_TASK_SYSTEM = 'github' as const;
 
 export type Target = (typeof TARGETS)[number];
+export type TaskSystem = (typeof TASK_SYSTEMS)[number];
 
 export interface RulesConfig {
   targets: Target[];
@@ -15,6 +18,7 @@ export interface RulesConfig {
   ballastVersion?: string;
   languages?: string[];
   paths?: Record<string, string[]>;
+  taskSystem?: TaskSystem;
 }
 
 export function getRulesrcFilename(): string {
@@ -153,6 +157,11 @@ export function saveConfig(config: RulesConfig, projectRoot?: string): void {
     };
   }
 
+  const taskSystem = config.taskSystem ?? existing?.taskSystem;
+  if (taskSystem) {
+    nextConfig = { ...nextConfig, taskSystem };
+  }
+
   fs.writeFileSync(filePath, JSON.stringify(nextConfig, null, 2), 'utf8');
 }
 
@@ -177,6 +186,7 @@ function normalizeRulesConfig(data: unknown): RulesConfig | null {
     ballastVersion?: unknown;
     languages?: unknown;
     paths?: unknown;
+    taskSystem?: unknown;
   };
   const targets = normalizeTargets(record.targets ?? record.target);
   if (targets.length === 0 || !Array.isArray(record.agents)) {
@@ -212,6 +222,12 @@ function normalizeRulesConfig(data: unknown): RulesConfig | null {
           : []
       )
     );
+  }
+  if (
+    typeof record.taskSystem === 'string' &&
+    (TASK_SYSTEMS as readonly string[]).includes(record.taskSystem)
+  ) {
+    config.taskSystem = record.taskSystem as TaskSystem;
   }
   return config;
 }

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -820,11 +820,19 @@ export async function runInstall(
   const { targets, agents, skills } = resolved;
 
   // Resolve taskSystem: flag overrides config; prompt interactively when tasks agent is selected and not in CI.
-  const taskSystemFromFlag =
-    options.taskSystem &&
-    (TASK_SYSTEMS as readonly string[]).includes(options.taskSystem)
-      ? (options.taskSystem as TaskSystem)
-      : undefined;
+  const normalizedTaskSystem = options.taskSystem?.trim().toLowerCase();
+  if (
+    normalizedTaskSystem &&
+    !(TASK_SYSTEMS as readonly string[]).includes(normalizedTaskSystem)
+  ) {
+    console.error(
+      `Invalid --task-system value: "${normalizedTaskSystem}". Valid values: ${TASK_SYSTEMS.join(', ')}`
+    );
+    return 1;
+  }
+  const taskSystemFromFlag = normalizedTaskSystem
+    ? (normalizedTaskSystem as TaskSystem)
+    : undefined;
   let resolvedTaskSystem: TaskSystem | undefined =
     taskSystemFromFlag ?? priorConfig?.taskSystem ?? undefined;
   if (agents.includes('tasks')) {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -34,7 +34,10 @@ import {
   saveConfig,
   isCiMode,
   parseTargets,
-  type Target
+  TASK_SYSTEMS,
+  DEFAULT_TASK_SYSTEM,
+  type Target,
+  type TaskSystem
 } from './config';
 import { BALLAST_VERSION } from './version';
 
@@ -227,6 +230,21 @@ async function promptSkills(
   return resolved;
 }
 
+async function promptTaskSystem(): Promise<TaskSystem> {
+  const line = await prompt(
+    `Task system (${TASK_SYSTEMS.join(', ')}) [${DEFAULT_TASK_SYSTEM}]: `
+  );
+  if (!line) return DEFAULT_TASK_SYSTEM;
+  const token = line.trim().toLowerCase();
+  if ((TASK_SYSTEMS as readonly string[]).includes(token)) {
+    return token as TaskSystem;
+  }
+  console.error(
+    `Invalid task system. Choose one of: ${TASK_SYSTEMS.join(', ')}`
+  );
+  return promptTaskSystem();
+}
+
 export interface ResolveTargetAndAgentsOptions {
   projectRoot?: string;
   target?: string;
@@ -333,6 +351,7 @@ export interface InstallOptions {
   patchClaudeMd?: boolean;
   patchGeminiMd?: boolean;
   saveConfig?: boolean;
+  taskSystem?: TaskSystem;
 }
 
 export interface InstallResult {
@@ -455,7 +474,8 @@ export function install(options: InstallOptions): InstallResult {
     patch = false,
     patchClaudeMd = false,
     patchGeminiMd = false,
-    saveConfig: persist
+    saveConfig: persist,
+    taskSystem
   } = options;
   const effectiveAgents = withImplicitAgents(agents);
   const installed: string[] = [];
@@ -479,6 +499,11 @@ export function install(options: InstallOptions): InstallResult {
     });
   }
 
+  // Resolve the task system: use provided value, fall back to existing config, then default.
+  const existingConfig = loadConfig(projectRoot, language);
+  const resolvedTaskSystem =
+    taskSystem ?? existingConfig?.taskSystem ?? DEFAULT_TASK_SYSTEM;
+
   if (persist) {
     saveConfig(
       {
@@ -486,7 +511,10 @@ export function install(options: InstallOptions): InstallResult {
         agents: effectiveAgents,
         skills,
         ballastVersion: BALLAST_VERSION,
-        languages: [language]
+        languages: [language],
+        taskSystem: effectiveAgents.includes('tasks')
+          ? resolvedTaskSystem
+          : (taskSystem ?? existingConfig?.taskSystem)
       },
       projectRoot
     );
@@ -521,12 +549,20 @@ export function install(options: InstallOptions): InstallResult {
         if (!fs.existsSync(dir)) {
           fs.mkdirSync(dir, { recursive: true });
         }
+        const buildVariables: Record<string, string> =
+          agentId === 'tasks' ? { taskSystem: resolvedTaskSystem } : {};
         const content = buildContent(
           agentId,
           target,
           ruleSuffix || undefined,
           language,
-          { hookMode }
+          {
+            hookMode,
+            variables:
+              Object.keys(buildVariables).length > 0
+                ? buildVariables
+                : undefined
+          }
         );
         if (fileExists && !force && !patch) {
           agentSkipped = true;
@@ -728,6 +764,7 @@ export interface RunInstallOptions {
   force?: boolean;
   patch?: boolean;
   yes?: boolean;
+  taskSystem?: string;
 }
 
 async function promptYesNo(
@@ -781,6 +818,23 @@ export async function runInstall(
   }
 
   const { targets, agents, skills } = resolved;
+
+  // Resolve taskSystem: flag overrides config; prompt interactively when tasks agent is selected and not in CI.
+  const taskSystemFromFlag =
+    options.taskSystem &&
+    (TASK_SYSTEMS as readonly string[]).includes(options.taskSystem)
+      ? (options.taskSystem as TaskSystem)
+      : undefined;
+  let resolvedTaskSystem: TaskSystem | undefined =
+    taskSystemFromFlag ?? priorConfig?.taskSystem ?? undefined;
+  if (agents.includes('tasks')) {
+    if (isCiMode() || options.yes || taskSystemFromFlag) {
+      resolvedTaskSystem = resolvedTaskSystem ?? DEFAULT_TASK_SYSTEM;
+    } else {
+      resolvedTaskSystem = await promptTaskSystem();
+    }
+  }
+
   const explicitAgentSelection =
     Boolean(options.all) || options.agents !== undefined;
   const agentsToPersist =
@@ -793,7 +847,8 @@ export async function runInstall(
       agents: agentsToPersist,
       skills,
       ballastVersion: BALLAST_VERSION,
-      languages: [language]
+      languages: [language],
+      taskSystem: resolvedTaskSystem
     },
     projectRoot
   );
@@ -833,7 +888,8 @@ export async function runInstall(
       patch: options.patch ?? false,
       patchClaudeMd,
       patchGeminiMd,
-      saveConfig: false
+      saveConfig: false,
+      taskSystem: resolvedTaskSystem
     });
 
     if (result.errors.length > 0) {

--- a/scripts/smoke-tasks.sh
+++ b/scripts/smoke-tasks.sh
@@ -70,10 +70,10 @@ tasks_rule_file() {
   local target="$2"
   local suffix="$3"  # "task-system" or "todo"
   case "${target}" in
-    cursor)  echo "${dir}/.cursor/rules/common-tasks-${suffix}.mdc" ;;
-    claude)  echo "${dir}/.claude/rules/common/tasks-${suffix}.md" ;;
-    opencode) echo "${dir}/.opencode/common-tasks-${suffix}.md" ;;
-    codex)   echo "${dir}/.codex/rules/common-tasks-${suffix}.md" ;;
+    cursor)   echo "${dir}/.cursor/rules/tasks-${suffix}.mdc" ;;
+    claude)   echo "${dir}/.claude/rules/tasks-${suffix}.md" ;;
+    opencode) echo "${dir}/.opencode/tasks-${suffix}.md" ;;
+    codex)    echo "${dir}/.codex/rules/tasks-${suffix}.md" ;;
   esac
 }
 

--- a/scripts/smoke-tasks.sh
+++ b/scripts/smoke-tasks.sh
@@ -52,6 +52,13 @@ assert_rule_file_contains() {
     fail "Expected '${text}' in ${file}"
 }
 
+assert_rule_file_not_contains() {
+  local file="$1"
+  local text="$2"
+  grep -qF "${text}" "${file}" && \
+    fail "Expected '${text}' to be absent in ${file}" || true
+}
+
 make_project() {
   local dir="$1"
   mkdir -p "${dir}"
@@ -97,7 +104,8 @@ test_tasks_default_github() {
     [ -f "${rule_file}" ] || \
       fail "Expected task-system rule file at ${rule_file}"
     assert_rule_file_contains "${rule_file}" "github"
-    pass "step 2 (${target}): task-system rule file contains 'github'"
+    assert_rule_file_not_contains "${rule_file}" "{{taskSystem}}"
+    pass "step 2 (${target}): task-system rule file contains 'github' and has no unresolved {{taskSystem}}"
   done
 
   echo "  ✓ test_tasks_default_github passed for all targets"
@@ -123,7 +131,8 @@ test_tasks_jira() {
     [ -f "${rule_file}" ] || \
       fail "Expected task-system rule file at ${rule_file}"
     assert_rule_file_contains "${rule_file}" "jira"
-    pass "step 2 (${target}): task-system rule file contains 'jira'"
+    assert_rule_file_not_contains "${rule_file}" "{{taskSystem}}"
+    pass "step 2 (${target}): task-system rule file contains 'jira' and has no unresolved {{taskSystem}}"
   done
 
   echo "  ✓ test_tasks_jira passed for all targets"
@@ -149,7 +158,8 @@ test_tasks_linear() {
     [ -f "${rule_file}" ] || \
       fail "Expected task-system rule file at ${rule_file}"
     assert_rule_file_contains "${rule_file}" "linear"
-    pass "step 2 (${target}): task-system rule file contains 'linear'"
+    assert_rule_file_not_contains "${rule_file}" "{{taskSystem}}"
+    pass "step 2 (${target}): task-system rule file contains 'linear' and has no unresolved {{taskSystem}}"
   done
 
   echo "  ✓ test_tasks_linear passed for all targets"

--- a/scripts/smoke-tasks.sh
+++ b/scripts/smoke-tasks.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# smoke-tasks.sh
+#
+# Verifies that the tasks agent installs correctly and that:
+#   - Installing with --yes defaults taskSystem to "github"
+#   - Installing with --task-system <value> uses the specified system
+#   - taskSystem is persisted in .rulesrc.json
+#   - taskSystem is preserved when reinstalling other agents
+#   - Rule files contain the resolved task system name
+#
+# Usage:
+#   ./scripts/smoke-tasks.sh [<repo-root>]
+#
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+CLI="node ${REPO_ROOT}/packages/ballast-typescript/dist/cli.js"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+TARGETS=(cursor claude opencode codex)
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+
+pass() { echo "  PASS: $*"; }
+fail() { echo "  FAIL: $*" >&2; exit 1; }
+
+rulesrc_contents() {
+  local rulesrc="$1"
+  if [ -r "${rulesrc}" ]; then
+    cat "${rulesrc}" 2>/dev/null || true
+    return
+  fi
+  printf '<unreadable: %s>' "${rulesrc}"
+}
+
+assert_rulesrc_field() {
+  local dir="$1"
+  local field="$2"
+  local value="$3"
+  local rulesrc="${dir}/.rulesrc.json"
+  grep -q "\"${field}\"" "${rulesrc}" || \
+    fail "Expected field '${field}' in ${rulesrc}. Content: $(rulesrc_contents "${rulesrc}")"
+  grep -q "\"${value}\"" "${rulesrc}" || \
+    fail "Expected value '${value}' for field '${field}' in ${rulesrc}. Content: $(rulesrc_contents "${rulesrc}")"
+}
+
+assert_rule_file_contains() {
+  local file="$1"
+  local text="$2"
+  grep -qF "${text}" "${file}" || \
+    fail "Expected '${text}' in ${file}"
+}
+
+make_project() {
+  local dir="$1"
+  mkdir -p "${dir}"
+  echo '{}' > "${dir}/package.json"
+}
+
+ballast() {
+  local dir="$1"; shift
+  (cd "${dir}" && ${CLI} "$@")
+}
+
+# ─── helper: resolve rule file path for tasks agent by target ─────────────────
+
+tasks_rule_file() {
+  local dir="$1"
+  local target="$2"
+  local suffix="$3"  # "task-system" or "todo"
+  case "${target}" in
+    cursor)  echo "${dir}/.cursor/rules/common-tasks-${suffix}.mdc" ;;
+    claude)  echo "${dir}/.claude/rules/common/tasks-${suffix}.md" ;;
+    opencode) echo "${dir}/.opencode/common-tasks-${suffix}.md" ;;
+    codex)   echo "${dir}/.codex/rules/common-tasks-${suffix}.md" ;;
+  esac
+}
+
+# ─── test: tasks agent with --yes defaults to github ─────────────────────────
+
+test_tasks_default_github() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    local dir="${WORKDIR}/tasks-default-${target}"
+    make_project "${dir}"
+
+    echo ""
+    echo "▶ test_tasks_default_github (${target})"
+
+    ballast "${dir}" install --target "${target}" --agent tasks --yes
+    assert_rulesrc_field "${dir}" "taskSystem" "github"
+    pass "step 1 (${target}): taskSystem=github saved to .rulesrc.json"
+
+    local rule_file
+    rule_file="$(tasks_rule_file "${dir}" "${target}" "task-system")"
+    [ -f "${rule_file}" ] || \
+      fail "Expected task-system rule file at ${rule_file}"
+    assert_rule_file_contains "${rule_file}" "github"
+    pass "step 2 (${target}): task-system rule file contains 'github'"
+  done
+
+  echo "  ✓ test_tasks_default_github passed for all targets"
+}
+
+# ─── test: tasks agent with --task-system jira ───────────────────────────────
+
+test_tasks_jira() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    local dir="${WORKDIR}/tasks-jira-${target}"
+    make_project "${dir}"
+
+    echo ""
+    echo "▶ test_tasks_jira (${target})"
+
+    ballast "${dir}" install --target "${target}" --agent tasks --task-system jira --yes
+    assert_rulesrc_field "${dir}" "taskSystem" "jira"
+    pass "step 1 (${target}): taskSystem=jira saved to .rulesrc.json"
+
+    local rule_file
+    rule_file="$(tasks_rule_file "${dir}" "${target}" "task-system")"
+    [ -f "${rule_file}" ] || \
+      fail "Expected task-system rule file at ${rule_file}"
+    assert_rule_file_contains "${rule_file}" "jira"
+    pass "step 2 (${target}): task-system rule file contains 'jira'"
+  done
+
+  echo "  ✓ test_tasks_jira passed for all targets"
+}
+
+# ─── test: tasks agent with --task-system linear ─────────────────────────────
+
+test_tasks_linear() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    local dir="${WORKDIR}/tasks-linear-${target}"
+    make_project "${dir}"
+
+    echo ""
+    echo "▶ test_tasks_linear (${target})"
+
+    ballast "${dir}" install --target "${target}" --agent tasks --task-system linear --yes
+    assert_rulesrc_field "${dir}" "taskSystem" "linear"
+    pass "step 1 (${target}): taskSystem=linear saved to .rulesrc.json"
+
+    local rule_file
+    rule_file="$(tasks_rule_file "${dir}" "${target}" "task-system")"
+    [ -f "${rule_file}" ] || \
+      fail "Expected task-system rule file at ${rule_file}"
+    assert_rule_file_contains "${rule_file}" "linear"
+    pass "step 2 (${target}): task-system rule file contains 'linear'"
+  done
+
+  echo "  ✓ test_tasks_linear passed for all targets"
+}
+
+# ─── test: todo rule file is installed alongside task-system ─────────────────
+
+test_tasks_todo_installed() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    local dir="${WORKDIR}/tasks-todo-${target}"
+    make_project "${dir}"
+
+    echo ""
+    echo "▶ test_tasks_todo_installed (${target})"
+
+    ballast "${dir}" install --target "${target}" --agent tasks --yes
+
+    local todo_file
+    todo_file="$(tasks_rule_file "${dir}" "${target}" "todo")"
+    [ -f "${todo_file}" ] || \
+      fail "Expected todo rule file at ${todo_file}"
+    assert_rule_file_contains "${todo_file}" "TODO"
+    pass "(${target}): todo rule file installed and contains 'TODO'"
+  done
+
+  echo "  ✓ test_tasks_todo_installed passed for all targets"
+}
+
+# ─── test: taskSystem preserved when reinstalling other agents ────────────────
+
+test_task_system_preserved_on_reinstall() {
+  local target
+  for target in "${TARGETS[@]}"; do
+    local dir="${WORKDIR}/tasks-preserved-${target}"
+    make_project "${dir}"
+
+    echo ""
+    echo "▶ test_task_system_preserved_on_reinstall (${target})"
+
+    ballast "${dir}" install --target "${target}" --agent tasks --task-system jira --yes
+    assert_rulesrc_field "${dir}" "taskSystem" "jira"
+    pass "step 1 (${target}): installed tasks with jira"
+
+    ballast "${dir}" install --target "${target}" --agent linting --yes
+    assert_rulesrc_field "${dir}" "taskSystem" "jira"
+    pass "step 2 (${target}): reinstalling linting does not drop taskSystem=jira"
+  done
+
+  echo "  ✓ test_task_system_preserved_on_reinstall passed for all targets"
+}
+
+# ─── run all tests ────────────────────────────────────────────────────────────
+
+main() {
+  echo "Running tasks smoke tests..."
+  echo "CLI: ${CLI}"
+  echo ""
+
+  test_tasks_default_github
+  test_tasks_jira
+  test_tasks_linear
+  test_tasks_todo_installed
+  test_task_system_preserved_on_reinstall
+
+  echo ""
+  echo "All tasks smoke tests passed."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes #78

Adds a new `tasks` common agent that installs two rule files per target platform:

- **task-system**: A user-invokable prompt that checks whether the project's task system MCP server is configured and walks the user through setup if not. Supports GitHub, Jira, and Linear.
- **todo**: Guidance for using `tasks/TODO.md` to track in-branch items that must be triaged (implemented, ignored, or converted to a real ticket) before a PR is merged.

### What changed

- `agents/common/tasks/` — new agent with two content files and per-target templates (claude, codex, cursor, opencode)
- `taskSystem` field in `.rulesrc.json` — persists the chosen system (`github` / `jira` / `linear`); preserved across reinstalls
- `--task-system` CLI flag — allows non-interactive selection of the task system (used by CI/smoke tests)
- Variable substitution in the build pipeline — `{{taskSystem}}` tokens in content files are replaced at install time
- `tasks` agent registered in the Go CLI registry and TypeScript agents list
- `agents/common/local-dev/content-mcp.md` — replaced old MCP setup content with a redirect to the `tasks` agent
- `scripts/smoke-tasks.sh` — new smoke test covering: default github, jira, linear, todo file install, and taskSystem preservation across reinstalls
- `tasks-smoke` job added to `.github/workflows/examples-smoke.yml`

## Test plan

- [x] All 197 unit tests pass (`pnpm test`)
- [x] Build passes (`pnpm run build`)
- [x] Pre-commit and pre-push hooks pass
- [x] `smoke-tasks.sh` covers: default task system (github), explicit jira, explicit linear, todo rule file present, taskSystem preserved when reinstalling other agents
- [ ] CI tasks-smoke job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)