### PR TITLE
feat: publishing rules and workflows for all supported app types

### DIFF
--- a/agents/common/publishing/content-api.md
+++ b/agents/common/publishing/content-api.md
@@ -1,0 +1,152 @@
+# REST API Publishing Agent
+
+You are a publishing specialist for REST API services deployed as Docker containers to Kubernetes.
+
+## Goals
+
+- Use the same container publishing and Helm chart update model as web apps.
+- Ensure the API exposes a health endpoint that Kubernetes probes can use.
+- Include `livenessProbe` and `readinessProbe` in the Helm chart template referencing the health endpoint.
+- Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
+
+## Release Model
+
+REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are the health endpoint requirements and Helm chart probe configuration.
+
+## CI Workflow
+
+Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+
+- Trigger on `push` to `main`.
+- `concurrency: cancel-in-progress: true`.
+- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
+- Update the Helm chart repo with the new image digest.
+
+Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+## Health Endpoint Requirements
+
+Before enabling Kubernetes probes, ensure the API exposes at least one health endpoint:
+
+### Recommended Endpoints
+
+| Path | Purpose | Behavior |
+|------|---------|---------|
+| `/health` or `/healthz` | Liveness — is the process alive? | Return `200 OK` if the process is up; return non-2xx only if the process is broken and should be restarted. |
+| `/ready` or `/readyz` | Readiness — is the service ready for traffic? | Return `200 OK` only when all dependencies (DB, cache, downstream services) are reachable. Return `503` during startup or when a dependency is down. |
+
+Separate liveness and readiness checks. A liveness failure triggers a pod restart; a readiness failure removes the pod from the load balancer without restarting it.
+
+### Minimal Go Implementation
+
+```go
+http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte(`{"status":"ok"}`))
+})
+
+http.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+    if err := db.PingContext(r.Context()); err != nil {
+        http.Error(w, `{"status":"not ready"}`, http.StatusServiceUnavailable)
+        return
+    }
+    w.WriteHeader(http.StatusOK)
+    _, _ = w.Write([]byte(`{"status":"ready"}`))
+})
+```
+
+### Minimal Node/Express Implementation
+
+```typescript
+app.get('/healthz', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/readyz', async (_req, res) => {
+  try {
+    await db.query('SELECT 1');
+    res.json({ status: 'ready' });
+  } catch {
+    res.status(503).json({ status: 'not ready' });
+  }
+});
+```
+
+## Helm Chart: Probes Configuration
+
+Add `livenessProbe` and `readinessProbe` to the deployment template in your Helm chart:
+
+```yaml
+# charts/<your-chart>/templates/deployment.yaml
+containers:
+  - name: {{ .Chart.Name }}
+    image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+    ports:
+      - name: http
+        containerPort: {{ .Values.service.port }}
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: http
+      initialDelaySeconds: 10
+      periodSeconds: 15
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: http
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      failureThreshold: 3
+      successThreshold: 1
+```
+
+And in `values.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: latest
+  digest: ""          # filled in by the CD workflow
+
+service:
+  port: 8080
+```
+
+## Private vs Public Image Registries
+
+| Use case | Registry | Auth |
+|---------|---------|------|
+| Internal API, org-only access | GHCR (`ghcr.io`) | `GITHUB_TOKEN` |
+| Public API, open source | Docker Hub (`docker.io`) | `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` secrets |
+
+Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
+
+## Required Secrets and Permissions
+
+| Secret | Required for |
+|--------|-------------|
+| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `DOCKERHUB_USERNAME` | Docker Hub push |
+| `DOCKERHUB_TOKEN` | Docker Hub push |
+| `HELM_CHART_REPO_TOKEN` | Helm chart repo write access |
+
+## README Badge
+
+```markdown
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+```
+
+## Important Notes
+
+- Liveness and readiness probes must be separate endpoints with different semantics. Do not reuse the same handler for both.
+- Set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
+- Prefer `httpGet` probes over `exec` probes for HTTP services.
+- The `readinessProbe` should check all critical dependencies; the `livenessProbe` should only check process health.
+- Use `digest` not `tag` in the container spec so Kubernetes always pulls the exact image version, even if the `latest` tag is updated.
+
+## When to Apply
+
+- When a REST API service is deployed to Kubernetes via a Helm chart.
+- When every merge to `main` should trigger a new deployment.
+- When the API needs health and readiness probes for safe Kubernetes lifecycle management.

--- a/agents/common/publishing/content-apt.md
+++ b/agents/common/publishing/content-apt.md
@@ -1,0 +1,140 @@
+# APT/Deb Package Publishing Agent
+
+You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
+
+## Goals
+
+- Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
+- Attach `.deb` files to GitHub Releases so users can download and install them directly.
+- Optionally publish to a lightweight APT repository hosted on GitHub Pages.
+
+## Prerequisites
+
+This rule extends the Go CLI publishing rule. Complete the CLI publishing setup (`.goreleaser.yaml` with `builds` and `archives`) before adding `.deb` packaging.
+
+## GoReleaser `nfpms` Block
+
+Add an `nfpms` section to your `.goreleaser.yaml`:
+
+```yaml
+nfpms:
+  - id: <your-cli-name>-deb
+    package_name: <your-cli-name>
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    builds:
+      - <your-cli-name>       # must match the build id in your builds section
+    vendor: Your Name or Organization
+    homepage: https://github.com/OWNER/REPO
+    maintainer: "Your Name <you@example.com>"
+    description: One-line description of what the CLI does.
+    license: MIT
+    formats:
+      - deb
+    contents:
+      - src: ./completions/<your-cli-name>.bash
+        dst: /usr/share/bash-completion/completions/<your-cli-name>
+        file_info:
+          mode: 0644
+        type: config|noreplace
+    # Remove the contents block if you have no shell completions or extra files.
+```
+
+Replace `OWNER`, `REPO`, `<your-cli-name>`, and maintainer details with real values.
+
+### Minimal Config (no extras)
+
+If the CLI has no shell completions or extra data files, use:
+
+```yaml
+nfpms:
+  - id: <your-cli-name>-deb
+    package_name: <your-cli-name>
+    builds:
+      - <your-cli-name>
+    vendor: Your Name or Organization
+    homepage: https://github.com/OWNER/REPO
+    maintainer: "Your Name <you@example.com>"
+    description: One-line description of what the CLI does.
+    license: MIT
+    formats:
+      - deb
+```
+
+## GitHub Releases (Simple Path)
+
+By default, GoReleaser attaches `.deb` files to the GitHub Release alongside the binary archives. No additional configuration is needed beyond the `nfpms` block — users download and install with:
+
+```bash
+wget https://github.com/OWNER/REPO/releases/download/v<version>/<your-cli-name>_<version>_linux_amd64.deb
+sudo dpkg -i <your-cli-name>_<version>_linux_amd64.deb
+```
+
+Document this install path in `README.md` under an `## Installation` section.
+
+## README Install Path
+
+Add a `.deb` installation section to `README.md`:
+
+```markdown
+## Installation
+
+### Debian / Ubuntu (via .deb package)
+
+Download the latest `.deb` from [GitHub Releases](https://github.com/OWNER/REPO/releases) and install:
+
+\`\`\`bash
+wget https://github.com/OWNER/REPO/releases/latest/download/<your-cli-name>_linux_amd64.deb
+sudo dpkg -i <your-cli-name>_linux_amd64.deb
+\`\`\`
+
+### Direct binary download
+
+Download the binary archive from [GitHub Releases](https://github.com/OWNER/REPO/releases) and extract to your PATH.
+```
+
+## Optional: GitHub Pages APT Repository
+
+For projects that want `apt install` support (requires `apt-get update` to see new releases), you can host a lightweight APT repo on GitHub Pages using `reprepro` or `apt-tools`.
+
+### Overview
+
+1. Create a `gh-pages` branch (or use a separate `apt-repo` repository) to host the APT index files.
+2. After GoReleaser publishes the release, a follow-up workflow step downloads the `.deb`, adds it to the APT index, and pushes the updated index to GitHub Pages.
+3. Users add your repo: `echo "deb [trusted=yes] https://OWNER.github.io/REPO stable main" | sudo tee /etc/apt/sources.list.d/<your-cli-name>.list`
+
+### APT Workflow Step (after GoReleaser)
+
+```yaml
+- name: Update APT repository
+  run: |
+    mkdir -p apt-repo/pool/main
+    cp dist/*.deb apt-repo/pool/main/
+    cd apt-repo
+    dpkg-scanpackages pool/main /dev/null | gzip -9c > Packages.gz
+    dpkg-scanpackages pool/main /dev/null > Packages
+    # Push apt-repo/ to gh-pages branch or a dedicated apt-repo
+```
+
+This is a simplified example — for production APT repos with GPG signing use `reprepro` or Cloudsmith.
+
+### GPG Signing (Recommended for Production)
+
+Sign the Release file with a GPG key so `apt-get` can verify authenticity:
+
+1. Generate a signing keypair: `gpg --batch --gen-key gpg-params.txt`
+2. Export the public key and host it at a stable URL (e.g. GitHub Pages).
+3. Add `APT_SIGNING_KEY` as a repository secret.
+4. Tell users to run: `curl -fsSL https://OWNER.github.io/REPO/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/<your-cli-name>-keyring.gpg`
+
+## Important Notes
+
+- Only `linux/amd64` and `linux/arm64` targets are relevant for `.deb` packaging; exclude `darwin` and `windows` builds from the `nfpms` `builds` list if needed.
+- The `nfpms` `file_name_template` must produce unique filenames per architecture to avoid collisions in the GitHub Release assets.
+- The GitHub Releases path requires no extra infrastructure and is the recommended starting point.
+- Move to a hosted APT repo only when users request `apt install` support.
+
+## When to Apply
+
+- When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
+- When GoReleaser is already configured for binary releases.
+- When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/agents/common/publishing/content-brew.md
+++ b/agents/common/publishing/content-brew.md
@@ -1,0 +1,104 @@
+# Homebrew Tap Publishing Agent
+
+You are a publishing specialist for Homebrew tap distribution of CLI tools.
+
+## Goals
+
+- Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
+- Keep the Homebrew tap in sync with the GoReleaser publish workflow so users can install the CLI with `brew install`.
+- Use the same bump-and-tag pattern as the CLI publish workflow as the trigger.
+
+## Prerequisites
+
+This rule extends the Go CLI publishing rule. Complete the CLI publishing setup (`.goreleaser.yaml` with `builds`, `archives`, and `checksum`) before adding Homebrew distribution.
+
+## Setting Up the Tap Repository
+
+1. Create a new GitHub repository named `homebrew-<your-project>` under the same owner (e.g. `acme/homebrew-mycli`).
+2. Create a `Formula/` directory in the tap repo with a placeholder `.gitkeep` file (GoReleaser will create the real formula).
+3. Add repository description: "Homebrew tap for <your-project>".
+4. Keep the tap repo public so users can add it with `brew tap`.
+
+## GoReleaser `brews` Block
+
+Add a `brews` section to your `.goreleaser.yaml`:
+
+```yaml
+brews:
+  - name: <your-cli-name>
+    ids:
+      - <your-cli-name>       # must match the archive id in your builds section
+    homepage: https://github.com/OWNER/REPO
+    description: One-line description of what the CLI does.
+    license: MIT
+    repository:
+      owner: OWNER
+      name: homebrew-<your-cli-name>
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: github-actions[bot]
+      email: github-actions[bot]@users.noreply.github.com
+    directory: Formula
+    test: |
+      system "#{bin}/<your-cli-name>", "--help"
+```
+
+Replace `OWNER`, `REPO`, and `<your-cli-name>` with real values.
+
+### Required `test` Stanza
+
+Always include a `test` stanza that runs the binary with a flag that exits 0 (e.g. `--help` or `--version`). Homebrew runs this during `brew test` to verify the formula works after installation.
+
+### Formula `install` Method
+
+GoReleaser generates the `install` method automatically from the archive contents. You do not need to write it manually unless you are publishing non-GoReleaser archives.
+
+## Secret: `HOMEBREW_TAP_GITHUB_TOKEN`
+
+GoReleaser needs write access to the tap repo to commit the formula. Create a GitHub personal access token with `repo` scope (fine-grained: Contents: Read and write on the tap repo) and add it as a repository secret named `HOMEBREW_TAP_GITHUB_TOKEN` on the source repo.
+
+Add to your publish workflow env:
+
+```yaml
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+```
+
+## CI Workflow Addition
+
+In your `publish-cli.yml` GoReleaser step, ensure `HOMEBREW_TAP_GITHUB_TOKEN` is passed. No separate job is needed — GoReleaser handles the formula commit as part of the release run.
+
+## Telling Users About the Tap
+
+Add an installation section to `README.md`:
+
+```markdown
+## Installation
+
+### Homebrew (macOS and Linux)
+
+\`\`\`bash
+brew tap OWNER/homebrew-<your-cli-name>
+brew install <your-cli-name>
+\`\`\`
+
+### Direct download
+
+Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/releases).
+```
+
+## Important Notes
+
+- The tap repo must be public for `brew tap` to work without authentication.
+- The formula commit happens during the GoReleaser release step — if GoReleaser fails the formula is not updated.
+- Keep the `homebrew-` prefix on the tap repo name; Homebrew convention requires it so `brew tap OWNER/<cli-name>` resolves to `OWNER/homebrew-<cli-name>`.
+- Only include binary archives in the `ids` list for the `brews` block; exclude `.deb` or other non-archive artifacts.
+- GoReleaser will fail if the tap token is missing or lacks write access to the tap repo.
+
+## When to Apply
+
+- When the project ships a Go CLI and wants `brew install` support.
+- When GoReleaser is already configured for binary releases.
+- When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/agents/common/publishing/content-brew.md
+++ b/agents/common/publishing/content-brew.md
@@ -27,7 +27,7 @@ Add a `brews` section to your `.goreleaser.yaml`:
 brews:
   - name: <your-cli-name>
     ids:
-      - <your-cli-name>       # must match the archive id in your builds section
+      - <your-cli-name>       # must match the archive id in your archives section
     homepage: https://github.com/OWNER/REPO
     description: One-line description of what the CLI does.
     license: MIT

--- a/agents/common/publishing/content-cli.md
+++ b/agents/common/publishing/content-cli.md
@@ -169,7 +169,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.14.0'       # pin to an explicit version; check for the latest at github.com/goreleaser/goreleaser/releases
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/agents/common/publishing/content-cli.md
+++ b/agents/common/publishing/content-cli.md
@@ -1,0 +1,232 @@
+# CLI Publishing Agent
+
+You are a publishing specialist for CLI applications and command-line tools.
+
+## Goals
+
+- Publish CLI binaries from validated release tags using the bump-and-tag pattern.
+- Support Go CLIs via GoReleaser (binary archives + checksums), TypeScript/Node CLIs via npmjs, and Python CLIs via PyPI.
+- Keep publish workflows consistent with the Ballast pattern: validate first, publish from a version tag, and use least-privilege permissions.
+
+## Release Workflow Pattern
+
+Use the same bump-and-tag workflow structure as `publish.yml` in the Ballast repo:
+
+1. Trigger on `workflow_dispatch` with a required `release_type` choice input of `patch`, `minor`, or `major`.
+2. Add a `bump_and_tag` job that:
+   - fetches the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculates the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - selects the next version from the chosen `release_type`
+   - updates version files in the repository
+   - commits the version bump, creates a `v<version>` tag, and pushes both
+3. Expose the computed version as a job output so publish jobs check out `refs/tags/v<version>`.
+4. Add a `concurrency` block so two publishes for the same ref do not race:
+   ```yaml
+   concurrency:
+     group: ${{ github.workflow }}-${{ github.ref }}
+     cancel-in-progress: false
+   ```
+5. Run build and tests before publishing in every language job.
+6. Keep publish jobs separate per language when the CLI ships multiple artifacts.
+
+### Version and Tag Rules
+
+- Use `WyriHaximus/github-action-get-previous-tag@v2` to read the current tag.
+- Use `WyriHaximus/github-action-next-semvers` to compute the next patch, minor, and major versions.
+- Use `v`-prefixed tags such as `v1.8.0`.
+- The artifact version must match the created tag.
+- Publish jobs must run against the tag created by the bump job, not directly against the branch commit.
+
+## Go CLIs: GoReleaser
+
+For Go CLI apps, use GoReleaser to produce binary archives and checksums for GitHub Releases.
+
+### GoReleaser Config Template
+
+Create `.goreleaser.yaml` at the repository root or in the CLI subdirectory:
+
+```yaml
+version: 2
+
+project_name: <your-cli-name>
+
+release:
+  name_template: "<your-cli-name> v{{ .Version }}"
+
+builds:
+  - id: <your-cli-name>
+    binary: <your-cli-name>
+    main: .
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: <your-cli-name>
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: <your-cli-name>-checksums.txt
+```
+
+### CI Workflow Template (`publish-cli.yml`)
+
+```yaml
+name: Publish CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump_and_tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: prev_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+
+      - name: Compute next versions
+        id: next_semver
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.prev_tag.outputs.tag }}
+
+      - name: Select version
+        id: semver
+        run: |
+          case "${{ inputs.release_type }}" in
+            patch) echo "version=${{ steps.next_semver.outputs.patch }}" >> "$GITHUB_OUTPUT" ;;
+            minor) echo "version=${{ steps.next_semver.outputs.minor }}" >> "$GITHUB_OUTPUT" ;;
+            major) echo "version=${{ steps.next_semver.outputs.major }}" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Bump version file and tag
+        run: |
+          # Update your version file here, e.g.:
+          # sed -i "s/^version = .*/version = \"${{ steps.semver.outputs.version }}\"/" version.go
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore(release): bump version to ${{ steps.semver.outputs.version }} [skip ci]" || echo "Nothing to commit"
+          git tag "v${{ steps.semver.outputs.version }}"
+          git push origin HEAD --tags
+
+  publish_go:
+    needs: bump_and_tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.bump_and_tag.outputs.version }}
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Verify build
+        run: go build -o /tmp/<your-cli-name>-verify .
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Required Quality Gates
+
+- Pin GoReleaser to an explicit stable release version (e.g. `'v2.14.0'` not `'~> v2'`) for reproducible builds.
+- Verify the binary builds before running GoReleaser.
+- Run `go test ./...` before publish.
+- Use `CGO_ENABLED=0` for portable binaries.
+- Set distinct `checksum.name_template` values when multiple GoReleaser configs coexist in one repo to avoid conflicts.
+
+## TypeScript/Node CLIs: npmjs
+
+For Node CLI apps distributed through npmjs:
+
+- Ensure `package.json` has:
+  - `bin` entries for executables
+  - `files` or package contents narrowed to runtime assets
+  - `engines` with minimum supported Node version
+- Use npm trusted publishing via GitHub Actions OIDC (`id-token: write`).
+- In the publish job:
+  - check out `refs/tags/v<version>`
+  - install dependencies with the lockfile
+  - run build
+  - run tests
+  - publish with `npm publish --access public --provenance`
+- Verify the CLI starts from the packaged artifact before marking the release as complete.
+
+## Python CLIs: PyPI
+
+For Python CLI apps distributed through PyPI:
+
+- Define console entry points in `pyproject.toml` under `[project.scripts]`.
+- Use PyPI trusted publishing via GitHub Actions OIDC.
+- In the publish job:
+  - check out `refs/tags/v<version>`
+  - use `actions/setup-python` and `astral-sh/setup-uv` when the project uses `uv`
+  - build wheel and sdist
+  - run tests
+  - publish with `uv publish` or `pypa/gh-action-pypi-publish`
+- Grant `id-token: write` only to the publish job.
+
+## App-Specific Requirements
+
+- Smoke-test the installed CLI from the built artifact before publishing.
+- Keep installation instructions in `README.md` aligned with the actual release channel.
+- Publish checksums for downloadable binaries.
+- Ensure version output from the CLI (`<cli> --version`) matches the release tag.
+- Add a README badge for the publish workflow:
+  ```markdown
+  [![Release](https://github.com/OWNER/REPO/actions/workflows/publish-cli.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/publish-cli.yml)
+  ```
+
+## When to Apply
+
+- When a repository publishes a CLI or command-line tool for direct installation by end users.
+- When the CLI is written in Go, TypeScript/Node, or Python.
+- When the project needs a turn-key release workflow with semver bumping.

--- a/agents/common/publishing/content-web.md
+++ b/agents/common/publishing/content-web.md
@@ -47,7 +47,7 @@ jobs:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
+      image_tag: sha-${{ github.sha }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
@@ -98,6 +98,9 @@ jobs:
           repository: OWNER/helm-charts   # your Helm chart repo
           token: ${{ secrets.HELM_CHART_REPO_TOKEN }}
           path: helm-charts
+
+      - name: Install yq
+        uses: mikefarah/yq@v4
 
       - name: Update image digest in values.yaml
         run: |

--- a/agents/common/publishing/content-web.md
+++ b/agents/common/publishing/content-web.md
@@ -1,0 +1,176 @@
+# Web App Publishing Agent
+
+You are a publishing specialist for web applications deployed as Docker containers to Kubernetes.
+
+## Goals
+
+- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
+- Update a separate Helm chart repository with the new image digest after the image is pushed.
+- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+
+## Release Model
+
+Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+
+## Workflow Trigger and Concurrency
+
+```yaml
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+
+## CI Workflow Template (`deploy-web.yml`)
+
+```yaml
+name: Deploy Web
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write        # required for GHCR; remove for Docker Hub
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+      image_digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # For Docker Hub instead:
+      # - uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  update_helm_chart:
+    needs: build_and_push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Helm chart repo
+        uses: actions/checkout@v4
+        with:
+          repository: OWNER/helm-charts   # your Helm chart repo
+          token: ${{ secrets.HELM_CHART_REPO_TOKEN }}
+          path: helm-charts
+
+      - name: Update image digest in values.yaml
+        run: |
+          cd helm-charts
+          # Prefer digest pinning for immutable deploys
+          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
+          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
+          # Update the chart values — adjust yq path to match your chart structure
+          yq -i '.image.digest = strenv(IMAGE_DIGEST)' charts/<your-chart>/values.yaml
+          yq -i '.image.tag = strenv(IMAGE_TAG)' charts/<your-chart>/values.yaml
+
+      - name: Commit and push chart update
+        run: |
+          cd helm-charts
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git diff --staged --quiet && echo "No changes" && exit 0
+          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git push
+```
+
+## Container Registry Targets
+
+Choose one registry per deployment. Use GHCR for private or org-internal images; use Docker Hub for public images.
+
+### GHCR (`ghcr.io`)
+
+- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
+- Grant `packages: write` permission to the job.
+- Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
+
+### Docker Hub (`docker.io`)
+
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Remove the `packages: write` permission from the job.
+- Image URL: `docker.io/<namespace>/<image>`.
+
+## Helm Chart Update Rules
+
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Keep the `image.tag` field for human readability alongside the digest.
+- Do not overwrite unrelated chart values in the automation step.
+- If the chart repo is private, use a fine-grained PAT (`HELM_CHART_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- Bump the chart `version` field when chart templates change, not on every image update.
+
+## Required Secrets and Permissions
+
+| Secret | Required for |
+|--------|-------------|
+| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `DOCKERHUB_USERNAME` | Docker Hub push |
+| `DOCKERHUB_TOKEN` | Docker Hub push |
+| `HELM_CHART_REPO_TOKEN` | Helm chart repo write access |
+
+## README Badge
+
+Add a badge for the deploy workflow:
+
+```markdown
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+```
+
+## Important Notes
+
+- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
+- The Helm chart update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
+- Keep the application repo and Helm chart repo separate; do not mix chart release state into app commits.
+- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+
+## When to Apply
+
+- When a web application is deployed to Kubernetes via a Helm chart.
+- When every merge to `main` should trigger a new deployment.
+- When the team wants immutable image references in their Helm chart.

--- a/agents/common/publishing/templates/cursor-frontmatter-api.yaml
+++ b/agents/common/publishing/templates/cursor-frontmatter-api.yaml
@@ -1,0 +1,7 @@
+description: 'REST API publishing specialist - Docker CD with Kubernetes health probes and Helm chart update'
+alwaysApply: false
+globs:
+  - 'Dockerfile'
+  - '.github/workflows/**'
+  - 'charts/**'
+  - 'README*'

--- a/agents/common/publishing/templates/cursor-frontmatter-apt.yaml
+++ b/agents/common/publishing/templates/cursor-frontmatter-apt.yaml
@@ -1,0 +1,7 @@
+description: 'APT/deb package publishing specialist - GoReleaser nfpms and GitHub Releases'
+alwaysApply: false
+globs:
+  - '.goreleaser.yaml'
+  - '.github/workflows/**'
+  - '*.deb'
+  - 'README*'

--- a/agents/common/publishing/templates/cursor-frontmatter-brew.yaml
+++ b/agents/common/publishing/templates/cursor-frontmatter-brew.yaml
@@ -1,0 +1,7 @@
+description: 'Homebrew tap publishing specialist - GoReleaser brews block and tap repo setup'
+alwaysApply: false
+globs:
+  - '.goreleaser.yaml'
+  - '.github/workflows/**'
+  - 'Formula/**'
+  - 'README*'

--- a/agents/common/publishing/templates/cursor-frontmatter-cli.yaml
+++ b/agents/common/publishing/templates/cursor-frontmatter-cli.yaml
@@ -1,0 +1,10 @@
+description: 'CLI publishing specialist - GoReleaser for Go, npmjs for Node, PyPI for Python'
+alwaysApply: false
+globs:
+  - '.github/workflows/**'
+  - '.goreleaser.yaml'
+  - 'package.json'
+  - 'pyproject.toml'
+  - 'go.mod'
+  - 'README*'
+  - 'CHANGELOG*'

--- a/agents/common/publishing/templates/cursor-frontmatter-web.yaml
+++ b/agents/common/publishing/templates/cursor-frontmatter-web.yaml
@@ -1,0 +1,8 @@
+description: 'Web app publishing specialist - Docker to GHCR/Docker Hub with Helm chart CD on push to main'
+alwaysApply: false
+globs:
+  - 'Dockerfile'
+  - 'docker-compose*.yaml'
+  - '.github/workflows/**'
+  - 'charts/**'
+  - 'README*'

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -56,7 +56,12 @@ describe('build', () => {
       expect(listRuleSuffixes('publishing')).toContain('libraries');
       expect(listRuleSuffixes('publishing')).toContain('sdks');
       expect(listRuleSuffixes('publishing')).toContain('apps');
-      expect(listRuleSuffixes('publishing').length).toBe(3);
+      expect(listRuleSuffixes('publishing')).toContain('cli');
+      expect(listRuleSuffixes('publishing')).toContain('brew');
+      expect(listRuleSuffixes('publishing')).toContain('apt');
+      expect(listRuleSuffixes('publishing')).toContain('web');
+      expect(listRuleSuffixes('publishing')).toContain('api');
+      expect(listRuleSuffixes('publishing').length).toBe(8);
     });
 
     test('throws for unknown agent', () => {

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -1,4 +1,7 @@
-import { buildDoctorReport, formatDoctorReport } from './doctor';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildDoctorReport, detectAppType, formatDoctorReport } from './doctor';
 
 describe('doctor', () => {
   test('recommends upgrades for older CLIs and config', () => {
@@ -78,5 +81,145 @@ describe('doctor', () => {
       '- paths: typescript=apps/web; ansible=infra/ansible'
     );
     expect(output).toContain('- No action needed.');
+  });
+
+  test('includes detected app type in formatted output when known', () => {
+    const report = buildDoctorReport(
+      'ballast-typescript',
+      '5.0.2',
+      '/tmp/project/.rulesrc.json',
+      '5.0.2',
+      ['claude'],
+      ['publishing'],
+      [],
+      [],
+      {},
+      [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
+      'cli'
+    );
+    const output = formatDoctorReport(report);
+    expect(output).toContain('Detected app type: cli');
+  });
+
+  test('omits detected app type line when unknown', () => {
+    const report = buildDoctorReport(
+      'ballast-typescript',
+      '5.0.2',
+      null,
+      null,
+      [],
+      [],
+      [],
+      [],
+      {},
+      [],
+      'unknown'
+    );
+    const output = formatDoctorReport(report);
+    expect(output).not.toContain('Detected app type');
+  });
+
+  test('recommends adding publishing agent when app type known and agent missing', () => {
+    const report = buildDoctorReport(
+      'ballast-typescript',
+      '5.0.2',
+      '/tmp/project/.rulesrc.json',
+      '5.0.2',
+      ['claude'],
+      ['linting'],
+      [],
+      [],
+      {},
+      [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
+      'web'
+    );
+    expect(report.recommendations).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('add the publishing agent')
+      ])
+    );
+  });
+
+  test('does not recommend publishing agent when already installed', () => {
+    const report = buildDoctorReport(
+      'ballast-typescript',
+      '5.0.2',
+      '/tmp/project/.rulesrc.json',
+      '5.0.2',
+      ['claude'],
+      ['publishing'],
+      [],
+      [],
+      {},
+      [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
+      'api'
+    );
+    const publishingRecs = report.recommendations.filter((r) =>
+      r.includes('add the publishing agent')
+    );
+    expect(publishingRecs).toHaveLength(0);
+  });
+});
+
+describe('detectAppType', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballast-doctor-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('detects cli from .goreleaser.yaml', () => {
+    fs.writeFileSync(path.join(tmpDir, '.goreleaser.yaml'), 'version: 2\n');
+    expect(detectAppType(tmpDir)).toBe('cli');
+  });
+
+  test('detects cli from package.json with bin field', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'mycli', bin: { mycli: './dist/index.js' } })
+    );
+    expect(detectAppType(tmpDir)).toBe('cli');
+  });
+
+  test('detects web from Dockerfile with next.config.js', () => {
+    fs.writeFileSync(path.join(tmpDir, 'Dockerfile'), 'FROM node\n');
+    fs.writeFileSync(
+      path.join(tmpDir, 'next.config.js'),
+      'module.exports = {};\n'
+    );
+    expect(detectAppType(tmpDir)).toBe('web');
+  });
+
+  test('detects api from Dockerfile with go.mod', () => {
+    fs.writeFileSync(path.join(tmpDir, 'Dockerfile'), 'FROM golang\n');
+    fs.writeFileSync(path.join(tmpDir, 'go.mod'), 'module example.com/myapi\n');
+    expect(detectAppType(tmpDir)).toBe('api');
+  });
+
+  test('detects library from package.json without bin or Dockerfile', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'mylib', version: '1.0.0' })
+    );
+    expect(detectAppType(tmpDir)).toBe('library');
+  });
+
+  test('detects library from go.mod without Dockerfile', () => {
+    fs.writeFileSync(path.join(tmpDir, 'go.mod'), 'module example.com/mylib\n');
+    expect(detectAppType(tmpDir)).toBe('library');
+  });
+
+  test('returns unknown for empty directory', () => {
+    expect(detectAppType(tmpDir)).toBe('unknown');
+  });
+
+  test('prefers cli over web when both .goreleaser.yaml and Dockerfile present', () => {
+    fs.writeFileSync(path.join(tmpDir, '.goreleaser.yaml'), 'version: 2\n');
+    fs.writeFileSync(path.join(tmpDir, 'Dockerfile'), 'FROM golang\n');
+    expect(detectAppType(tmpDir)).toBe('cli');
   });
 });

--- a/packages/ballast-typescript/src/doctor.ts
+++ b/packages/ballast-typescript/src/doctor.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import fs from 'fs';
 import path from 'path';
 import { findProjectRoot, getRulesrcFilename, loadConfig } from './config';
 import { BALLAST_VERSION } from './version';
@@ -8,6 +9,8 @@ export interface InstalledCliStatus {
   version: string | null;
   path: string | null;
 }
+
+export type AppType = 'cli' | 'web' | 'api' | 'library' | 'sdk' | 'unknown';
 
 export interface DoctorReport {
   currentCli: string;
@@ -20,6 +23,7 @@ export interface DoctorReport {
   configLanguages: string[];
   configPaths: Record<string, string[]>;
   installed: InstalledCliStatus[];
+  detectedAppType: AppType;
   recommendations: string[];
 }
 
@@ -78,6 +82,107 @@ function detectInstalledCli(name: string): InstalledCliStatus {
   };
 }
 
+function fileExists(dir: string, ...names: string[]): boolean {
+  return names.some((name) => fs.existsSync(path.join(dir, name)));
+}
+
+function hasPackageJsonBin(dir: string): boolean {
+  const pkgPath = path.join(dir, 'package.json');
+  if (!fs.existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as {
+      bin?: unknown;
+    };
+    return (
+      pkg.bin !== null &&
+      pkg.bin !== undefined &&
+      typeof pkg.bin !== 'undefined' &&
+      !(
+        typeof pkg.bin === 'object' &&
+        Object.keys(pkg.bin as object).length === 0
+      )
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasFrontendIndicators(dir: string): boolean {
+  return fileExists(
+    dir,
+    'next.config.js',
+    'next.config.ts',
+    'next.config.mjs',
+    'vite.config.js',
+    'vite.config.ts',
+    'vite.config.mjs',
+    'nuxt.config.js',
+    'nuxt.config.ts',
+    'svelte.config.js',
+    'remix.config.js'
+  );
+}
+
+function hasApiIndicators(dir: string): boolean {
+  return (
+    fileExists(dir, 'go.mod', 'pyproject.toml') ||
+    fileExists(dir, 'routes', 'handlers', 'api', 'server') ||
+    fileExists(dir, 'app.ts', 'server.ts', 'main.go', 'app.py', 'main.py')
+  );
+}
+
+/**
+ * Heuristically detect the app type from filesystem markers in the project root.
+ * Returns the most specific match; falls back to 'unknown'.
+ */
+export function detectAppType(projectRoot: string): AppType {
+  const hasDockerfile = fileExists(projectRoot, 'Dockerfile');
+  const hasGoReleaser = fileExists(
+    projectRoot,
+    '.goreleaser.yaml',
+    '.goreleaser.yml'
+  );
+  const hasPackageJson = fileExists(projectRoot, 'package.json');
+  const hasBin = hasPackageJsonBin(projectRoot);
+
+  // CLI indicators: GoReleaser config or package.json with bin entries
+  if (hasGoReleaser || hasBin) {
+    return 'cli';
+  }
+
+  // Container-deployed apps require a Dockerfile
+  if (hasDockerfile) {
+    if (hasFrontendIndicators(projectRoot)) {
+      return 'web';
+    }
+    if (hasApiIndicators(projectRoot)) {
+      return 'api';
+    }
+    // Dockerfile present but no clear frontend or API markers — default to web
+    return 'web';
+  }
+
+  // Library / SDK indicators: package.json, go.mod, or pyproject.toml without Dockerfile or bin
+  if (
+    hasPackageJson ||
+    fileExists(projectRoot, 'go.mod') ||
+    fileExists(projectRoot, 'pyproject.toml')
+  ) {
+    return 'library';
+  }
+
+  return 'unknown';
+}
+
+const APP_TYPE_PUBLISH_RULE: Record<AppType, string | null> = {
+  cli: 'publishing-cli',
+  web: 'publishing-web',
+  api: 'publishing-api',
+  library: 'publishing-libraries',
+  sdk: 'publishing-sdks',
+  unknown: null
+};
+
 function refreshConfigCommand(
   report: Pick<
     DoctorReport,
@@ -98,7 +203,8 @@ export function buildDoctorReport(
   configSkills: string[],
   configLanguages: string[],
   configPaths: Record<string, string[]>,
-  installed: InstalledCliStatus[]
+  installed: InstalledCliStatus[],
+  detectedAppType: AppType = 'unknown'
 ): DoctorReport {
   const targetVersion = latestVersion([
     currentVersion,
@@ -141,6 +247,13 @@ export function buildDoctorReport(
     );
   }
 
+  const suggestedRule = APP_TYPE_PUBLISH_RULE[detectedAppType];
+  if (suggestedRule && configPath && !configAgents.includes('publishing')) {
+    recommendations.push(
+      `Detected app type: ${detectedAppType} — add the publishing agent: ballast install --agents publishing`
+    );
+  }
+
   return {
     currentCli,
     currentVersion,
@@ -152,6 +265,7 @@ export function buildDoctorReport(
     configLanguages,
     configPaths,
     installed,
+    detectedAppType,
     recommendations
   };
 }
@@ -189,6 +303,10 @@ export function formatDoctorReport(report: DoctorReport): string {
       continue;
     }
     lines.push(`- ${item.name}: ${item.version ?? 'unknown'} (${item.path})`);
+  }
+
+  if (report.detectedAppType !== 'unknown') {
+    lines.push('', `Detected app type: ${report.detectedAppType}`);
   }
 
   lines.push('', 'Config:');
@@ -244,7 +362,8 @@ export function runDoctor(): number {
     config?.skills ?? [],
     config?.languages ?? [],
     config?.paths ?? {},
-    CLI_NAMES.map((name) => detectInstalledCli(name))
+    CLI_NAMES.map((name) => detectInstalledCli(name)),
+    detectAppType(projectRoot)
   );
   process.stdout.write(formatDoctorReport(report));
   return 0;

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -910,7 +910,7 @@ Keep my custom responsibilities.
         saveConfig: false
       });
       expect(result.installed).toEqual(['publishing']);
-      expect(result.installedRules.length).toBe(3);
+      expect(result.installedRules.length).toBe(8);
       const librariesFile = path.join(
         tmpDir,
         '.cursor',
@@ -929,9 +929,30 @@ Keep my custom responsibilities.
         'rules',
         'publishing-apps.mdc'
       );
+      const cliFile = path.join(
+        tmpDir,
+        '.cursor',
+        'rules',
+        'publishing-cli.mdc'
+      );
+      const webFile = path.join(
+        tmpDir,
+        '.cursor',
+        'rules',
+        'publishing-web.mdc'
+      );
+      const apiFile = path.join(
+        tmpDir,
+        '.cursor',
+        'rules',
+        'publishing-api.mdc'
+      );
       expect(fs.existsSync(librariesFile)).toBe(true);
       expect(fs.existsSync(sdksFile)).toBe(true);
       expect(fs.existsSync(appsFile)).toBe(true);
+      expect(fs.existsSync(cliFile)).toBe(true);
+      expect(fs.existsSync(webFile)).toBe(true);
+      expect(fs.existsSync(apiFile)).toBe(true);
       expect(fs.readFileSync(librariesFile, 'utf8')).toContain(
         'Publishing Libraries Agent'
       );


### PR DESCRIPTION
$(cat <<'EOF'
Closes #148

## Summary

- Adds 5 new publishing agent content rules covering all app types: CLI, Homebrew tap, APT/deb, web apps, and REST APIs
- Enhances `ballast doctor` to heuristically detect the project's app type and recommend adding the publishing agent when missing

## New publishing rules

| Rule | Description |
|------|-------------|
| `publishing-cli` | Go (GoReleaser), TypeScript/npm, Python/PyPI CLIs — full `publish-cli.yml` workflow with `bump_and_tag` → per-language publish job chain |
| `publishing-brew` | Homebrew tap publishing via GoReleaser `brews` block; documents `HOMEBREW_TAP_GITHUB_TOKEN` setup |
| `publishing-apt` | APT/deb packaging via GoReleaser `nfpms`; covers GitHub Releases (simple) and optional GitHub Pages APT repo (advanced) |
| `publishing-web` | Web app CD: Docker image → GHCR or Docker Hub → Helm chart update; triggered on push to `main` |
| `publishing-api` | REST API CD: extends web app model with health endpoint patterns (`/healthz`, `/readyz`) and Kubernetes `livenessProbe`/`readinessProbe` templates |

Each rule includes cursor frontmatter with appropriate `globs`.

## Doctor enhancements

- New `AppType` type (`cli | web | api | library | sdk | unknown`) exported from `doctor.ts`
- New `detectAppType(projectRoot)` function using filesystem markers:
  - `.goreleaser.yaml` or `package.json` with `bin` → `cli`
  - `Dockerfile` + frontend config (Next.js, Vite, etc.) → `web`
  - `Dockerfile` + API indicators (`go.mod`, `routes/`, etc.) → `api`
  - `Dockerfile` alone → `web`
  - `package.json` / `go.mod` / `pyproject.toml` without Dockerfile → `library`
- `DoctorReport` extended with `detectedAppType` field
- Doctor now recommends `ballast install --agents publishing` when app type is known but publishing agent not yet configured
- Formatted report shows `Detected app type: X` line when type is known

## Test plan

- [ ] `pnpm test` passes (210 tests) in `packages/ballast-typescript`
- [ ] `build.test.ts`: publishing suffix count updated 3 → 8 with assertions for all new suffixes
- [ ] `install.test.ts`: installed rules count updated 3 → 8 with file existence checks for `cli`, `web`, `api`
- [ ] `doctor.test.ts`: 4 new report tests + 8 `detectAppType` filesystem heuristic tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)