### PR TITLE
fix: prevent duplicate task system prompt and preserve taskSystem in monorepo config

### DIFF
--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -137,6 +137,7 @@ type monorepoConfig struct {
 	BallastVersion string              `json:"ballastVersion,omitempty"`
 	Languages      []string            `json:"languages,omitempty"`
 	Paths          map[string][]string `json:"paths,omitempty"`
+	TaskSystem     string              `json:"taskSystem,omitempty"`
 }
 
 type repoProfile struct {
@@ -1585,6 +1586,10 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		return nil, err
 	}
 
+	var savedTaskSystem string
+	if config != nil {
+		savedTaskSystem = config.TaskSystem
+	}
 	configToSave := monorepoConfig{
 		Targets:        savedTargets,
 		Agents:         persistAgents,
@@ -1592,6 +1597,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		BallastVersion: normalizeVersion(resolveVersion()),
 		Languages:      make([]string, 0, len(profiles)),
 		Paths:          map[string][]string{},
+		TaskSystem:     savedTaskSystem,
 	}
 	for _, profile := range profiles {
 		configToSave.Languages = append(configToSave.Languages, string(profile.Language))

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -261,6 +261,11 @@ func run(args []string) int {
 				fmt.Println(err)
 				return 1
 			}
+			// Merge taskSystem written by backend invocations (e.g. on a fresh
+			// install where plan.Config.TaskSystem starts empty).
+			if plan.Config.TaskSystem == "" {
+				plan.Config.TaskSystem = readTaskSystem(root)
+			}
 			if err := saveMonorepoConfig(root, plan.Config); err != nil {
 				fmt.Println(err)
 				return 1
@@ -1688,6 +1693,23 @@ func loadMonorepoConfig(root string) (*monorepoConfig, error) {
 		return nil, nil
 	}
 	return &config, nil
+}
+
+// readTaskSystem reads only the taskSystem field from .rulesrc.json.
+// It does not validate Languages/Paths so it works on configs written by a
+// single-language backend invocation during a fresh monorepo install.
+func readTaskSystem(root string) string {
+	data, err := os.ReadFile(filepath.Join(root, ".rulesrc.json"))
+	if err != nil {
+		return ""
+	}
+	var raw struct {
+		TaskSystem string `json:"taskSystem"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	return raw.TaskSystem
 }
 
 func saveMonorepoConfig(root string, config monorepoConfig) error {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -2912,6 +2912,103 @@ func TestRunMonorepoRemoveTargetDoesNotPersistConfigWhenCleanupFails(t *testing.
 	}
 }
 
+// TestRunMonorepoInstallPreservesTaskSystemWrittenByBackend asserts that a
+// taskSystem value written to .rulesrc.json by a backend invocation (simulating
+// what ballast-typescript does after prompting the user) is not clobbered by
+// the final saveMonorepoConfig call.
+func TestRunMonorepoInstallPreservesTaskSystemWrittenByBackend(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["cursor"],
+  "agents": ["tasks", "linting"],
+  "languages": ["typescript"],
+  "paths": {"typescript": ["apps/frontend"]}
+}`)
+
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	callCount := 0
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		callCount++
+		// Simulate the common backend invocation writing taskSystem to .rulesrc.json
+		// after prompting the user (as ballast-typescript does).
+		if callCount == 1 {
+			mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["cursor"],
+  "agents": ["tasks", "linting"],
+  "taskSystem": "github",
+  "languages": ["typescript"],
+  "paths": {"typescript": ["apps/frontend"]}
+}`)
+		}
+		return 0, nil
+	}
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--target", "cursor", "--all", "--yes"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	config, err := os.ReadFile(filepath.Join(root, ".rulesrc.json"))
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if !strings.Contains(string(config), `"taskSystem": "github"`) {
+		t.Fatalf("expected taskSystem to be preserved in final .rulesrc.json, got %q", string(config))
+	}
+}
+
+// TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig asserts that a
+// taskSystem already present in .rulesrc.json before the install runs is
+// carried through into the final saved config.
+func TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["cursor"],
+  "agents": ["tasks", "linting"],
+  "taskSystem": "linear",
+  "languages": ["typescript"],
+  "paths": {"typescript": ["apps/frontend"]}
+}`)
+
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--target", "cursor", "--all", "--yes"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	config, err := os.ReadFile(filepath.Join(root, ".rulesrc.json"))
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if !strings.Contains(string(config), `"taskSystem": "linear"`) {
+		t.Fatalf("expected taskSystem to be preserved from existing config, got %q", string(config))
+	}
+}
+
 func TestPatchInstalledRulesSectionIgnoresHeadingInsideCodeFence(t *testing.T) {
 	existing := "# CLAUDE.md\n\n```md\n## Installed agent rules\n```\n\n## Installed agent rules\n\n- `.claude/rules/old.md` — Old rule\n"
 	canonical := "# CLAUDE.md\n\n## Installed agent rules\n\nCreated by Ballast. Do not edit this section.\n\n- `.claude/rules/typescript-linting.md` — Rules for typescript/linting\n"

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -838,7 +838,7 @@ export async function runInstall(
   if (agents.includes('tasks')) {
     if (isCiMode() || options.yes || taskSystemFromFlag) {
       resolvedTaskSystem = resolvedTaskSystem ?? DEFAULT_TASK_SYSTEM;
-    } else {
+    } else if (resolvedTaskSystem === undefined) {
       resolvedTaskSystem = await promptTaskSystem();
     }
   }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Double prompt**: In monorepo installs, `promptTaskSystem()` was firing once for the common backend invocation and again for each language invocation. Language invocations merge the saved config agents (which include `tasks`) with the passed language-specific agents, causing the prompt condition to trigger a second time even though the user already answered.
- **taskSystem not persisted**: The Go CLI's `monorepoConfig` struct had no `taskSystem` field, so `saveMonorepoConfig` silently dropped the value written by the backend on every install.

## Changes

**`packages/ballast-typescript/src/install.ts`**
Only call `promptTaskSystem()` when `resolvedTaskSystem` is still `undefined`. If a prior config entry or an earlier invocation already resolved the value, skip the prompt.

**`cli/ballast/main.go`**
Add `TaskSystem string` to `monorepoConfig` and preserve it when building `configToSave` in `resolveMonorepoPlan`, so the value survives subsequent `saveMonorepoConfig` writes.

## Test plan

- [ ] Run `ballast install --all --patch` on a monorepo with `tasks` agent — confirm task system is prompted exactly once
- [ ] Verify `taskSystem` appears in `.rulesrc.json` after the install
- [ ] Run again — confirm no prompt (value already in config)
- [ ] Unit tests: `pnpm test` in `packages/ballast-typescript` (198 passing), `go test ./...` in `cli/ballast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)