### PR TITLE
Add skill patching and support file force confirmation

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -12,7 +12,7 @@ Ballast does not apply the same overwrite decision matrix to installed skill fil
 2. `--patch` must merge canonical skill content into an existing skill file using the existing patch logic for the selected target.
 3. `--force` must overwrite an existing skill file without patching.
 4. `--force` must prompt before replacing an existing support file (`AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`) that would lose user customizations.
-5. In non-interactive mode (`--yes`, CI, or non-TTY stdin), an attempted `--force` overwrite of an existing support file must fail with a clear error telling the operator to rerun interactively.
+5. In non-interactive mode (`--yes` or CI environment variables), an attempted `--force` overwrite of an existing support file must fail with a clear error telling the operator to rerun interactively without `--yes`.
 6. Creating a missing support file with `--force` must continue without prompting.
 7. Support-file patch behavior and existing agent-rule overwrite semantics must remain unchanged.
 8. README and installation documentation must describe the updated `--patch` and `--force` behavior.

--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,34 @@
 # Product Requirements
 
+## Skill Patch Support And Support File Force Confirmation
+
+### Problem
+
+Ballast does not apply the same overwrite decision matrix to installed skill files that it applies to agent rule files, and `--force` can silently replace support files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`. Operators need a safe way to merge upstream skill updates without discarding local edits, and destructive support-file overwrites must require explicit confirmation.
+
+### Requirements
+
+1. Existing installed skill files must follow the same force/patch/skip decision matrix as agent rule files across the TypeScript, Python, Go, and wrapper install paths.
+2. `--patch` must merge canonical skill content into an existing skill file using the existing patch logic for the selected target.
+3. `--force` must overwrite an existing skill file without patching.
+4. `--force` must prompt before replacing an existing support file (`AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`) that would lose user customizations.
+5. In non-interactive mode (`--yes`, CI, or non-TTY stdin), an attempted `--force` overwrite of an existing support file must fail with a clear error telling the operator to rerun interactively.
+6. Creating a missing support file with `--force` must continue without prompting.
+7. Support-file patch behavior and existing agent-rule overwrite semantics must remain unchanged.
+8. README and installation documentation must describe the updated `--patch` and `--force` behavior.
+
+### Acceptance Criteria
+
+1. Given an existing skill file and `force=false, patch=false`, install skips the file and leaves the existing content unchanged.
+2. Given a missing skill file and `force=false, patch=true`, install creates the file with canonical content.
+3. Given an existing skill file and `force=false, patch=true`, install merges canonical content into the existing file and preserves user-managed sections supported by the patcher.
+4. Given an existing skill file and `force=true`, install overwrites the file with canonical content.
+5. Given an existing support file and interactive `--force`, answering no skips the support file and prints a clear notice.
+6. Given an existing support file and interactive `--force`, answering yes overwrites the support file with canonical content.
+7. Given an existing support file and non-interactive `--force`, install exits with an error and does not overwrite the file.
+8. Automated tests cover the skill-file decision matrix and support-file confirmation behavior in the TypeScript, Python, and Go backends.
+9. README and `docs/installation.md` describe when to use `--patch` versus `--force`, including the support-file confirmation behavior.
+
 ## Ballast Upgrade Skill Refresh
 
 ### Problem

--- a/README.md
+++ b/README.md
@@ -294,7 +294,11 @@ Recommended order for one repository that uses all five language profiles:
 4. If the repo also contains Ansible, run `ballast-go install --language ansible --target cursor --all`.
 5. If the repo also contains Terraform, run `ballast-go install --language terraform --target cursor --all`.
 
-Ballast only installs shipped agents and skills and follows the single overwrite policy (existing rule files are preserved unless `--force` is passed). Use `--patch` to merge new Ballast content into an existing rule file while preserving the user's version of edited sections.
+Ballast only installs shipped agents and skills and follows the single overwrite policy: existing rule and skill files are preserved unless you explicitly choose `--patch` or `--force`.
+
+Use `--patch` when you want to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
+
+Use `--force` when you want to reset a managed rule or skill file to canonical Ballast content. When `AGENTS.md` or `CLAUDE.md` already exists, `--force` prompts before overwriting it; in non-interactive mode (`--yes` or CI), Ballast aborts instead of replacing the support file silently.
 
 ## CLI Flags
 
@@ -304,8 +308,8 @@ Ballast only installs shipped agents and skills and follows the single overwrite
 - `--skill, -s`: comma-separated skill list
 - `--all`: install all agents for the selected language
 - `--all-skills`: install all available skills for the selected language
-- `--force, -f`: overwrite existing rule files
-- `--patch, -p`: merge upstream rule updates into existing rule files while preserving user-edited sections (`--force` wins if both are set)
+- `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files such as `AGENTS.md` and `CLAUDE.md`
+- `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
 ## Wrapper Commands

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Ballast only installs shipped agents and skills and follows the single overwrite
 
 Use `--patch` when you want to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
 
-Use `--force` when you want to reset a managed rule or skill file to canonical Ballast content. When `AGENTS.md` or `CLAUDE.md` already exists, `--force` prompts before overwriting it; in non-interactive mode (`--yes` or CI), Ballast aborts instead of replacing the support file silently.
+Use `--force` when you want to reset a managed rule or skill file to canonical Ballast content. When `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md` already exists, `--force` prompts before overwriting it; in non-interactive mode (`--yes` or CI), Ballast aborts instead of replacing the support file silently.
 
 ## CLI Flags
 
@@ -308,7 +308,7 @@ Use `--force` when you want to reset a managed rule or skill file to canonical B
 - `--skill, -s`: comma-separated skill list
 - `--all`: install all agents for the selected language
 - `--all-skills`: install all available skills for the selected language
-- `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files such as `AGENTS.md` and `CLAUDE.md`
+- `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -184,7 +184,11 @@ uvx --from "https://github.com/everydaydevopsio/ballast/releases/download/v${VER
 ballast-go install --target cursor --all
 ```
 
-Ballast preserves existing rule and skill files unless `--force` is provided. Use `--patch` to merge upstream Ballast updates into an existing rule file while preserving the user's edited sections.
+Ballast preserves existing rule and skill files unless you explicitly choose `--patch` or `--force`.
+
+Use `--patch` to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
+
+Use `--force` to reset a managed rule or skill file to canonical Ballast content. When `AGENTS.md`, `CLAUDE.md`, or `GEMINI.md` already exists, Ballast prompts before overwriting it; in non-interactive mode (`--yes` or CI), Ballast aborts instead of replacing the support file silently.
 
 For single-language TypeScript installs, the `git-hooks` rules should use `pre-commit` instead of Husky and add unit tests to the `pre-push` stage.
 
@@ -196,8 +200,8 @@ For single-language TypeScript installs, the `git-hooks` rules should use `pre-c
 - `--skill, -s`: comma-separated list
 - `--all`: install all available agents
 - `--all-skills`: install all available skills
-- `--force, -f`: overwrite existing files
-- `--patch, -p`: merge upstream rule updates into existing files while preserving user-edited sections (`--force` wins if both are set)
+- `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files
+- `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
 ## Wrapper Commands

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -87,13 +87,14 @@ type rawRulesConfig struct {
 }
 
 type installResult struct {
-	installed           []string
-	installedRules      []installedRule
-	installedSkills     []string
-	installedSupport    []string
-	skipped             []string
-	skippedSupportFiles []string
-	errors              []agentError
+	installed            []string
+	installedRules       []installedRule
+	installedSkills      []string
+	installedSupport     []string
+	skipped              []string
+	skippedSupportFiles  []string
+	declinedSupportFiles []string
+	errors               []agentError
 }
 
 type installedRule struct {
@@ -354,6 +355,12 @@ func runInstall(args []string) int {
 		fmt.Printf(
 			"Skipped support files (already present; use --force to overwrite): %s\n",
 			strings.Join(result.skippedSupportFiles, ", "),
+		)
+	}
+	if len(result.declinedSupportFiles) > 0 {
+		fmt.Printf(
+			"Skipped support files (overwrite declined): %s\n",
+			strings.Join(result.declinedSupportFiles, ", "),
 		)
 	}
 	if len(result.installed) == 0 && len(result.installedSkills) == 0 && len(result.skipped) == 0 && len(result.errors) == 0 {
@@ -932,8 +939,8 @@ func install(opts installOptions) installResult {
 		if target == "codex" && !disableSupportFiles {
 			agentsPath := codexAgentsMDPath(opts.projectRoot)
 			if _, skipped := opts.skipSupport[agentsPath]; skipped {
-				if !contains(result.skippedSupportFiles, agentsPath) {
-					result.skippedSupportFiles = append(result.skippedSupportFiles, agentsPath)
+				if !contains(result.declinedSupportFiles, agentsPath) {
+					result.declinedSupportFiles = append(result.declinedSupportFiles, agentsPath)
 				}
 			} else if exists(agentsPath) && !opts.force && !opts.patch {
 				if !contains(result.skippedSupportFiles, agentsPath) {
@@ -966,8 +973,8 @@ func install(opts installOptions) installResult {
 			claudePath := claudeMDPath(opts.projectRoot)
 			shouldPatchClaude := opts.patch || opts.patchClaude
 			if _, skipped := opts.skipSupport[claudePath]; skipped {
-				if !contains(result.skippedSupportFiles, claudePath) {
-					result.skippedSupportFiles = append(result.skippedSupportFiles, claudePath)
+				if !contains(result.declinedSupportFiles, claudePath) {
+					result.declinedSupportFiles = append(result.declinedSupportFiles, claudePath)
 				}
 			} else if exists(claudePath) && !opts.force && !shouldPatchClaude {
 				if !contains(result.skippedSupportFiles, claudePath) {

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -276,6 +276,9 @@ func runInstall(args []string) int {
 		if supportPath == "" || !*force || !exists(supportPath) {
 			continue
 		}
+		if os.Getenv("BALLAST_DISABLE_SUPPORT_FILES") == "1" {
+			continue
+		}
 		if *yes || isCIMode() {
 			fmt.Printf("Cannot overwrite existing support file %s in non-interactive mode. Re-run interactively without --yes to confirm the destructive overwrite.\n", filepath.Base(supportPath))
 			return 1

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -126,6 +127,7 @@ type installOptions struct {
 	force       bool
 	patch       bool
 	patchClaude bool
+	skipSupport map[string]struct{}
 	saveConfig  bool
 }
 
@@ -193,9 +195,9 @@ func runInstall(args []string) int {
 	fs.StringVar(skill, "s", "", "comma-separated list")
 	all := fs.Bool("all", false, "install all agents")
 	allSkills := fs.Bool("all-skills", false, "install all skills")
-	force := fs.Bool("force", false, "overwrite files")
-	patch := fs.Bool("patch", false, "merge upstream updates into existing files")
-	fs.BoolVar(patch, "p", false, "merge upstream updates into existing files")
+	force := fs.Bool("force", false, "overwrite existing rule and skill files; prompts before replacing support files")
+	patch := fs.Bool("patch", false, "merge upstream rule and skill updates into existing files")
+	fs.BoolVar(patch, "p", false, "merge upstream rule and skill updates into existing files")
 	yes := fs.Bool("yes", false, "non-interactive mode")
 	fs.BoolVar(yes, "y", false, "non-interactive mode")
 	if err := fs.Parse(trimCommand(args)); err != nil {
@@ -267,6 +269,32 @@ func runInstall(args []string) int {
 			break
 		}
 	}
+	skippedSupport := map[string]struct{}{}
+	for _, target := range resolved.Targets {
+		supportPath := supportFilePath(root, target)
+		if supportPath == "" || !*force || !exists(supportPath) {
+			continue
+		}
+		if *yes || isCIMode() {
+			fmt.Printf("Cannot overwrite existing support file %s in non-interactive mode. Re-run interactively without --yes to confirm the destructive overwrite.\n", filepath.Base(supportPath))
+			return 1
+		}
+		approved, promptErr := promptYesNo(
+			fmt.Sprintf(
+				"\n⚠️  %s already exists and may contain your customizations.\n    --force will replace it with the canonical template.\n    Your current file will be lost.\n\n    Continue?",
+				filepath.Base(supportPath),
+			),
+			false,
+		)
+		if promptErr != nil {
+			fmt.Println(promptErr)
+			return 1
+		}
+		if !approved {
+			skippedSupport[supportPath] = struct{}{}
+			fmt.Printf("Skipped support file: %s (%s)\n", filepath.Base(supportPath), supportPath)
+		}
+	}
 	result := install(installOptions{
 		projectRoot: root,
 		targets:     resolved.Targets,
@@ -276,6 +304,7 @@ func runInstall(args []string) int {
 		force:       *force,
 		patch:       *patch,
 		patchClaude: patchClaude,
+		skipSupport: skippedSupport,
 		saveConfig:  true,
 	})
 
@@ -334,6 +363,17 @@ func runInstall(args []string) int {
 	return 0
 }
 
+func supportFilePath(projectRoot, target string) string {
+	switch target {
+	case "codex":
+		return codexAgentsMDPath(projectRoot)
+	case "claude":
+		return claudeMDPath(projectRoot)
+	default:
+		return ""
+	}
+}
+
 func printHelp() {
 	fmt.Printf(`
 ballast-go v%s
@@ -351,8 +391,8 @@ Options:
   --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check (comma-separated)
   --all                     Install all agents
   --all-skills              Install all skills
-  --force                   Overwrite existing rule files
-  --patch, -p               Merge upstream rule updates into existing files; ignored when --force is set
+  --force                   Overwrite existing rule/skill files; prompts before replacing AGENTS.md or CLAUDE.md
+  --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
   --help, -h                Show this help
   --version, -v             Show version
@@ -819,6 +859,9 @@ func install(opts installOptions) installResult {
 				result.errors = append(result.errors, agentError{agent: skillID, err: err.Error()})
 				continue
 			}
+			if exists(file) && !opts.force && !opts.patch {
+				continue
+			}
 			switch target {
 			case "cursor":
 				content, buildErr := buildCursorSkillFormat(skillID, opts.language)
@@ -826,9 +869,32 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: skillID, err: buildErr.Error()})
 					continue
 				}
-				err = os.WriteFile(file, []byte(content), 0o644)
+				nextContent := content
+				if exists(file) && !opts.force && opts.patch {
+					existing, readErr := os.ReadFile(file)
+					if readErr != nil {
+						result.errors = append(result.errors, agentError{agent: skillID, err: readErr.Error()})
+						continue
+					}
+					nextContent = patchRuleContent(string(existing), content, target)
+				}
+				err = os.WriteFile(file, []byte(nextContent), 0o644)
 			case "claude":
-				content, buildErr := buildClaudeSkill(skillID, opts.language)
+				skillContent, readErr := readSkillContent(skillID, opts.language)
+				if readErr != nil {
+					result.errors = append(result.errors, agentError{agent: skillID, err: readErr.Error()})
+					continue
+				}
+				nextContent := skillContent
+				if exists(file) && !opts.force && opts.patch {
+					existing, readErr := readClaudeSkillContent(file)
+					if readErr != nil {
+						result.errors = append(result.errors, agentError{agent: skillID, err: readErr.Error()})
+						continue
+					}
+					nextContent = patchRuleContent(existing, skillContent, target)
+				}
+				content, buildErr := buildClaudeSkill(skillID, opts.language, nextContent)
 				if buildErr != nil {
 					result.errors = append(result.errors, agentError{agent: skillID, err: buildErr.Error()})
 					continue
@@ -840,7 +906,16 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: skillID, err: buildErr.Error()})
 					continue
 				}
-				err = os.WriteFile(file, []byte(content), 0o644)
+				nextContent := content
+				if exists(file) && !opts.force && opts.patch {
+					existing, readErr := os.ReadFile(file)
+					if readErr != nil {
+						result.errors = append(result.errors, agentError{agent: skillID, err: readErr.Error()})
+						continue
+					}
+					nextContent = patchRuleContent(string(existing), content, target)
+				}
+				err = os.WriteFile(file, []byte(nextContent), 0o644)
 			default:
 				err = fmt.Errorf("unknown target: %s", target)
 			}
@@ -856,7 +931,11 @@ func install(opts installOptions) installResult {
 
 		if target == "codex" && !disableSupportFiles {
 			agentsPath := codexAgentsMDPath(opts.projectRoot)
-			if exists(agentsPath) && !opts.force && !opts.patch {
+			if _, skipped := opts.skipSupport[agentsPath]; skipped {
+				if !contains(result.skippedSupportFiles, agentsPath) {
+					result.skippedSupportFiles = append(result.skippedSupportFiles, agentsPath)
+				}
+			} else if exists(agentsPath) && !opts.force && !opts.patch {
 				if !contains(result.skippedSupportFiles, agentsPath) {
 					result.skippedSupportFiles = append(result.skippedSupportFiles, agentsPath)
 				}
@@ -886,7 +965,11 @@ func install(opts installOptions) installResult {
 		if target == "claude" && !disableSupportFiles {
 			claudePath := claudeMDPath(opts.projectRoot)
 			shouldPatchClaude := opts.patch || opts.patchClaude
-			if exists(claudePath) && !opts.force && !shouldPatchClaude {
+			if _, skipped := opts.skipSupport[claudePath]; skipped {
+				if !contains(result.skippedSupportFiles, claudePath) {
+					result.skippedSupportFiles = append(result.skippedSupportFiles, claudePath)
+				}
+			} else if exists(claudePath) && !opts.force && !shouldPatchClaude {
 				if !contains(result.skippedSupportFiles, claudePath) {
 					result.skippedSupportFiles = append(result.skippedSupportFiles, claudePath)
 				}
@@ -1181,10 +1264,16 @@ func buildSkillMarkdown(skillID, language string) (string, error) {
 	return strings.TrimRight(body, "\n") + "\n", nil
 }
 
-func buildClaudeSkill(skillID, language string) ([]byte, error) {
-	content, err := readSkillContent(skillID, language)
-	if err != nil {
-		return nil, err
+func buildClaudeSkill(skillID, language string, skillContent ...string) ([]byte, error) {
+	content := ""
+	if len(skillContent) > 0 {
+		content = skillContent[0]
+	} else {
+		var err error
+		content, err = readSkillContent(skillID, language)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var buffer bytes.Buffer
 	archive := zip.NewWriter(&buffer)
@@ -1247,6 +1336,33 @@ func buildClaudeSkill(skillID, language string) ([]byte, error) {
 		return nil, err
 	}
 	return buffer.Bytes(), nil
+}
+
+func readClaudeSkillContent(archivePath string) (string, error) {
+	content, err := os.ReadFile(archivePath)
+	if err != nil {
+		return "", err
+	}
+	reader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+	if err != nil {
+		return "", err
+	}
+	for _, file := range reader.File {
+		if file.Name != "SKILL.md" {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return "", err
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+	return "", fmt.Errorf("skill archive missing SKILL.md")
 }
 
 func normalizeLineEndings(content string) string {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -958,6 +958,48 @@ Keep team-specific usage notes.
 	}
 }
 
+func TestInstallPatchMergesClaudeSkillArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".claude", "skills", "owasp-security-scan.skill")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	existingSkillContent := "# owasp-security-scan\n\nTeam intro preserved by patch.\n\n## Team Custom Section\n\nKeep this team-specific section.\n"
+	initialArchive, err := buildClaudeSkill("owasp-security-scan", "go", existingSkillContent)
+	if err != nil {
+		t.Fatalf("build initial skill archive: %v", err)
+	}
+	if err := os.WriteFile(skillPath, initialArchive, 0o644); err != nil {
+		t.Fatalf("seed skill archive: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"claude"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       false,
+		patch:       true,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected patched skill install, got %+v", result.installedSkills)
+	}
+	skillMd, err := readClaudeSkillContent(skillPath)
+	if err != nil {
+		t.Fatalf("read merged skill archive: %v", err)
+	}
+	if !strings.Contains(skillMd, "Team intro preserved by patch.") {
+		t.Fatalf("expected user intro to remain: %s", skillMd)
+	}
+	if !strings.Contains(skillMd, "Team Custom Section") {
+		t.Fatalf("expected custom section to remain: %s", skillMd)
+	}
+	if !strings.Contains(skillMd, "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content to be merged: %s", skillMd)
+	}
+}
+
 func TestInstallForceOverwritesExistingSkill(t *testing.T) {
 	tmpDir := t.TempDir()
 	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")
@@ -1042,6 +1084,10 @@ func TestRunInstallWritesSharedRulesrcForMultipleTargets(t *testing.T) {
 }
 
 func TestRunInstallForceSupportFileDeclinedSkipsFile(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("TF_BUILD", "")
 	tmpDir := t.TempDir()
 	originalWD, err := os.Getwd()
 	if err != nil {
@@ -1098,6 +1144,10 @@ func TestRunInstallForceSupportFileDeclinedSkipsFile(t *testing.T) {
 }
 
 func TestRunInstallForceSupportFileAcceptedOverwritesFile(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("TF_BUILD", "")
 	tmpDir := t.TempDir()
 	originalWD, err := os.Getwd()
 	if err != nil {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -1000,6 +1000,48 @@ func TestInstallPatchMergesClaudeSkillArchive(t *testing.T) {
 	}
 }
 
+func TestInstallForceOverwritesExistingClaudeSkillArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".claude", "skills", "owasp-security-scan.skill")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	existingSkillContent := "# owasp-security-scan\n\nTeam-only intro that should be removed on force.\n\n## Team Custom Section\n\nThis section should not survive a force overwrite.\n"
+	initialArchive, err := buildClaudeSkill("owasp-security-scan", "go", existingSkillContent)
+	if err != nil {
+		t.Fatalf("build initial skill archive: %v", err)
+	}
+	if err := os.WriteFile(skillPath, initialArchive, 0o644); err != nil {
+		t.Fatalf("seed skill archive: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"claude"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       true,
+		patch:       false,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected force install, got %+v", result.installedSkills)
+	}
+	skillMd, err := readClaudeSkillContent(skillPath)
+	if err != nil {
+		t.Fatalf("read overwritten skill archive: %v", err)
+	}
+	if strings.Contains(skillMd, "Team-only intro") {
+		t.Fatalf("expected team intro to be removed by force overwrite: %s", skillMd)
+	}
+	if strings.Contains(skillMd, "Team Custom Section") {
+		t.Fatalf("expected custom section to be removed by force overwrite: %s", skillMd)
+	}
+	if !strings.Contains(skillMd, "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content after force overwrite: %s", skillMd)
+	}
+}
+
 func TestInstallForceOverwritesExistingSkill(t *testing.T) {
 	tmpDir := t.TempDir()
 	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -853,7 +853,7 @@ func TestInstallCreatesCodexSupportFileForSkillOnlyInstall(t *testing.T) {
 	}
 }
 
-func TestInstallRefreshesExistingManagedSkillWithoutForce(t *testing.T) {
+func TestInstallSkipsExistingSkillWithoutForceOrPatch(t *testing.T) {
 	tmpDir := t.TempDir()
 	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")
 	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
@@ -871,19 +871,124 @@ func TestInstallRefreshesExistingManagedSkillWithoutForce(t *testing.T) {
 		force:       false,
 		saveConfig:  false,
 	})
-	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
-		t.Fatalf("expected refreshed skill, got %+v", result.installedSkills)
+	if len(result.installedSkills) != 0 {
+		t.Fatalf("expected existing skill to be skipped, got %+v", result.installedSkills)
 	}
 	content, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("read existing skill: %v", err)
 	}
+	if string(content) != "stale skill content" {
+		t.Fatalf("expected existing skill content to remain, got %q", string(content))
+	}
+}
+
+func TestInstallPatchCreatesMissingSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"opencode"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       false,
+		patch:       true,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected patched install to create skill, got %+v", result.installedSkills)
+	}
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md"))
+	if err != nil {
+		t.Fatalf("read created skill: %v", err)
+	}
+	if !strings.Contains(string(content), "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content, got %q", string(content))
+	}
+}
+
+func TestInstallPatchMergesExistingSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".cursor", "rules", "owasp-security-scan.mdc")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte(`---
+description: Team customized skill
+alwaysApply: true
+---
+
+Team intro.
+
+## Usage
+
+Keep team-specific usage notes.
+`), 0o644); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"cursor"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       false,
+		patch:       true,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected patched skill install, got %+v", result.installedSkills)
+	}
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read merged skill: %v", err)
+	}
 	text := string(content)
-	if !strings.Contains(text, "# OWASP Security Scan Skill") {
-		t.Fatalf("expected refreshed managed skill content, got %q", text)
+	if !strings.Contains(text, "description: Team customized skill") {
+		t.Fatalf("expected custom frontmatter to remain: %s", text)
+	}
+	if !strings.Contains(text, "alwaysApply: true") {
+		t.Fatalf("expected custom alwaysApply to remain: %s", text)
+	}
+	if !strings.Contains(text, "Keep team-specific usage notes.") {
+		t.Fatalf("expected custom section to remain: %s", text)
+	}
+	if !strings.Contains(text, "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content to be merged: %s", text)
+	}
+}
+
+func TestInstallForceOverwritesExistingSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("stale skill content"), 0o644); err != nil {
+		t.Fatalf("seed skill file: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"opencode"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       true,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected force install to overwrite skill, got %+v", result.installedSkills)
+	}
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read overwritten skill: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content, got %q", text)
 	}
 	if text == "stale skill content" {
-		t.Fatalf("expected stale skill content to be refreshed")
+		t.Fatalf("expected stale skill content to be overwritten")
 	}
 }
 
@@ -933,6 +1038,155 @@ func TestRunInstallWritesSharedRulesrcForMultipleTargets(t *testing.T) {
 	}
 	if !strings.Contains(string(content), `"paths": {`) {
 		t.Fatalf("expected paths in shared config: %s", string(content))
+	}
+}
+
+func TestRunInstallForceSupportFileDeclinedSkipsFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsPath := filepath.Join(tmpDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# AGENTS.md\n\nTeam customizations.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalStdin := os.Stdin
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = reader.Close()
+	})
+	if _, err := writer.WriteString("n\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := runInstall([]string{"install", "--target", "codex", "--skill", "owasp-security-scan", "--force"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "Team customizations.") {
+		t.Fatalf("expected AGENTS.md to remain unchanged: %s", string(content))
+	}
+	if !strings.Contains(output, "Skipped support file: AGENTS.md") {
+		t.Fatalf("expected skip notice in output, got %q", output)
+	}
+}
+
+func TestRunInstallForceSupportFileAcceptedOverwritesFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsPath := filepath.Join(tmpDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# AGENTS.md\n\nTeam customizations.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalStdin := os.Stdin
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = reader.Close()
+	})
+	if _, err := writer.WriteString("y\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode := runInstall([]string{"install", "--target", "codex", "--skill", "owasp-security-scan", "--force"})
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "## Installed skills") {
+		t.Fatalf("expected canonical AGENTS.md content, got %s", text)
+	}
+	if strings.Contains(text, "Team customizations.") {
+		t.Fatalf("expected AGENTS.md to be overwritten, got %s", text)
+	}
+}
+
+func TestRunInstallForceSupportFileNonInteractiveAborts(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentsPath := filepath.Join(tmpDir, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte("# AGENTS.md\n\nTeam customizations.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := runInstall([]string{"install", "--target", "codex", "--skill", "owasp-security-scan", "--force", "--yes"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+
+	content, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "Team customizations.") {
+		t.Fatalf("expected AGENTS.md to remain unchanged: %s", string(content))
+	}
+	if !strings.Contains(output, "Cannot overwrite existing support file AGENTS.md in non-interactive mode") {
+		t.Fatalf("expected non-interactive error, got %q", output)
 	}
 }
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -67,6 +67,7 @@ class InstallResult:
     installed_support_files: list[str] = field(default_factory=list)
     skipped: list[str] = field(default_factory=list)
     skipped_support_files: list[str] = field(default_factory=list)
+    declined_support_files: list[str] = field(default_factory=list)
     errors: list[tuple[str, str]] = field(default_factory=list)
 
 
@@ -1658,7 +1659,7 @@ def install(
         claude_md = root / "CLAUDE.md"
         should_patch_claude_md = patch or patch_claude_md
         if str(claude_md) in skipped_support_files:
-            result.skipped_support_files.append(str(claude_md))
+            result.declined_support_files.append(str(claude_md))
         elif claude_md.exists() and not force and not should_patch_claude_md:
             result.skipped_support_files.append(str(claude_md))
         else:
@@ -1681,7 +1682,7 @@ def install(
         agents_md = root / "AGENTS.md"
         should_patch_gemini_md = patch or patch_gemini_md
         if str(gemini_md) in skipped_support_files:
-            result.skipped_support_files.append(str(gemini_md))
+            result.declined_support_files.append(str(gemini_md))
         elif gemini_md.exists() and not force and not should_patch_gemini_md:
             result.skipped_support_files.append(str(gemini_md))
         else:
@@ -1712,7 +1713,7 @@ def install(
     if target == "codex" and not disable_support_files:
         agents_md = root / "AGENTS.md"
         if str(agents_md) in skipped_support_files:
-            result.skipped_support_files.append(str(agents_md))
+            result.declined_support_files.append(str(agents_md))
         elif agents_md.exists() and not force and not patch:
             result.skipped_support_files.append(str(agents_md))
         else:
@@ -1808,6 +1809,11 @@ def print_install_result(
             "Skipped support files (already present; use --force to overwrite): "
             + ", ".join(result.skipped_support_files)
         )
+    if result.declined_support_files:
+        print(
+            "Skipped support files (overwrite declined): "
+            + ", ".join(result.declined_support_files)
+        )
 
 
 def run_install(args: argparse.Namespace) -> int:
@@ -1850,8 +1856,7 @@ def run_install(args: argparse.Namespace) -> int:
                 f"Existing GEMINI.md found at {root / 'GEMINI.md'}. Patch the Installed agent rules section?"
             )
 
-    per_target_results: list[tuple[str, InstallResult]] = []
-    save_config(root, language, targets, with_implicit_agents(agents), skills)
+    support_decisions: dict[str, str | None] = {}
     for target in targets:
         skipped_support_file, support_error = confirm_support_file_overwrite(
             root, target, bool(args.force), bool(args.yes)
@@ -1859,6 +1864,12 @@ def run_install(args: argparse.Namespace) -> int:
         if support_error:
             print(support_error)
             return 1
+        support_decisions[target] = skipped_support_file
+
+    per_target_results: list[tuple[str, InstallResult]] = []
+    save_config(root, language, targets, with_implicit_agents(agents), skills)
+    for target in targets:
+        skipped_support_file = support_decisions.get(target)
         if skipped_support_file:
             print(
                 f"Skipped support file: {Path(skipped_support_file).name} ({skipped_support_file})"
@@ -1891,6 +1902,7 @@ def run_install(args: argparse.Namespace) -> int:
         combined.installed_support_files.extend(result.installed_support_files)
         combined.skipped.extend(result.skipped)
         combined.skipped_support_files.extend(result.skipped_support_files)
+        combined.declined_support_files.extend(result.declined_support_files)
         combined.errors.extend(result.errors)
 
     if combined.errors:

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1414,6 +1414,8 @@ def confirm_support_file_overwrite(
 ) -> tuple[str | None, str | None]:
     if not force:
         return None, None
+    if os.environ.get("BALLAST_DISABLE_SUPPORT_FILES") == "1":
+        return None, None
     support_file = support_file_path(root, target)
     if support_file is None or not support_file.exists():
         return None, None

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -830,10 +830,12 @@ def build_skill_markdown(skill: str, language: str) -> str:
     return body.rstrip() + "\n"
 
 
-def build_claude_skill(skill: str, language: str) -> bytes:
+def build_claude_skill(
+    skill: str, language: str, skill_content: str | None = None
+) -> bytes:
     output = io.BytesIO()
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_STORED) as archive:
-        archive.writestr("SKILL.md", read_skill(skill, language))
+        archive.writestr("SKILL.md", skill_content or read_skill(skill, language))
         references = skill_dir(skill, language) / "references"
         if references.exists():
             for ref in sorted(references.rglob("*")):
@@ -842,6 +844,12 @@ def build_claude_skill(skill: str, language: str) -> bytes:
                         ref, f"references/{ref.relative_to(references).as_posix()}"
                     )
     return output.getvalue()
+
+
+def read_claude_skill_content(archive_path: Path) -> str:
+    with zipfile.ZipFile(archive_path) as archive:
+        with archive.open("SKILL.md") as skill_file:
+            return skill_file.read().decode("utf-8")
 
 
 def destination(root: Path, target: str, basename: str) -> Path:
@@ -1390,6 +1398,39 @@ def prompt_yes_no(question: str, default: bool = False) -> bool:
     return value in {"y", "yes"}
 
 
+def support_file_path(root: Path, target: str) -> Path | None:
+    if target == "claude":
+        return root / "CLAUDE.md"
+    if target == "gemini":
+        return root / "GEMINI.md"
+    if target == "codex":
+        return root / "AGENTS.md"
+    return None
+
+
+def confirm_support_file_overwrite(
+    root: Path, target: str, force: bool, yes: bool
+) -> tuple[str | None, str | None]:
+    if not force:
+        return None, None
+    support_file = support_file_path(root, target)
+    if support_file is None or not support_file.exists():
+        return None, None
+    if is_ci_mode() or yes:
+        return (
+            None,
+            f"Cannot overwrite existing support file {support_file.name} in non-interactive mode. Re-run interactively without --yes to confirm the destructive overwrite.",
+        )
+    approved = prompt_yes_no(
+        "\n"
+        f"⚠️  {support_file.name} already exists and may contain your customizations.\n"
+        "    --force will replace it with the canonical template.\n"
+        "    Your current file will be lost.\n\n"
+        "    Continue?"
+    )
+    return (None, None) if approved else (str(support_file), None)
+
+
 def prompt_targets() -> list[str]:
     value = prompt(f"AI platform(s) ({', '.join(TARGETS)}, comma-separated): ")
     if value.strip().lower() == "all":
@@ -1506,6 +1547,7 @@ def install(
     persist: bool,
     patch_claude_md: bool = False,
     patch_gemini_md: bool = False,
+    skip_support_files: set[str] | None = None,
 ) -> InstallResult:
     result = InstallResult()
     agents = with_implicit_agents(agents)
@@ -1532,6 +1574,7 @@ def install(
         if config_for_support_files
         else skills
     )
+    skipped_support_files = skip_support_files or set()
 
     for agent in agents:
         if not is_valid_agent(agent, language):
@@ -1576,15 +1619,36 @@ def install(
             continue
         try:
             dst = skill_destination(root, target, skill)
+            file_exists = dst.exists()
             dst.parent.mkdir(parents=True, exist_ok=True)
+            if file_exists and not force and not patch:
+                continue
             if target == "cursor":
-                dst.write_text(
-                    build_cursor_skill_format(skill, language), encoding="utf-8"
+                content = build_cursor_skill_format(skill, language)
+                next_content = (
+                    patch_rule_content(dst.read_text(encoding="utf-8"), content, target)
+                    if file_exists and not force and patch
+                    else content
                 )
+                dst.write_text(next_content, encoding="utf-8")
             elif target == "claude":
-                dst.write_bytes(build_claude_skill(skill, language))
+                skill_content = read_skill(skill, language)
+                next_content = (
+                    patch_rule_content(
+                        read_claude_skill_content(dst), skill_content, target
+                    )
+                    if file_exists and not force and patch
+                    else skill_content
+                )
+                dst.write_bytes(build_claude_skill(skill, language, next_content))
             else:
-                dst.write_text(build_skill_markdown(skill, language), encoding="utf-8")
+                content = build_skill_markdown(skill, language)
+                next_content = (
+                    patch_rule_content(dst.read_text(encoding="utf-8"), content, target)
+                    if file_exists and not force and patch
+                    else content
+                )
+                dst.write_text(next_content, encoding="utf-8")
             result.installed_skills.append(skill)
             processed_skills.append(skill)
         except Exception as err:
@@ -1593,7 +1657,9 @@ def install(
     if target == "claude" and not disable_support_files:
         claude_md = root / "CLAUDE.md"
         should_patch_claude_md = patch or patch_claude_md
-        if claude_md.exists() and not force and not should_patch_claude_md:
+        if str(claude_md) in skipped_support_files:
+            result.skipped_support_files.append(str(claude_md))
+        elif claude_md.exists() and not force and not should_patch_claude_md:
             result.skipped_support_files.append(str(claude_md))
         else:
             try:
@@ -1614,7 +1680,9 @@ def install(
         gemini_md = root / "GEMINI.md"
         agents_md = root / "AGENTS.md"
         should_patch_gemini_md = patch or patch_gemini_md
-        if gemini_md.exists() and not force and not should_patch_gemini_md:
+        if str(gemini_md) in skipped_support_files:
+            result.skipped_support_files.append(str(gemini_md))
+        elif gemini_md.exists() and not force and not should_patch_gemini_md:
             result.skipped_support_files.append(str(gemini_md))
         else:
             try:
@@ -1631,7 +1699,7 @@ def install(
             except Exception as err:
                 result.errors.append(("gemini", str(err)))
 
-        if not agents_md.exists():
+        if not agents_md.exists() and str(agents_md) not in skipped_support_files:
             try:
                 agents_md.write_text(
                     build_codex_agents_md(support_agents, support_skills, language),
@@ -1643,7 +1711,9 @@ def install(
 
     if target == "codex" and not disable_support_files:
         agents_md = root / "AGENTS.md"
-        if agents_md.exists() and not force and not patch:
+        if str(agents_md) in skipped_support_files:
+            result.skipped_support_files.append(str(agents_md))
+        elif agents_md.exists() and not force and not patch:
             result.skipped_support_files.append(str(agents_md))
         else:
             try:
@@ -1780,36 +1850,36 @@ def run_install(args: argparse.Namespace) -> int:
                 f"Existing GEMINI.md found at {root / 'GEMINI.md'}. Patch the Installed agent rules section?"
             )
 
-    if len(targets) == 1:
-        per_target_results = [
+    per_target_results: list[tuple[str, InstallResult]] = []
+    save_config(root, language, targets, with_implicit_agents(agents), skills)
+    for target in targets:
+        skipped_support_file, support_error = confirm_support_file_overwrite(
+            root, target, bool(args.force), bool(args.yes)
+        )
+        if support_error:
+            print(support_error)
+            return 1
+        if skipped_support_file:
+            print(
+                f"Skipped support file: {Path(skipped_support_file).name} ({skipped_support_file})"
+            )
+        per_target_results.append(
             (
-                targets[0],
+                target,
                 install(
                     root,
-                    targets[0],
+                    target,
                     agents,
                     skills,
                     language,
                     bool(args.force),
                     bool(args.patch),
-                    True,
+                    False,
                     patch_claude_md,
                     patch_gemini_md,
+                    {skipped_support_file} if skipped_support_file else None,
                 ),
             )
-        ]
-    else:
-        per_target_results = install_for_targets(
-            root,
-            targets,
-            agents,
-            skills,
-            language,
-            bool(args.force),
-            bool(args.patch),
-            True,
-            patch_claude_md,
-            patch_gemini_md,
         )
 
     combined = InstallResult()
@@ -1862,8 +1932,18 @@ def parser() -> argparse.ArgumentParser:
     install_cmd.add_argument("--skill", "-s")
     install_cmd.add_argument("--all", action="store_true")
     install_cmd.add_argument("--all-skills", action="store_true")
-    install_cmd.add_argument("--force", "-f", action="store_true")
-    install_cmd.add_argument("--patch", "-p", action="store_true")
+    install_cmd.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Overwrite existing rule and skill files; prompt before replacing support files",
+    )
+    install_cmd.add_argument(
+        "--patch",
+        "-p",
+        action="store_true",
+        help="Merge upstream rule and skill updates into existing files",
+    )
     install_cmd.add_argument("--yes", "-y", action="store_true")
     sub.add_parser(
         "doctor", help="Check local Ballast CLI versions and .rulesrc.json metadata"

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -737,6 +737,40 @@ Keep team-specific usage notes.
             self.assertIn("Team Custom Section", skill_md)
             self.assertIn("## Scan Architecture", skill_md)
 
+    def test_install_force_overwrites_existing_claude_skill_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".claude" / "skills" / "owasp-security-scan.skill"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            existing_skill_content = (
+                "# owasp-security-scan\n\n"
+                "Team intro that should be discarded on force.\n\n"
+                "## Team Custom Section\n\n"
+                "This section should be gone after force.\n"
+            )
+            skill_path.write_bytes(
+                cli.build_claude_skill(
+                    "owasp-security-scan", "python", existing_skill_content
+                )
+            )
+
+            result = cli.install(
+                root,
+                "claude",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                True,
+                False,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            skill_md = cli.read_claude_skill_content(skill_path)
+            self.assertNotIn("Team intro that should be discarded on force.", skill_md)
+            self.assertNotIn("Team Custom Section", skill_md)
+            self.assertIn("## Scan Architecture", skill_md)
+
     def test_install_force_overwrites_existing_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -703,6 +703,40 @@ Keep team-specific usage notes.
             self.assertIn("Keep team-specific usage notes.", content)
             self.assertIn("## Scan Architecture", content)
 
+    def test_install_patch_merges_claude_skill_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".claude" / "skills" / "owasp-security-scan.skill"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            existing_skill_content = (
+                "# owasp-security-scan\n\n"
+                "Team intro preserved by patch.\n\n"
+                "## Team Custom Section\n\n"
+                "Keep this team-specific section.\n"
+            )
+            skill_path.write_bytes(
+                cli.build_claude_skill(
+                    "owasp-security-scan", "python", existing_skill_content
+                )
+            )
+
+            result = cli.install(
+                root,
+                "claude",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                False,
+                True,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            skill_md = cli.read_claude_skill_content(skill_path)
+            self.assertIn("Team intro preserved by patch.", skill_md)
+            self.assertIn("Team Custom Section", skill_md)
+            self.assertIn("## Scan Architecture", skill_md)
+
     def test_install_force_overwrites_existing_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -1058,6 +1092,7 @@ Read and follow these rule files in `.gemini/rules/` when they apply:
 
             with (
                 mock.patch.object(cli, "resolve_project_root", return_value=root),
+                mock.patch.object(cli, "is_ci_mode", return_value=False),
                 mock.patch.object(cli, "prompt_yes_no", return_value=False),
                 io.StringIO() as buf,
                 redirect_stdout(buf),
@@ -1095,6 +1130,7 @@ Read and follow these rule files in `.gemini/rules/` when they apply:
 
             with (
                 mock.patch.object(cli, "resolve_project_root", return_value=root),
+                mock.patch.object(cli, "is_ci_mode", return_value=False),
                 mock.patch.object(cli, "prompt_yes_no", return_value=True),
             ):
                 exit_code = cli.run_install(args)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -337,7 +337,7 @@ class PatchInstallTests(unittest.TestCase):
             self.assertTrue(skill.exists())
             self.assertTrue(skill.read_bytes().startswith(b"PK\x03\x04"))
 
-    def test_install_refreshes_existing_managed_skill_without_force(self) -> None:
+    def test_install_skips_existing_managed_skill_without_force(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             skill = root / ".opencode" / "skills" / "owasp-security-scan.md"
@@ -355,10 +355,8 @@ class PatchInstallTests(unittest.TestCase):
                 False,
             )
 
-            self.assertIn("owasp-security-scan", result.installed_skills)
-            refreshed = skill.read_text(encoding="utf-8")
-            self.assertIn("# OWASP Security Scan Skill", refreshed)
-            self.assertNotEqual(refreshed, "stale skill content")
+            self.assertEqual(result.installed_skills, [])
+            self.assertEqual(skill.read_text(encoding="utf-8"), "stale skill content")
 
     def test_install_adds_ballast_to_gitignore(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -621,6 +619,112 @@ class PatchInstallTests(unittest.TestCase):
             agents_md = (root / "AGENTS.md").read_text(encoding="utf-8")
             self.assertIn("## Installed skills", agents_md)
             self.assertIn("`.codex/rules/owasp-security-scan.md`", agents_md)
+
+    def test_install_skips_existing_skill_when_force_and_patch_are_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".opencode" / "skills" / "owasp-security-scan.md"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            skill_path.write_text("stale skill content", encoding="utf-8")
+
+            result = cli.install(
+                root,
+                "opencode",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                False,
+                False,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, [])
+            self.assertEqual(
+                skill_path.read_text(encoding="utf-8"), "stale skill content"
+            )
+
+    def test_install_patch_creates_missing_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            result = cli.install(
+                root,
+                "opencode",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                False,
+                True,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            skill_path = root / ".opencode" / "skills" / "owasp-security-scan.md"
+            self.assertIn(
+                "## Scan Architecture",
+                skill_path.read_text(encoding="utf-8"),
+            )
+
+    def test_install_patch_merges_existing_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".cursor" / "rules" / "owasp-security-scan.mdc"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            skill_path.write_text(
+                """---
+description: Team customized skill
+alwaysApply: true
+---
+
+Team intro.
+
+## Usage
+
+Keep team-specific usage notes.
+""",
+                encoding="utf-8",
+            )
+
+            result = cli.install(
+                root,
+                "cursor",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                False,
+                True,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            content = skill_path.read_text(encoding="utf-8")
+            self.assertIn("description: Team customized skill", content)
+            self.assertIn("alwaysApply: true", content)
+            self.assertIn("Keep team-specific usage notes.", content)
+            self.assertIn("## Scan Architecture", content)
+
+    def test_install_force_overwrites_existing_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".opencode" / "skills" / "owasp-security-scan.md"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            skill_path.write_text("stale skill content", encoding="utf-8")
+
+            result = cli.install(
+                root,
+                "opencode",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                True,
+                False,
+                False,
+            )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            content = skill_path.read_text(encoding="utf-8")
+            self.assertIn("## Scan Architecture", content)
+            self.assertNotEqual(content, "stale skill content")
 
     def test_install_creates_language_prefixed_rule_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -930,6 +1034,115 @@ Read and follow these rule files in `.gemini/rules/` when they apply:
             "Invalid --target. Use: cursor, claude, opencode, codex, gemini",
             output,
         )
+
+    def test_run_install_force_support_file_declined_skips_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname='demo'\n", encoding="utf-8"
+            )
+            (root / "AGENTS.md").write_text(
+                "# AGENTS.md\n\nTeam customizations.\n",
+                encoding="utf-8",
+            )
+            args = cli.parser().parse_args(
+                [
+                    "install",
+                    "--target",
+                    "codex",
+                    "--skill",
+                    "owasp-security-scan",
+                    "--force",
+                ]
+            )
+
+            with (
+                mock.patch.object(cli, "resolve_project_root", return_value=root),
+                mock.patch.object(cli, "prompt_yes_no", return_value=False),
+                io.StringIO() as buf,
+                redirect_stdout(buf),
+            ):
+                exit_code = cli.run_install(args)
+                output = buf.getvalue()
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Skipped support file: AGENTS.md", output)
+            self.assertIn(
+                "Team customizations.",
+                (root / "AGENTS.md").read_text(encoding="utf-8"),
+            )
+
+    def test_run_install_force_support_file_accepted_overwrites_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname='demo'\n", encoding="utf-8"
+            )
+            (root / "AGENTS.md").write_text(
+                "# AGENTS.md\n\nTeam customizations.\n",
+                encoding="utf-8",
+            )
+            args = cli.parser().parse_args(
+                [
+                    "install",
+                    "--target",
+                    "codex",
+                    "--skill",
+                    "owasp-security-scan",
+                    "--force",
+                ]
+            )
+
+            with (
+                mock.patch.object(cli, "resolve_project_root", return_value=root),
+                mock.patch.object(cli, "prompt_yes_no", return_value=True),
+            ):
+                exit_code = cli.run_install(args)
+
+            self.assertEqual(exit_code, 0)
+            content = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("## Installed skills", content)
+            self.assertNotIn("Team customizations.", content)
+
+    def test_run_install_force_support_file_non_interactive_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "pyproject.toml").write_text(
+                "[project]\nname='demo'\n", encoding="utf-8"
+            )
+            (root / "AGENTS.md").write_text(
+                "# AGENTS.md\n\nTeam customizations.\n",
+                encoding="utf-8",
+            )
+            args = cli.parser().parse_args(
+                [
+                    "install",
+                    "--target",
+                    "codex",
+                    "--skill",
+                    "owasp-security-scan",
+                    "--force",
+                    "--yes",
+                ]
+            )
+
+            with (
+                mock.patch.object(cli, "resolve_project_root", return_value=root),
+                io.StringIO() as buf,
+                redirect_stdout(buf),
+            ):
+                exit_code = cli.run_install(args)
+                output = buf.getvalue()
+
+            self.assertEqual(exit_code, 1)
+            self.assertIn(
+                "Cannot overwrite existing support file AGENTS.md in non-interactive mode",
+                output,
+            )
+            self.assertIn(
+                "Team customizations.",
+                (root / "AGENTS.md").read_text(encoding="utf-8"),
+            )
 
     def test_patch_flag_updates_claude_md_section(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -477,11 +477,14 @@ export function buildSkillMarkdown(skillId: string): string {
   return parseSkillMetadata(skillId).body.trimEnd() + '\n';
 }
 
-export function buildClaudeSkill(skillId: string): Buffer {
+export function buildClaudeSkill(
+  skillId: string,
+  skillContent?: string
+): Buffer {
   const entries: SkillEntry[] = [
     {
       name: 'SKILL.md',
-      data: Buffer.from(getSkillContent(skillId), 'utf8')
+      data: Buffer.from(skillContent ?? getSkillContent(skillId), 'utf8')
     }
   ];
   for (const relativePath of listSkillReferenceFiles(skillId)) {

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -148,7 +148,7 @@ Options:
   --all                     Install all agents
   --all-skills              Install all skills
   --task-system <system>    Task system for the tasks agent: ${TASK_SYSTEMS.join(', ')} (default: github)
-  --force, -f               Overwrite existing rule/skill files; prompts before replacing AGENTS.md or CLAUDE.md
+  --force, -f               Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
   --help, -h                Show this help

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -148,8 +148,8 @@ Options:
   --all                     Install all agents
   --all-skills              Install all skills
   --task-system <system>    Task system for the tasks agent: ${TASK_SYSTEMS.join(', ')} (default: github)
-  --force, -f               Overwrite existing rule files
-  --patch, -p               Merge upstream rule updates into existing files; ignored when --force is set
+  --force, -f               Overwrite existing rule/skill files; prompts before replacing AGENTS.md or CLAUDE.md
+  --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
   --help, -h                Show this help
   --version, -v             Show version

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import readline from 'readline';
 import { install, resolveTargetAndAgents, runInstall } from './install';
 import {
+  buildClaudeSkill,
   buildCodexAgentsMd,
   getClaudeMdPath,
   getDestination,
@@ -443,6 +444,69 @@ Keep team-specific usage notes.
       expect(fs.readFileSync(skillFile, 'utf8')).not.toBe(
         'stale skill content'
       );
+    });
+
+    test('patches SKILL.md inside an existing claude .skill archive when patch is true', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      const existingSkillContent = `# owasp-security-scan
+
+Team intro preserved by patch.
+
+## Team Custom Section
+
+Keep this team-specific section.
+`;
+      fs.writeFileSync(
+        skillFile,
+        buildClaudeSkill('owasp-security-scan', existingSkillContent)
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installedSkills).toContain('owasp-security-scan');
+
+      // Read SKILL.md from output archive (stored/no-compression ZIP)
+      const archive = fs.readFileSync(skillFile);
+      function readStoredZipEntry(
+        buf: Buffer,
+        entry: string
+      ): string | undefined {
+        let offset = 0;
+        while (offset + 30 <= buf.length) {
+          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
+          const compressedSize = buf.readUInt32LE(offset + 18);
+          const fileNameLength = buf.readUInt16LE(offset + 26);
+          const extraLength = buf.readUInt16LE(offset + 28);
+          const fileName = buf.toString(
+            'utf8',
+            offset + 30,
+            offset + 30 + fileNameLength
+          );
+          const dataStart = offset + 30 + fileNameLength + extraLength;
+          if (fileName === entry)
+            return buf.toString('utf8', dataStart, dataStart + compressedSize);
+          offset = dataStart + compressedSize;
+        }
+        return undefined;
+      }
+      const skillMd = readStoredZipEntry(archive, 'SKILL.md');
+      expect(skillMd).toContain('Team intro preserved by patch.');
+      expect(skillMd).toContain('Team Custom Section');
+      expect(skillMd).toContain('## Scan Architecture');
     });
 
     test('writes ansible language rules when requested', () => {

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -28,6 +28,7 @@ describe('install', () => {
     if (tmpDir && fs.existsSync(tmpDir)) {
       fs.rmSync(tmpDir, { recursive: true });
     }
+    jest.restoreAllMocks();
     process.env = origEnv;
   });
 
@@ -326,7 +327,7 @@ describe('install', () => {
       ).toBe(true);
     });
 
-    test('refreshes existing managed skill files without force', () => {
+    test('skips an existing skill file when force and patch are false', () => {
       const skillFile = path.join(
         tmpDir,
         '.opencode',
@@ -345,10 +346,103 @@ describe('install', () => {
         saveConfig: false
       });
 
+      expect(result.installedSkills).toEqual([]);
+      expect(result.skipped).toEqual([]);
+      expect(fs.readFileSync(skillFile, 'utf8')).toBe('stale skill content');
+    });
+
+    test('creates a missing skill file when patch is true', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.opencode',
+        'skills',
+        'owasp-security-scan.md'
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'opencode',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
       expect(result.installedSkills).toContain('owasp-security-scan');
-      const refreshed = fs.readFileSync(skillFile, 'utf8');
-      expect(refreshed).toContain('# OWASP Security Scan Skill');
-      expect(refreshed).not.toBe('stale skill content');
+      expect(fs.readFileSync(skillFile, 'utf8')).toContain(
+        '## Scan Architecture'
+      );
+    });
+
+    test('patches an existing skill file when patch is true', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.cursor',
+        'rules',
+        'owasp-security-scan.mdc'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(
+        skillFile,
+        `---
+description: Team customized skill
+alwaysApply: true
+---
+
+Team intro.
+
+## Usage
+
+Keep team-specific usage notes.
+`,
+        'utf8'
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'cursor',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installedSkills).toContain('owasp-security-scan');
+      const content = fs.readFileSync(skillFile, 'utf8');
+      expect(content).toContain('description: Team customized skill');
+      expect(content).toContain('alwaysApply: true');
+      expect(content).toContain('Keep team-specific usage notes.');
+      expect(content).toContain('## Scan Architecture');
+    });
+
+    test('overwrites an existing skill file when force is true', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.opencode',
+        'skills',
+        'owasp-security-scan.md'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(skillFile, 'stale skill content', 'utf8');
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'opencode',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        force: true,
+        saveConfig: false
+      });
+
+      expect(result.installedSkills).toContain('owasp-security-scan');
+      expect(fs.readFileSync(skillFile, 'utf8')).toContain(
+        '## Scan Architecture'
+      );
+      expect(fs.readFileSync(skillFile, 'utf8')).not.toBe(
+        'stale skill content'
+      );
     });
 
     test('writes ansible language rules when requested', () => {
@@ -1550,6 +1644,100 @@ Read and follow these rule files in \`.codex/rules/\` when they apply:
         yes: true
       });
       expect(exitCode).toBe(1);
+    });
+
+    test('prompts before force-overwriting an existing support file and skips on no', async () => {
+      const agentsMdPath = path.join(tmpDir, 'AGENTS.md');
+      fs.writeFileSync(
+        agentsMdPath,
+        '# AGENTS.md\n\nTeam customizations.\n',
+        'utf8'
+      );
+      const consoleLog = jest
+        .spyOn(console, 'log')
+        .mockImplementation(() => {});
+      jest.spyOn(readline, 'createInterface').mockImplementation(
+        () =>
+          ({
+            question: (_prompt: string, cb: (answer: string) => void) =>
+              cb('n'),
+            close: () => {}
+          }) as unknown as readline.Interface
+      );
+
+      const exitCode = await runInstall({
+        projectRoot: tmpDir,
+        target: 'codex',
+        skills: ['owasp-security-scan'],
+        force: true
+      });
+
+      expect(exitCode).toBe(0);
+      expect(fs.readFileSync(agentsMdPath, 'utf8')).toContain(
+        'Team customizations.'
+      );
+      expect(consoleLog).toHaveBeenCalledWith(
+        expect.stringContaining('Skipped support file: AGENTS.md')
+      );
+    });
+
+    test('force-overwrites an existing support file when prompt is accepted', async () => {
+      const agentsMdPath = path.join(tmpDir, 'AGENTS.md');
+      fs.writeFileSync(
+        agentsMdPath,
+        '# AGENTS.md\n\nTeam customizations.\n',
+        'utf8'
+      );
+      jest.spyOn(readline, 'createInterface').mockImplementation(
+        () =>
+          ({
+            question: (_prompt: string, cb: (answer: string) => void) =>
+              cb('y'),
+            close: () => {}
+          }) as unknown as readline.Interface
+      );
+
+      const exitCode = await runInstall({
+        projectRoot: tmpDir,
+        target: 'codex',
+        skills: ['owasp-security-scan'],
+        force: true
+      });
+
+      expect(exitCode).toBe(0);
+      const content = fs.readFileSync(agentsMdPath, 'utf8');
+      expect(content).toContain('## Installed skills');
+      expect(content).not.toContain('Team customizations.');
+    });
+
+    test('refuses force-overwriting an existing support file in non-interactive mode', async () => {
+      const agentsMdPath = path.join(tmpDir, 'AGENTS.md');
+      fs.writeFileSync(
+        agentsMdPath,
+        '# AGENTS.md\n\nTeam customizations.\n',
+        'utf8'
+      );
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      const exitCode = await runInstall({
+        projectRoot: tmpDir,
+        target: 'codex',
+        skills: ['owasp-security-scan'],
+        force: true,
+        yes: true
+      });
+
+      expect(exitCode).toBe(1);
+      expect(fs.readFileSync(agentsMdPath, 'utf8')).toContain(
+        'Team customizations.'
+      );
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Cannot overwrite existing support file AGENTS.md in non-interactive mode'
+        )
+      );
     });
   });
 });

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -509,6 +509,70 @@ Keep this team-specific section.
       expect(skillMd).toContain('## Scan Architecture');
     });
 
+    test('force-overwrites an existing claude .skill archive without patching', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      const existingSkillContent = `# owasp-security-scan
+
+Team intro that should be discarded on force.
+
+## Team Custom Section
+
+This section should be gone after force.
+`;
+      fs.writeFileSync(
+        skillFile,
+        buildClaudeSkill('owasp-security-scan', existingSkillContent)
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: false,
+        force: true,
+        saveConfig: false
+      });
+
+      expect(result.installedSkills).toContain('owasp-security-scan');
+
+      const archive = fs.readFileSync(skillFile);
+      function readStoredZipEntryLocal(
+        buf: Buffer,
+        entry: string
+      ): string | undefined {
+        let offset = 0;
+        while (offset + 30 <= buf.length) {
+          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
+          const compressedSize = buf.readUInt32LE(offset + 18);
+          const fileNameLength = buf.readUInt16LE(offset + 26);
+          const extraLength = buf.readUInt16LE(offset + 28);
+          const fileName = buf.toString(
+            'utf8',
+            offset + 30,
+            offset + 30 + fileNameLength
+          );
+          const dataStart = offset + 30 + fileNameLength + extraLength;
+          if (fileName === entry)
+            return buf.toString('utf8', dataStart, dataStart + compressedSize);
+          offset = dataStart + compressedSize;
+        }
+        return undefined;
+      }
+      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      expect(skillMd).not.toContain(
+        'Team intro that should be discarded on force.'
+      );
+      expect(skillMd).not.toContain('Team Custom Section');
+      expect(skillMd).toContain('## Scan Architecture');
+    });
+
     test('writes ansible language rules when requested', () => {
       const result = install({
         projectRoot: tmpDir,

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -9,6 +9,7 @@ import {
   buildCursorSkillFormat,
   buildCodexAgentsMd,
   buildSkillMarkdown,
+  getSkillContent,
   getClaudeMdPath,
   getGeminiMdPath,
   getCodexAgentsMdPath,
@@ -350,6 +351,7 @@ export interface InstallOptions {
   patch?: boolean;
   patchClaudeMd?: boolean;
   patchGeminiMd?: boolean;
+  skipSupportFiles?: string[];
   saveConfig?: boolean;
   taskSystem?: TaskSystem;
 }
@@ -363,6 +365,11 @@ export interface InstallResult {
   skipped: string[];
   skippedSupportFiles: string[];
   errors: Array<{ agent: string; error: string }>;
+}
+
+interface SupportFileDecision {
+  error?: string;
+  skipSupportFile?: string;
 }
 
 function resolveSupportFileSelections(
@@ -383,6 +390,55 @@ function resolveSupportFileSelections(
     agents: [...new Set(withImplicitAgents(rawAgents))],
     skills: [...new Set(rawSkills)]
   };
+}
+
+function readStoredZipEntry(
+  archive: Buffer,
+  entryName: string
+): string | undefined {
+  let offset = 0;
+  while (offset + 30 <= archive.length) {
+    const signature = archive.readUInt32LE(offset);
+    if (signature !== 0x04034b50) {
+      break;
+    }
+    const compressionMethod = archive.readUInt16LE(offset + 8);
+    const compressedSize = archive.readUInt32LE(offset + 18);
+    const fileNameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    const fileName = archive.toString(
+      'utf8',
+      offset + 30,
+      offset + 30 + fileNameLength
+    );
+    const dataStart = offset + 30 + fileNameLength + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    if (dataEnd > archive.length) {
+      break;
+    }
+    if (fileName === entryName) {
+      if (compressionMethod !== 0) {
+        return undefined;
+      }
+      return archive.toString('utf8', dataStart, dataEnd);
+    }
+    offset = dataEnd;
+  }
+  return undefined;
+}
+
+function getSupportFilePath(
+  target: Target,
+  projectRoot: string
+): string | undefined {
+  if (target === 'claude') return getClaudeMdPath(projectRoot);
+  if (target === 'gemini') return getGeminiMdPath(projectRoot);
+  if (target === 'codex') return getCodexAgentsMdPath(projectRoot);
+  return undefined;
+}
+
+function getSupportFileLabel(filePath: string): string {
+  return path.basename(filePath);
 }
 
 /**
@@ -473,6 +529,7 @@ export function install(options: InstallOptions): InstallResult {
     patch = false,
     patchClaudeMd = false,
     patchGeminiMd = false,
+    skipSupportFiles = [],
     saveConfig: persist,
     taskSystem
   } = options;
@@ -524,6 +581,7 @@ export function install(options: InstallOptions): InstallResult {
     effectiveAgents,
     skills
   );
+  const skippedSupportSet = new Set(skipSupportFiles);
 
   for (const agentId of effectiveAgents) {
     if (!isValidAgent(agentId, language)) {
@@ -594,15 +652,34 @@ export function install(options: InstallOptions): InstallResult {
     }
     try {
       const { dir, file } = getSkillDestination(skillId, target, projectRoot);
+      const fileExists = fs.existsSync(file);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
+      if (fileExists && !force && !patch) {
+        continue;
+      }
       switch (target) {
-        case 'cursor':
-          fs.writeFileSync(file, buildCursorSkillFormat(skillId), 'utf8');
+        case 'cursor': {
+          const content = buildCursorSkillFormat(skillId);
+          const nextContent =
+            fileExists && !force && patch
+              ? patchRuleContent(fs.readFileSync(file, 'utf8'), content, target)
+              : content;
+          fs.writeFileSync(file, nextContent, 'utf8');
           break;
+        }
         case 'claude': {
-          fs.writeFileSync(file, buildClaudeSkill(skillId));
+          const skillContent = getSkillContent(skillId);
+          const nextSkillContent =
+            fileExists && !force && patch
+              ? patchRuleContent(
+                  readStoredZipEntry(fs.readFileSync(file), 'SKILL.md') ?? '',
+                  skillContent,
+                  target
+                )
+              : skillContent;
+          fs.writeFileSync(file, buildClaudeSkill(skillId, nextSkillContent));
           const skillSettings = getSkillClaudeSettings(skillId);
           if (skillSettings) {
             try {
@@ -618,9 +695,15 @@ export function install(options: InstallOptions): InstallResult {
         }
         case 'opencode':
         case 'codex':
-        case 'gemini':
-          fs.writeFileSync(file, buildSkillMarkdown(skillId), 'utf8');
+        case 'gemini': {
+          const content = buildSkillMarkdown(skillId);
+          const nextContent =
+            fileExists && !force && patch
+              ? patchRuleContent(fs.readFileSync(file, 'utf8'), content, target)
+              : content;
+          fs.writeFileSync(file, nextContent, 'utf8');
           break;
+        }
         default:
           throw new Error(`Unknown target: ${target}`);
       }
@@ -637,7 +720,9 @@ export function install(options: InstallOptions): InstallResult {
   if (!disableSupportFiles && target === 'claude') {
     const claudeMdPath = getClaudeMdPath(projectRoot);
     const shouldPatchClaudeMd = patch || patchClaudeMd;
-    if (fs.existsSync(claudeMdPath) && !force && !shouldPatchClaudeMd) {
+    if (skippedSupportSet.has(claudeMdPath)) {
+      skippedSupportFiles.push(claudeMdPath);
+    } else if (fs.existsSync(claudeMdPath) && !force && !shouldPatchClaudeMd) {
       skippedSupportFiles.push(claudeMdPath);
     } else {
       try {
@@ -665,7 +750,9 @@ export function install(options: InstallOptions): InstallResult {
     const geminiMdPath = getGeminiMdPath(projectRoot);
     const agentsMdPath = getCodexAgentsMdPath(projectRoot);
     const shouldPatchGeminiMd = patch || patchGeminiMd;
-    if (fs.existsSync(geminiMdPath) && !force && !shouldPatchGeminiMd) {
+    if (skippedSupportSet.has(geminiMdPath)) {
+      skippedSupportFiles.push(geminiMdPath);
+    } else if (fs.existsSync(geminiMdPath) && !force && !shouldPatchGeminiMd) {
       skippedSupportFiles.push(geminiMdPath);
     } else {
       try {
@@ -688,7 +775,7 @@ export function install(options: InstallOptions): InstallResult {
       }
     }
 
-    if (!fs.existsSync(agentsMdPath)) {
+    if (!fs.existsSync(agentsMdPath) && !skippedSupportSet.has(agentsMdPath)) {
       try {
         const agentsContent = buildCodexAgentsMd(
           supportSelections.agents,
@@ -708,7 +795,9 @@ export function install(options: InstallOptions): InstallResult {
 
   if (!disableSupportFiles && target === 'codex') {
     const agentsMdPath = getCodexAgentsMdPath(projectRoot);
-    if (fs.existsSync(agentsMdPath) && !force && !patch) {
+    if (skippedSupportSet.has(agentsMdPath)) {
+      skippedSupportFiles.push(agentsMdPath);
+    } else if (fs.existsSync(agentsMdPath) && !force && !patch) {
       skippedSupportFiles.push(agentsMdPath);
     } else {
       try {
@@ -766,6 +855,31 @@ async function promptYesNo(
   const line = (await prompt(question + suffix)).toLowerCase();
   if (!line) return defaultAnswer;
   return line === 'y' || line === 'yes';
+}
+
+async function confirmSupportFileOverwrite(
+  target: Target,
+  projectRoot: string,
+  force: boolean,
+  yes: boolean
+): Promise<SupportFileDecision> {
+  if (!force) return {};
+  const supportFilePath = getSupportFilePath(target, projectRoot);
+  if (!supportFilePath || !fs.existsSync(supportFilePath)) {
+    return {};
+  }
+  const label = getSupportFileLabel(supportFilePath);
+  if (isCiMode() || yes) {
+    return {
+      error: `Cannot overwrite existing support file ${label} in non-interactive mode. Re-run interactively without --yes to confirm the destructive overwrite.`
+    };
+  }
+
+  const approved = await promptYesNo(
+    `\n⚠️  ${label} already exists and may contain your customizations.\n    --force will replace it with the canonical template.\n    Your current file will be lost.\n\n    Continue?`
+  );
+
+  return approved ? {} : { skipSupportFile: supportFilePath };
 }
 
 /**
@@ -853,6 +967,22 @@ export async function runInstall(
   );
 
   for (const target of targets) {
+    const supportDecision = await confirmSupportFileOverwrite(
+      target,
+      projectRoot,
+      options.force ?? false,
+      options.yes ?? false
+    );
+    if (supportDecision.error) {
+      console.error(supportDecision.error);
+      return 1;
+    }
+    if (supportDecision.skipSupportFile) {
+      console.log(
+        `Skipped support file: ${getSupportFileLabel(supportDecision.skipSupportFile)} (${supportDecision.skipSupportFile})`
+      );
+    }
+
     const claudeMdPath = getClaudeMdPath(projectRoot);
     let patchClaudeMd = false;
     if (target === 'claude' && fs.existsSync(claudeMdPath) && !options.force) {
@@ -887,6 +1017,9 @@ export async function runInstall(
       patch: options.patch ?? false,
       patchClaudeMd,
       patchGeminiMd,
+      skipSupportFiles: supportDecision.skipSupportFile
+        ? [supportDecision.skipSupportFile]
+        : [],
       saveConfig: false,
       taskSystem: resolvedTaskSystem
     });

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
+import zlib from 'zlib';
 import {
   buildContent,
   buildClaudeSkill,
@@ -418,10 +419,14 @@ function readStoredZipEntry(
       break;
     }
     if (fileName === entryName) {
-      if (compressionMethod !== 0) {
-        return undefined;
+      const data = archive.subarray(dataStart, dataEnd);
+      if (compressionMethod === 0) {
+        return data.toString('utf8');
       }
-      return archive.toString('utf8', dataStart, dataEnd);
+      if (compressionMethod === 8) {
+        return zlib.inflateRawSync(data).toString('utf8');
+      }
+      return undefined;
     }
     offset = dataEnd;
   }
@@ -867,6 +872,7 @@ async function confirmSupportFileOverwrite(
   yes: boolean
 ): Promise<SupportFileDecision> {
   if (!force) return {};
+  if (process.env.BALLAST_DISABLE_SUPPORT_FILES === '1') return {};
   const supportFilePath = getSupportFilePath(target, projectRoot);
   if (!supportFilePath || !fs.existsSync(supportFilePath)) {
     return {};

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -364,6 +364,7 @@ export interface InstallResult {
   installedSupportFiles: string[];
   skipped: string[];
   skippedSupportFiles: string[];
+  declinedSupportFiles: string[];
   errors: Array<{ agent: string; error: string }>;
 }
 
@@ -540,6 +541,7 @@ export function install(options: InstallOptions): InstallResult {
   const installedSupportFiles: string[] = [];
   const skipped: string[] = [];
   const skippedSupportFiles: string[] = [];
+  const declinedSupportFiles: string[] = [];
   const errors: Array<{ agent: string; error: string }> = [];
   const processedAgentIds = new Set<string>();
   const processedSkillIds = new Set<string>();
@@ -721,7 +723,7 @@ export function install(options: InstallOptions): InstallResult {
     const claudeMdPath = getClaudeMdPath(projectRoot);
     const shouldPatchClaudeMd = patch || patchClaudeMd;
     if (skippedSupportSet.has(claudeMdPath)) {
-      skippedSupportFiles.push(claudeMdPath);
+      declinedSupportFiles.push(claudeMdPath);
     } else if (fs.existsSync(claudeMdPath) && !force && !shouldPatchClaudeMd) {
       skippedSupportFiles.push(claudeMdPath);
     } else {
@@ -751,7 +753,7 @@ export function install(options: InstallOptions): InstallResult {
     const agentsMdPath = getCodexAgentsMdPath(projectRoot);
     const shouldPatchGeminiMd = patch || patchGeminiMd;
     if (skippedSupportSet.has(geminiMdPath)) {
-      skippedSupportFiles.push(geminiMdPath);
+      declinedSupportFiles.push(geminiMdPath);
     } else if (fs.existsSync(geminiMdPath) && !force && !shouldPatchGeminiMd) {
       skippedSupportFiles.push(geminiMdPath);
     } else {
@@ -796,7 +798,7 @@ export function install(options: InstallOptions): InstallResult {
   if (!disableSupportFiles && target === 'codex') {
     const agentsMdPath = getCodexAgentsMdPath(projectRoot);
     if (skippedSupportSet.has(agentsMdPath)) {
-      skippedSupportFiles.push(agentsMdPath);
+      declinedSupportFiles.push(agentsMdPath);
     } else if (fs.existsSync(agentsMdPath) && !force && !patch) {
       skippedSupportFiles.push(agentsMdPath);
     } else {
@@ -828,6 +830,7 @@ export function install(options: InstallOptions): InstallResult {
     installedSupportFiles,
     skipped,
     skippedSupportFiles,
+    declinedSupportFiles,
     errors
   };
 }
@@ -954,6 +957,22 @@ export async function runInstall(
     explicitAgentSelection || agents.length > 0
       ? agents
       : withImplicitAgents(priorConfig?.agents ?? []);
+
+  const supportDecisions = new Map<Target, SupportFileDecision>();
+  for (const target of targets) {
+    const supportDecision = await confirmSupportFileOverwrite(
+      target,
+      projectRoot,
+      options.force ?? false,
+      options.yes ?? false
+    );
+    if (supportDecision.error) {
+      console.error(supportDecision.error);
+      return 1;
+    }
+    supportDecisions.set(target, supportDecision);
+  }
+
   saveConfig(
     {
       targets,
@@ -967,16 +986,7 @@ export async function runInstall(
   );
 
   for (const target of targets) {
-    const supportDecision = await confirmSupportFileOverwrite(
-      target,
-      projectRoot,
-      options.force ?? false,
-      options.yes ?? false
-    );
-    if (supportDecision.error) {
-      console.error(supportDecision.error);
-      return 1;
-    }
+    const supportDecision = supportDecisions.get(target) ?? {};
     if (supportDecision.skipSupportFile) {
       console.log(
         `Skipped support file: ${getSupportFileLabel(supportDecision.skipSupportFile)} (${supportDecision.skipSupportFile})`
@@ -1072,6 +1082,11 @@ export async function runInstall(
         `Skipped support files (already present; use --force to overwrite): ${result.skippedSupportFiles.join(
           ', '
         )}`
+      );
+    }
+    if (result.declinedSupportFiles.length > 0) {
+      console.log(
+        `Skipped support files (overwrite declined): ${result.declinedSupportFiles.join(', ')}`
       );
     }
     if (

--- a/scripts/smoke-monorepo-patch.sh
+++ b/scripts/smoke-monorepo-patch.sh
@@ -111,6 +111,11 @@ Read and follow these rule files in \`${existing_path%/old.md}/\` when they appl
 EOF
 }
 
+remove_support_files() {
+  local monorepo="$1"
+  rm -f "${monorepo}/CLAUDE.md" "${monorepo}/AGENTS.md" "${monorepo}/GEMINI.md"
+}
+
 rule_path() {
   local monorepo="$1"
   local target="$2"
@@ -238,6 +243,8 @@ run_typescript_smoke() {
     verify_rule "${rule_file}" "## When Completed"
     verify_support_file "${monorepo}" "${target}" "${rule_name}"
 
+    remove_support_files "${monorepo}"
+
     (
       cd "${monorepo}"
       node "${REPO_ROOT}/packages/ballast-typescript/dist/cli.js" install --target "${target}" --agent linting --force --yes
@@ -273,6 +280,8 @@ run_python_smoke() {
     verify_rule "${rule_file}" "## Baseline Tooling"
     verify_support_file "${monorepo}" "${target}" "${rule_name}"
 
+    remove_support_files "${monorepo}"
+
     (
       cd "${monorepo}"
       PYTHONPATH="${REPO_ROOT}/packages/ballast-python" python3 -m ballast install --language python --target "${target}" --agent linting --force --yes
@@ -307,6 +316,8 @@ run_go_smoke() {
     rule_file="$(rule_path "${monorepo}" "${target}" "${rule_name}")"
     verify_rule "${rule_file}" "## Commands"
     verify_support_file "${monorepo}" "${target}" "${rule_name}"
+
+    remove_support_files "${monorepo}"
 
     (
       cd "${monorepo}"

--- a/scripts/smoke-wrapper-monorepo.sh
+++ b/scripts/smoke-wrapper-monorepo.sh
@@ -247,7 +247,7 @@ EOF
 
   (
     cd "${project}"
-    ballast --language go upgrade
+    ballast --language go upgrade --force
   )
 
   grep -q "# OWASP Security Scan Skill" "${project}/.codex/rules/owasp-security-scan.md"


### PR DESCRIPTION
## Summary
- add --patch support for existing skill files across the TypeScript, Python, and Go backends
- prompt before destructive --force overwrites of existing support files and abort in non-interactive mode
- update PRD, tests, CLI help text, and installation docs to match the new behavior

## Testing
- pnpm test -- --runInBand src/install.test.ts src/cli.test.ts
- python3 -m unittest packages.ballast-python.tests.test_cli
- go test ./cmd/ballast-go

Closes #132