### PR TITLE
Fix Dependabot TypeScript ESLint grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,13 +28,14 @@ updates:
           - 'eslint*'
           - '@eslint/*'
           - '@typescript-eslint/*'
+          - 'typescript-eslint'
       prettier:
         patterns:
           - 'prettier*'
           - 'eslint-*-prettier'
       typescript:
         patterns:
-          - 'typescript*'
+          - 'typescript'
       jest:
         patterns:
           - 'jest*'


### PR DESCRIPTION
## Summary
- keep the unscoped `typescript-eslint` package in the ESLint Dependabot group with `@typescript-eslint/*`
- narrow the TypeScript Dependabot group to the exact `typescript` compiler package
- prevents duplicate Dependabot PRs from acting on `packages/ballast-typescript/package.json` and `pnpm-lock.yaml` for the same upstream typescript-eslint release

## Root Cause
The open Dependabot PRs split related packages across two groups:
- PR #155: `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` matched the `eslint` group
- PR #156: `typescript-eslint` matched the broad `typescript*` group

Both PRs therefore touched the same package directory and root lockfile.

## PRD
No PRD update: this is a repository automation configuration fix with no product, CLI, API, or operator workflow contract change.

## Verification
- pre-commit YAML checks passed during commit
- pre-push unit test hook passed during push
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'` passed
- `git diff --check` passed

`pnpm exec prettier .github/dependabot.yml --check` could not run locally because dependencies are not installed in the workspace and `.npmrc` references an unset `GITHUB_TOKEN`.