### PR TITLE
Add e2e lifecycle coverage for existing installs

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -266,3 +266,128 @@ jobs:
 
       - name: Run wrapper monorepo smoke test
         run: ./scripts/smoke-wrapper-monorepo.sh "$GITHUB_WORKSPACE/.ci/ballast-examples"
+
+  e2e:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: upgrade-refresh-skills-e2e
+            script: ./scripts/e2e-upgrade-refresh-skills.sh
+          - name: upgrade-patch-unreadable-claude-skill-e2e
+            script: ./scripts/e2e-upgrade-patch-unreadable-claude-skill.sh
+          - name: remove-target-existing-install-e2e
+            script: ./scripts/e2e-remove-target-existing-install.sh
+          - name: refresh-after-target-removal-e2e
+            script: ./scripts/e2e-refresh-after-target-removal.sh
+          - name: add-skill-existing-install-e2e
+            script: ./scripts/e2e-add-skill-existing-install.sh
+          - name: change-task-system-e2e
+            script: ./scripts/e2e-change-task-system.sh
+            needs_typescript: true
+
+    steps:
+      - name: Checkout ballast repo
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/ballast-go/go.mod
+
+      - name: Setup pnpm
+        if: matrix.needs_typescript
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.27.0
+
+      - name: Setup Node.js
+        if: matrix.needs_typescript
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: matrix.needs_typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ballast wrapper and Go backend
+        run: make build-go build-cli
+
+      - name: Build ballast-typescript
+        if: matrix.needs_typescript
+        run: pnpm run build
+
+      - name: Run e2e script
+        run: SKIP_BUILD=1 "${{ matrix.script }}" "$GITHUB_WORKSPACE"
+
+  e2e-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: add-target-existing-install-e2e
+            script: ./scripts/e2e-add-target-existing-install.sh
+          - name: add-agent-existing-install-e2e
+            script: ./scripts/e2e-add-agent-existing-install.sh
+          - name: add-task-system-e2e
+            script: ./scripts/e2e-add-task-system.sh
+            needs_typescript: true
+          - name: doctor-after-lifecycle-change-e2e
+            script: ./scripts/e2e-doctor-after-lifecycle-change.sh
+          - name: remove-skill-existing-install-e2e
+            script: ./scripts/e2e-remove-skill-existing-install.sh
+          - name: remove-agent-existing-install-e2e
+            script: ./scripts/e2e-remove-agent-existing-install.sh
+
+    steps:
+      - name: Checkout ballast repo
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/ballast-go/go.mod
+
+      - name: Setup pnpm
+        if: matrix.needs_typescript
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.27.0
+
+      - name: Setup Node.js
+        if: matrix.needs_typescript
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        if: matrix.needs_typescript
+        run: pnpm install --frozen-lockfile
+
+      - name: Build ballast wrapper and Go backend
+        run: make build-go build-cli
+
+      - name: Build ballast-typescript
+        if: matrix.needs_typescript
+        run: pnpm run build
+
+      - name: Run e2e script
+        run: SKIP_BUILD=1 "${{ matrix.script }}" "$GITHUB_WORKSPACE"

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -346,6 +346,7 @@ jobs:
             needs_typescript: true
           - name: doctor-after-lifecycle-change-e2e
             script: ./scripts/e2e-doctor-after-lifecycle-change.sh
+            needs_typescript: true
           - name: remove-skill-existing-install-e2e
             script: ./scripts/e2e-remove-skill-existing-install.sh
           - name: remove-agent-existing-install-e2e

--- a/PRD.md
+++ b/PRD.md
@@ -81,6 +81,27 @@ Ballast-installed skill files are generated managed artifacts, but the current r
 4. Automated unit coverage demonstrates the backend skill refresh behavior for TypeScript, Python, and Go.
 5. Smoke coverage demonstrates the wrapper upgrade path refreshes stale managed skill content.
 
+## Existing Install Refresh Reconciliation
+
+### Problem
+
+Ballast refreshes saved installs from `.rulesrc.json`, but removing managed agents or skills from saved config can leave stale managed files on disk for targets that remain installed. Operators need refresh behavior that reconciles the managed surface to the current saved config instead of only adding newly selected content.
+
+### Requirements
+
+1. Wrapper `install --refresh-config`, `upgrade`, and `doctor --fix` must remove stale managed agent-rule files for agents no longer present in saved `.rulesrc.json` while preserving remaining configured agents.
+2. Wrapper `install --refresh-config`, `upgrade`, and `doctor --fix` must remove stale managed skill files for skills no longer present in saved `.rulesrc.json` while preserving remaining configured skills.
+3. Reconciliation must apply only to Ballast-managed files for targets that remain installed; it must not remove unrelated user files.
+4. Support-file managed sections such as `AGENTS.md` and `CLAUDE.md` must be refreshed so removed agents and skills are no longer referenced.
+5. Target removal behavior must remain unchanged and continue deleting the full Ballast-managed surface for removed targets.
+
+### Acceptance Criteria
+
+1. Given an existing install with configured agents `linting, docs`, editing `.rulesrc.json` to keep only `linting` and running wrapper `install --refresh-config` deletes the managed `docs` rule files while leaving `linting` files intact.
+2. Given an existing install with configured skills `owasp-security-scan, github-health-check`, editing `.rulesrc.json` to keep only `owasp-security-scan` and running wrapper `install --refresh-config` deletes the managed `github-health-check` files while leaving `owasp-security-scan` intact.
+3. After either reconciliation flow, support files no longer list removed agent or skill references.
+4. Refresh does not delete unmanaged user-authored files outside the Ballast-managed paths for the retained targets.
+
 ## Ballast Doctor Config Visibility
 
 ### Problem
@@ -91,15 +112,17 @@ Operators use `ballast doctor` to inspect the effective Ballast state for a repo
 
 1. `ballast doctor` must display configured `languages` when `.rulesrc.json` contains them.
 2. `ballast doctor` must display configured `paths` when `.rulesrc.json` contains them.
-3. The change must apply consistently across the TypeScript, Python, Go, and wrapper CLIs.
-4. Existing `doctor` output for targets, agents, skills, installed CLIs, and recommendations must remain intact.
+3. `ballast doctor` must display configured `taskSystem` when `.rulesrc.json` contains it.
+4. The change must apply consistently across the TypeScript, Python, Go, and wrapper CLIs.
+5. Existing `doctor` output for targets, agents, skills, installed CLIs, and recommendations must remain intact.
 
 ### Acceptance Criteria
 
 1. Given a `.rulesrc.json` with `languages`, `ballast doctor` prints a `- languages: ...` line in the `Config:` section.
 2. Given a `.rulesrc.json` with `paths`, `ballast doctor` prints a `- paths: ...` line in the `Config:` section.
-3. Given a `.rulesrc.json` without `languages` or `paths`, `ballast doctor` does not print empty placeholder lines for those fields.
-4. Automated tests cover the new output in each CLI implementation that renders `doctor` output.
+3. Given a `.rulesrc.json` with `taskSystem`, `ballast doctor` prints a `- taskSystem: ...` line in the `Config:` section.
+4. Given a `.rulesrc.json` without `languages`, `paths`, or `taskSystem`, `ballast doctor` does not print empty placeholder lines for those fields.
+5. Automated tests cover the new output in each CLI implementation that renders `doctor` output.
 
 ## JavaScript Detection Warning
 

--- a/PRD.md
+++ b/PRD.md
@@ -44,6 +44,7 @@ Ballast does not apply the same overwrite decision matrix to installed skill fil
 6. Creating a missing support file with `--force` must continue without prompting.
 7. Support-file patch behavior and existing agent-rule overwrite semantics must remain unchanged.
 8. README and installation documentation must describe the updated `--patch` and `--force` behavior.
+9. If an existing Claude `.skill` archive is unreadable during `--patch`, install must recover by overwriting it with canonical packaged skill content instead of failing the run.
 
 ### Acceptance Criteria
 
@@ -56,6 +57,7 @@ Ballast does not apply the same overwrite decision matrix to installed skill fil
 7. Given an existing support file and non-interactive `--force`, install exits with an error and does not overwrite the file.
 8. Automated tests cover the skill-file decision matrix and support-file confirmation behavior in the TypeScript, Python, and Go backends.
 9. README and `docs/installation.md` describe when to use `--patch` versus `--force`, including the support-file confirmation behavior.
+10. Given an existing unreadable Claude `.skill` archive and `force=false, patch=true`, install replaces it with canonical content and completes without an install error.
 
 ## Ballast Upgrade Skill Refresh
 

--- a/PRD.md
+++ b/PRD.md
@@ -67,19 +67,21 @@ Ballast-installed skill files are generated managed artifacts, but the current r
 
 ### Requirements
 
-1. Normal install refreshes must rewrite selected managed skill files when they already exist.
-2. `ballast upgrade` and `doctor --fix` must refresh saved skill selections through their existing `install --refresh-config` path without requiring `--force`.
-3. Existing agent rule overwrite, patch, and force semantics must remain unchanged.
-4. The behavior must stay consistent across the TypeScript, Python, Go, and wrapper CLIs.
-5. Support files such as `AGENTS.md` and `CLAUDE.md` must continue reflecting the saved skill list after refresh.
+1. Config-refresh flows (`install --refresh-config`, `upgrade`, and `doctor --fix`) must rewrite selected managed skill files when they already exist.
+2. Ordinary backend install behavior outside those refresh flows must keep the existing skill decision matrix: skip on existing files unless `--patch` or `--force` is selected.
+3. `ballast upgrade` and `doctor --fix` must refresh saved skill selections through their existing `install --refresh-config` path without requiring `--force`.
+4. Existing agent rule overwrite, patch, and force semantics must remain unchanged.
+5. The behavior must stay consistent across the TypeScript, Python, Go, and wrapper CLIs.
+6. Support files such as `AGENTS.md` and `CLAUDE.md` must continue reflecting the saved skill list after refresh.
 
 ### Acceptance Criteria
 
-1. Given an existing installed skill file with stale content, running backend install with the same skill and `force=false` rewrites the file to current packaged skill content.
-2. Given an existing installed agent rule and `force=false`, backend install still skips the rule unless patch mode or force mode is selected.
-3. Given a repository with `.rulesrc.json` that declares a skill, running wrapper `upgrade` without `--force` invokes the refresh path that updates the existing managed skill file.
-4. Automated unit coverage demonstrates the backend skill refresh behavior for TypeScript, Python, and Go.
-5. Smoke coverage demonstrates the wrapper upgrade path refreshes stale managed skill content.
+1. Given an existing installed skill file with stale content, running backend install with the same skill and `force=false, patch=false` leaves the file unchanged outside config-refresh flows.
+2. Given an existing installed skill file with stale content and refresh mode enabled through the wrapper config-refresh path, backend install rewrites the file to current packaged skill content without `--force`.
+3. Given an existing installed agent rule and `force=false`, backend install still skips the rule unless patch mode or force mode is selected.
+4. Given a repository with `.rulesrc.json` that declares a skill, running wrapper `upgrade` without `--force` invokes the refresh path that updates the existing managed skill file.
+5. Automated unit coverage demonstrates the backend skill refresh behavior for TypeScript, Python, and Go.
+6. Smoke coverage demonstrates the wrapper upgrade path refreshes stale managed skill content.
 
 ## Existing Install Refresh Reconciliation
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -216,6 +219,7 @@ func run(args []string) int {
 	}
 
 	root := findProjectRoot("")
+	refreshConfigRequested := len(forwardedArgs) > 0 && forwardedArgs[0] == "install" && hasFlag(forwardedArgs, "--refresh-config", "")
 	normalizedArgs, err := normalizeInstallArgs(forwardedArgs, root)
 	if err != nil {
 		fmt.Println(err)
@@ -235,6 +239,10 @@ func run(args []string) int {
 				if !ok {
 					fmt.Printf("Unsupported language: %s\n", invocation.Language)
 					return 1
+				}
+				if refreshConfigRequested {
+					invocation.Env = cloneEnvMap(invocation.Env)
+					invocation.Env["BALLAST_REFRESH_SKILLS"] = "1"
 				}
 				resolved := resolveBackendCommand(invocation.Language, tool, invocation.Args, invocation.Env)
 				if !resolved.UseLocal {
@@ -293,13 +301,17 @@ func run(args []string) int {
 		return 1
 	}
 
-	resolved := resolveBackendCommand(selectedLanguage, tool, forwardedArgs, nil)
+	singleEnv := map[string]string(nil)
+	if refreshConfigRequested {
+		singleEnv = map[string]string{"BALLAST_REFRESH_SKILLS": "1"}
+	}
+	resolved := resolveBackendCommand(selectedLanguage, tool, forwardedArgs, singleEnv)
 	if !resolved.UseLocal {
 		if err := ensureInstalledFunc(tool); err != nil {
 			fmt.Println(err)
 			return 1
 		}
-		resolved = resolveBackendCommand(selectedLanguage, tool, forwardedArgs, nil)
+		resolved = resolveBackendCommand(selectedLanguage, tool, forwardedArgs, singleEnv)
 	}
 
 	exitCode, err := execToolFunc(resolved.Binary, resolved.Args, "", resolved.Env)
@@ -1651,11 +1663,12 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	commonSelection := filterAgents(selectedAgents, commonAgentIDs())
 	languageSelection := filterAgents(selectedAgents, languageAgentIDs())
 	baseArgs := withTargetSelection(stripMonorepoFlags(args), requestedTargets)
+	requestedTaskSystem := strings.TrimSpace(strings.ToLower(findFlagValue(args, "--task-system", "")))
 
 	plan := make([]backendInvocation, 0, len(profiles)+1)
 	commonArgs := withSkillSelection(withAgentSelection(baseArgs, commonSelection), selectedSkills)
-	if findFlagValue(args, "--task-system", "") != "" && slices.Contains(configToSave.Agents, "tasks") && !hasFlag(commonArgs, "--force", "") {
-		commonArgs = append(commonArgs, "--force")
+	if requestedTaskSystem != "" && slices.Contains(configToSave.Agents, "tasks") {
+		commonArgs = append(commonArgs, "--task-system", requestedTaskSystem)
 	}
 	if len(commonSelection) > 0 || len(selectedSkills) > 0 {
 		commonLanguage := profiles[0].Language
@@ -1663,11 +1676,15 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 			commonLanguage = langTypeScript
 		}
 		tool := toolsByLanguage[commonLanguage]
+		env := monorepoInvocationEnv("common")
+		if requestedTaskSystem != "" && slices.Contains(commonSelection, "tasks") {
+			env["BALLAST_REFRESH_TASK_RULES"] = "1"
+		}
 		plan = append(plan, backendInvocation{
 			Language: commonLanguage,
 			Binary:   tool.binary,
 			Dir:      root,
-			Env:      monorepoInvocationEnv("common"),
+			Env:      env,
 			Args:     commonArgs,
 		})
 	}
@@ -1975,10 +1992,17 @@ func stripMonorepoFlags(args []string) []string {
 			i++
 			continue
 		}
+		if arg == "--task-system" {
+			i++
+			continue
+		}
 		if strings.HasPrefix(arg, "--language=") {
 			continue
 		}
 		if strings.HasPrefix(arg, "--remove-target=") {
+			continue
+		}
+		if strings.HasPrefix(arg, "--task-system=") {
 			continue
 		}
 		filtered = append(filtered, arg)
@@ -2163,7 +2187,8 @@ func envPairs(env map[string]string) []string {
 }
 
 func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) error {
-	_ = args
+	allowReplaceUnmanaged := hasPatchFlag(args)
+	interactive := isInteractiveInstall(args)
 	for _, target := range plan.Targets {
 		if target != "claude" && target != "codex" && target != "gemini" {
 			continue
@@ -2176,7 +2201,17 @@ func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) 
 			}
 			continue
 		}
-		if err := os.WriteFile(path, []byte(patchManagedSupportSections(readFile(path), content)), 0o644); err != nil {
+		existing := readFile(path)
+		allowUnmanaged := allowReplaceUnmanaged
+		if !allowUnmanaged && interactive && supportFileHasUnmanagedManagedSections(existing) {
+			confirmed, err := promptSupportFilePatch(path)
+			if err != nil {
+				return err
+			}
+			allowUnmanaged = confirmed
+		}
+		merged := mergeManagedSupportSections(existing, content, allowUnmanaged)
+		if err := os.WriteFile(path, []byte(merged), 0o644); err != nil {
 			return err
 		}
 		if target == "gemini" {
@@ -2227,13 +2262,20 @@ func removeStaleManagedFiles(root string, target string, next *monorepoConfig) e
 	if next == nil {
 		return nil
 	}
+	trackedPaths := ballastManagedPathsFromSupportFile(root, target)
 	for _, file := range stringDifference(allManagedRulePaths(root, target), managedRulePaths(root, target, next)) {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] {
+			continue
+		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
 	}
 	for _, file := range stringDifference(allManagedSkillPaths(root, target), managedSkillPaths(root, target, next.Skills)) {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] {
+			continue
+		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -2571,6 +2613,8 @@ func patchInstalledRulesSection(existing string, canonical string) string {
 }
 
 const rootPlaceholder = "__BALLAST_ROOT__"
+const ballastManagedMarker = "Created by [Ballast]"
+const ballastManagedSectionNotice = "Created by Ballast. Do not edit this section."
 
 func patchManagedSupportSections(existing string, canonical string) string {
 	next := existing
@@ -2597,6 +2641,48 @@ func patchSupportSection(existing string, canonical string, heading string) stri
 		strings.TrimLeft(existing[existingRange[1]:], "\n")
 }
 
+func mergeManagedSupportSections(existing string, canonical string, allowUnmanaged bool) string {
+	next := existing
+	for _, heading := range []string{"Installed agent rules", "Installed skills"} {
+		next = mergeSupportSection(next, canonical, heading, allowUnmanaged)
+	}
+	return next
+}
+
+func mergeSupportSection(existing string, canonical string, heading string, allowUnmanaged bool) string {
+	canonicalRange := findSectionRange(canonical, heading)
+	if canonicalRange == nil {
+		return existing
+	}
+	canonicalSection := strings.TrimRight(canonical[canonicalRange[0]:canonicalRange[1]], "\n")
+
+	existingRange := findSectionRange(existing, heading)
+	if existingRange == nil {
+		return strings.TrimRight(existing, "\n") + "\n\n" + canonicalSection + "\n"
+	}
+	existingSection := existing[existingRange[0]:existingRange[1]]
+	if !allowUnmanaged && !strings.Contains(existingSection, ballastManagedSectionNotice) {
+		return existing
+	}
+
+	return strings.TrimRight(existing[:existingRange[0]], "\n") + "\n\n" +
+		canonicalSection + "\n\n" +
+		strings.TrimLeft(existing[existingRange[1]:], "\n")
+}
+
+func supportFileHasUnmanagedManagedSections(existing string) bool {
+	for _, heading := range []string{"Installed agent rules", "Installed skills"} {
+		section := findSectionRange(existing, heading)
+		if section == nil {
+			continue
+		}
+		if !strings.Contains(existing[section[0]:section[1]], ballastManagedSectionNotice) {
+			return true
+		}
+	}
+	return false
+}
+
 func removeManagedSections(existing string) string {
 	next := existing
 	for _, heading := range []string{"Installed agent rules", "Installed skills"} {
@@ -2607,6 +2693,75 @@ func removeManagedSections(existing string) string {
 		next = strings.TrimRight(next[:section[0]], "\n") + "\n\n" + strings.TrimLeft(next[section[1]:], "\n")
 	}
 	return strings.TrimRight(next, "\n") + "\n"
+}
+
+func ballastOwnsManagedFile(path string) bool {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	if strings.HasSuffix(path, ".skill") {
+		reader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+		if err != nil {
+			return false
+		}
+		for _, file := range reader.File {
+			if file.Name != "SKILL.md" {
+				continue
+			}
+			rc, err := file.Open()
+			if err != nil {
+				return false
+			}
+			data, readErr := io.ReadAll(rc)
+			_ = rc.Close()
+			if readErr != nil {
+				return false
+			}
+			return strings.Contains(string(data), ballastManagedMarker)
+		}
+		return false
+	}
+	return strings.Contains(string(content), ballastManagedMarker)
+}
+
+func ballastManagedPathsFromSupportFile(root string, target string) map[string]bool {
+	if target != "claude" && target != "codex" && target != "gemini" {
+		return nil
+	}
+	path := supportFilePath(root, target)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	tracked := map[string]bool{}
+	for _, heading := range []string{"Installed agent rules", "Installed skills"} {
+		section := findSectionRange(string(content), heading)
+		if section == nil {
+			continue
+		}
+		sectionText := string(content[section[0]:section[1]])
+		if !strings.Contains(sectionText, ballastManagedSectionNotice) {
+			continue
+		}
+		for _, line := range strings.Split(sectionText, "\n") {
+			start := strings.Index(line, "`")
+			if start < 0 {
+				continue
+			}
+			rest := line[start+1:]
+			end := strings.Index(rest, "`")
+			if end < 0 {
+				continue
+			}
+			ref := strings.TrimSpace(rest[:end])
+			if ref == "" || filepath.IsAbs(ref) {
+				continue
+			}
+			tracked[filepath.Clean(filepath.Join(root, ref))] = true
+		}
+	}
+	return tracked
 }
 
 func findSectionRange(content string, heading string) []int {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -2331,7 +2331,6 @@ func cleanupStaleManagedSelections(root string, plan *monorepoPlan) error {
 }
 
 func removeStaleManagedFiles(root string, target string, previous *monorepoConfig, next *monorepoConfig) error {
-	_ = previous
 	if next == nil {
 		return nil
 	}
@@ -2346,7 +2345,7 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
 	}
 	for _, file := range stringDifference(allManagedSkillPaths(root, target), managedSkillPaths(root, target, next.Skills)) {
-		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !allowConfigBackedStaleSkillRemoval(target, file) {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !allowConfigBackedStaleSkillRemoval(root, target, file, previous) {
 			continue
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -2357,8 +2356,19 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 	return nil
 }
 
-func allowConfigBackedStaleSkillRemoval(target string, path string) bool {
-	return target == "cursor" || target == "opencode"
+func allowConfigBackedStaleSkillRemoval(root string, target string, path string, previous *monorepoConfig) bool {
+	if target != "cursor" && target != "opencode" {
+		return false
+	}
+	if previous == nil {
+		return false
+	}
+	for _, previousPath := range managedSkillPaths(root, target, previous.Skills) {
+		if previousPath == path {
+			return true
+		}
+	}
+	return false
 }
 
 func allManagedRulePaths(root string, target string) []string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -257,6 +257,10 @@ func run(args []string) int {
 				fmt.Println(err)
 				return 1
 			}
+			if err := cleanupStaleManagedSelections(root, plan); err != nil {
+				fmt.Println(err)
+				return 1
+			}
 			if err := updateMonorepoSupportFiles(root, plan, forwardedArgs); err != nil {
 				fmt.Println(err)
 				return 1
@@ -759,6 +763,9 @@ func printDoctorSummary(root string, selectedLanguage language, fix bool) {
 	}
 	if formattedPaths := formatDoctorConfigPaths(config.Languages, config.Paths); formattedPaths != "" {
 		fmt.Printf("- paths: %s\n", formattedPaths)
+	}
+	if strings.TrimSpace(config.TaskSystem) != "" {
+		fmt.Printf("- taskSystem: %s\n", config.TaskSystem)
 	}
 	fmt.Println()
 }
@@ -1613,6 +1620,9 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if config != nil {
 		savedTaskSystem = config.TaskSystem
 	}
+	if taskSystem := strings.TrimSpace(strings.ToLower(findFlagValue(args, "--task-system", ""))); taskSystem != "" {
+		savedTaskSystem = taskSystem
+	}
 	configToSave := monorepoConfig{
 		Targets:        savedTargets,
 		Agents:         persistAgents,
@@ -1644,6 +1654,9 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 
 	plan := make([]backendInvocation, 0, len(profiles)+1)
 	commonArgs := withSkillSelection(withAgentSelection(baseArgs, commonSelection), selectedSkills)
+	if findFlagValue(args, "--task-system", "") != "" && slices.Contains(configToSave.Agents, "tasks") && !hasFlag(commonArgs, "--force", "") {
+		commonArgs = append(commonArgs, "--force")
+	}
 	if len(commonSelection) > 0 || len(selectedSkills) > 0 {
 		commonLanguage := profiles[0].Language
 		if hasLanguage(profiles, langTypeScript) {
@@ -1683,8 +1696,8 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		Invocations: plan,
 		Config:      configToSave,
 		Targets:     requestedTargets,
-		Common:      commonSelection,
-		Language:    languageSelection,
+		Common:      filterAgents(configToSave.Agents, commonAgentIDs()),
+		Language:    filterAgents(configToSave.Agents, languageAgentIDs()),
 		Removed:     removeTargets,
 		Previous:    config,
 	}, nil
@@ -2081,6 +2094,24 @@ func subtractStrings(values []string, remove []string) []string {
 	return uniqueStrings(filtered)
 }
 
+func stringDifference(values []string, remove []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	removeSet := map[string]struct{}{}
+	for _, value := range remove {
+		removeSet[value] = struct{}{}
+	}
+	filtered := make([]string, 0, len(values))
+	for _, value := range uniqueStrings(values) {
+		if _, ok := removeSet[value]; ok {
+			continue
+		}
+		filtered = append(filtered, value)
+	}
+	return filtered
+}
+
 func hasLanguage(profiles []repoProfile, target language) bool {
 	for _, profile := range profiles {
 		if profile.Language == target {
@@ -2132,6 +2163,7 @@ func envPairs(env map[string]string) []string {
 }
 
 func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) error {
+	_ = args
 	for _, target := range plan.Targets {
 		if target != "claude" && target != "codex" && target != "gemini" {
 			continue
@@ -2144,22 +2176,8 @@ func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) 
 			}
 			continue
 		}
-		if hasPatchFlag(args) {
-			if err := os.WriteFile(path, []byte(patchManagedSupportSections(readFile(path), content)), 0o644); err != nil {
-				return err
-			}
-			continue
-		}
-		if isInteractiveInstall(args) {
-			approved, err := promptSupportFilePatch(path)
-			if err != nil {
-				return err
-			}
-			if approved {
-				if err := os.WriteFile(path, []byte(patchManagedSupportSections(readFile(path), content)), 0o644); err != nil {
-					return err
-				}
-			}
+		if err := os.WriteFile(path, []byte(patchManagedSupportSections(readFile(path), content)), 0o644); err != nil {
+			return err
 		}
 		if target == "gemini" {
 			agentsPath := supportFilePath(root, "codex")
@@ -2191,6 +2209,52 @@ func cleanupRemovedMonorepoTargets(root string, plan *monorepoPlan) error {
 		}
 	}
 	return nil
+}
+
+func cleanupStaleManagedSelections(root string, plan *monorepoPlan) error {
+	if plan == nil {
+		return nil
+	}
+	for _, target := range plan.Targets {
+		if err := removeStaleManagedFiles(root, target, &plan.Config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeStaleManagedFiles(root string, target string, next *monorepoConfig) error {
+	if next == nil {
+		return nil
+	}
+	for _, file := range stringDifference(allManagedRulePaths(root, target), managedRulePaths(root, target, next)) {
+		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
+	}
+	for _, file := range stringDifference(allManagedSkillPaths(root, target), managedSkillPaths(root, target, next.Skills)) {
+		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
+	}
+	return nil
+}
+
+func allManagedRulePaths(root string, target string) []string {
+	languages := make([]string, 0, len(supportedLanguages))
+	for _, lang := range supportedLanguages {
+		languages = append(languages, string(lang))
+	}
+	return managedRulePaths(root, target, &monorepoConfig{
+		Agents:    supportedAgentIDs(),
+		Languages: languages,
+	})
+}
+
+func allManagedSkillPaths(root string, target string) []string {
+	return managedSkillPaths(root, target, supportedSkillIDs())
 }
 
 func removeManagedTargetFiles(root string, target string, config *monorepoConfig) error {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -132,6 +132,8 @@ var runCommandOutputFunc = runCommandOutput
 var resolveInstalledVersionFunc = resolveInstalledVersion
 var collectDoctorBackendsFunc = collectDoctorBackends
 
+var supportedTaskSystems = []string{"github", "jira", "linear"}
+
 type monorepoConfig struct {
 	Target         string              `json:"target,omitempty"`
 	Targets        []string            `json:"targets,omitempty"`
@@ -322,6 +324,12 @@ func run(args []string) int {
 	if err != nil {
 		fmt.Println(err)
 		return 1
+	}
+	if exitCode == 0 && refreshConfigRequested {
+		if err := cleanupSingleLanguageManagedSelections(root, selectedLanguage); err != nil {
+			fmt.Println(err)
+			return 1
+		}
 	}
 	return exitCode
 }
@@ -1524,6 +1532,11 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		return nil, nil
 	}
 
+	requestedTaskSystem, err := parseTaskSystemFlag(args)
+	if err != nil {
+		return nil, err
+	}
+
 	config, err := loadMonorepoConfig(root)
 	if err != nil {
 		return nil, err
@@ -1636,8 +1649,8 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if config != nil {
 		savedTaskSystem = config.TaskSystem
 	}
-	if taskSystem := strings.TrimSpace(strings.ToLower(findFlagValue(args, "--task-system", ""))); taskSystem != "" {
-		savedTaskSystem = taskSystem
+	if requestedTaskSystem != "" {
+		savedTaskSystem = requestedTaskSystem
 	}
 	configToSave := monorepoConfig{
 		Targets:        savedTargets,
@@ -1667,8 +1680,6 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	commonSelection := filterAgents(selectedAgents, commonAgentIDs())
 	languageSelection := filterAgents(selectedAgents, languageAgentIDs())
 	baseArgs := withTargetSelection(stripMonorepoFlags(args), requestedTargets)
-	requestedTaskSystem := strings.TrimSpace(strings.ToLower(findFlagValue(args, "--task-system", "")))
-
 	plan := make([]backendInvocation, 0, len(profiles)+1)
 	commonArgs := withSkillSelection(withAgentSelection(baseArgs, commonSelection), selectedSkills)
 	if requestedTaskSystem != "" && slices.Contains(configToSave.Agents, "tasks") {
@@ -1745,6 +1756,28 @@ func loadMonorepoConfig(root string) (*monorepoConfig, error) {
 		return nil, nil
 	}
 	return &config, nil
+}
+
+func cleanupSingleLanguageManagedSelections(root string, selectedLanguage language) error {
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		return err
+	}
+	if config == nil {
+		return nil
+	}
+	if len(config.Targets) == 0 {
+		return nil
+	}
+	if len(config.Languages) == 0 && selectedLanguage != "" {
+		config.Languages = []string{string(selectedLanguage)}
+	}
+	for _, target := range config.Targets {
+		if err := removeStaleManagedFiles(root, target, nil, config); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // readTaskSystem reads only the taskSystem field from .rulesrc.json.
@@ -1956,6 +1989,41 @@ func splitAgentValues(raw string) []string {
 		agents = append(agents, trimmed)
 	}
 	return agents
+}
+
+func parseTaskSystemFlag(args []string) (string, error) {
+	raw := ""
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "--task-system=") {
+			raw = strings.TrimSpace(strings.TrimPrefix(arg, "--task-system="))
+			continue
+		}
+		if arg != "--task-system" {
+			continue
+		}
+		if i+1 >= len(args) {
+			return "", errors.New("missing value for --task-system")
+		}
+		candidate := strings.TrimSpace(args[i+1])
+		if candidate == "" || strings.HasPrefix(candidate, "-") {
+			return "", errors.New("missing value for --task-system")
+		}
+		raw = candidate
+		i++
+	}
+	if raw == "" {
+		return "", nil
+	}
+	normalized := strings.ToLower(raw)
+	if slices.Contains(supportedTaskSystems, normalized) {
+		return normalized, nil
+	}
+	return "", fmt.Errorf(
+		"invalid --task-system: %s (valid: %s)",
+		raw,
+		strings.Join(supportedTaskSystems, ", "),
+	)
 }
 
 func findFlagValue(args []string, longFlag string, shortFlag string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -243,6 +243,7 @@ func run(args []string) int {
 				if refreshConfigRequested {
 					invocation.Env = cloneEnvMap(invocation.Env)
 					invocation.Env["BALLAST_REFRESH_SKILLS"] = "1"
+					invocation.Env["BALLAST_REFRESH_TASK_RULES"] = "1"
 				}
 				resolved := resolveBackendCommand(invocation.Language, tool, invocation.Args, invocation.Env)
 				if !resolved.UseLocal {
@@ -303,7 +304,10 @@ func run(args []string) int {
 
 	singleEnv := map[string]string(nil)
 	if refreshConfigRequested {
-		singleEnv = map[string]string{"BALLAST_REFRESH_SKILLS": "1"}
+		singleEnv = map[string]string{
+			"BALLAST_REFRESH_SKILLS":     "1",
+			"BALLAST_REFRESH_TASK_RULES": "1",
+		}
 	}
 	resolved := resolveBackendCommand(selectedLanguage, tool, forwardedArgs, singleEnv)
 	if !resolved.UseLocal {
@@ -2251,14 +2255,15 @@ func cleanupStaleManagedSelections(root string, plan *monorepoPlan) error {
 		return nil
 	}
 	for _, target := range plan.Targets {
-		if err := removeStaleManagedFiles(root, target, &plan.Config); err != nil {
+		if err := removeStaleManagedFiles(root, target, plan.Previous, &plan.Config); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func removeStaleManagedFiles(root string, target string, next *monorepoConfig) error {
+func removeStaleManagedFiles(root string, target string, previous *monorepoConfig, next *monorepoConfig) error {
+	_ = previous
 	if next == nil {
 		return nil
 	}
@@ -2273,7 +2278,7 @@ func removeStaleManagedFiles(root string, target string, next *monorepoConfig) e
 		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
 	}
 	for _, file := range stringDifference(allManagedSkillPaths(root, target), managedSkillPaths(root, target, next.Skills)) {
-		if !ballastOwnsManagedFile(file) && !trackedPaths[file] {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !allowConfigBackedStaleSkillRemoval(target, file) {
 			continue
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -2282,6 +2287,10 @@ func removeStaleManagedFiles(root string, target string, next *monorepoConfig) e
 		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
 	}
 	return nil
+}
+
+func allowConfigBackedStaleSkillRemoval(target string, path string) bool {
+	return target == "cursor" || target == "opencode"
 }
 
 func allManagedRulePaths(root string, target string) []string {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -121,7 +121,8 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
   "paths":{
     "typescript":["apps/web"],
     "ansible":["infra/ansible"]
-  }
+  },
+  "taskSystem":"jira"
 }`)
 
 	output := captureStdout(t, func() {
@@ -149,6 +150,9 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 	if !strings.Contains(output, "paths: typescript=apps/web; ansible=infra/ansible") {
 		t.Fatalf("expected config paths in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "taskSystem: jira") {
+		t.Fatalf("expected config task system in doctor output, got %q", output)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -1177,6 +1177,9 @@ func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 	if invocation.Env["BALLAST_REFRESH_SKILLS"] != "1" {
 		t.Fatalf("expected refresh-config to enable managed skill refresh, got %#v", invocation.Env)
 	}
+	if invocation.Env["BALLAST_REFRESH_TASK_RULES"] != "1" {
+		t.Fatalf("expected refresh-config to enable task rule refresh, got %#v", invocation.Env)
+	}
 }
 
 func TestRunInstallCLICommand(t *testing.T) {
@@ -2986,11 +2989,17 @@ func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
 		Languages:  []string{"typescript"},
 		TaskSystem: "",
 	}
+	previous := &monorepoConfig{
+		Targets:   []string{"codex", "claude"},
+		Agents:    []string{"local-dev", "docs"},
+		Skills:    []string{"owasp-security-scan", "github-health-check"},
+		Languages: []string{"typescript"},
+	}
 
-	if err := removeStaleManagedFiles(root, "codex", next); err != nil {
+	if err := removeStaleManagedFiles(root, "codex", previous, next); err != nil {
 		t.Fatalf("removeStaleManagedFiles(codex): %v", err)
 	}
-	if err := removeStaleManagedFiles(root, "claude", next); err != nil {
+	if err := removeStaleManagedFiles(root, "claude", previous, next); err != nil {
 		t.Fatalf("removeStaleManagedFiles(claude): %v", err)
 	}
 
@@ -2999,6 +3008,32 @@ func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(skillPath); err != nil {
 		t.Fatalf("expected unmanaged skill archive to remain, got %v", err)
+	}
+}
+
+func TestRemoveStaleManagedFilesDeletesConfigBackedOpencodeSkill(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, ".opencode", "skills", "github-health-check.md")
+	mustWriteFile(t, skillPath, "legacy managed skill without explicit marker\n")
+
+	previous := &monorepoConfig{
+		Targets:   []string{"opencode"},
+		Agents:    []string{"local-dev"},
+		Skills:    []string{"owasp-security-scan", "github-health-check"},
+		Languages: []string{"typescript"},
+	}
+	next := &monorepoConfig{
+		Targets:   []string{"opencode"},
+		Agents:    []string{"local-dev"},
+		Skills:    []string{"owasp-security-scan"},
+		Languages: []string{"typescript"},
+	}
+
+	if err := removeStaleManagedFiles(root, "opencode", previous, next); err != nil {
+		t.Fatalf("removeStaleManagedFiles(opencode): %v", err)
+	}
+	if _, err := os.Stat(skillPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected config-backed stale opencode skill to be removed, got %v", err)
 	}
 }
 
@@ -3224,6 +3259,56 @@ func TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig(t *testing.T) {
 	}
 	if !strings.Contains(string(config), `"taskSystem": "linear"`) {
 		t.Fatalf("expected taskSystem to be preserved from existing config, got %q", string(config))
+	}
+}
+
+func TestRunMonorepoRefreshConfigEnablesTaskAndSkillRefresh(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["codex"],
+  "agents": ["tasks", "linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["typescript", "python"],
+  "paths": {"typescript": ["apps/frontend"], "python": ["services/api"]},
+  "taskSystem": "linear"
+}`)
+
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	var invocations []backendInvocation
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		invocations = append(invocations, backendInvocation{
+			Binary: binary,
+			Args:   append([]string(nil), args...),
+			Dir:    dir,
+			Env:    cloneEnvMap(env),
+		})
+		return 0, nil
+	}
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--refresh-config"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if len(invocations) == 0 {
+		t.Fatal("expected backend invocations")
+	}
+	if invocations[0].Env["BALLAST_REFRESH_SKILLS"] != "1" {
+		t.Fatalf("expected refresh-config to enable skill refresh in common invocation, got %#v", invocations[0].Env)
+	}
+	if invocations[0].Env["BALLAST_REFRESH_TASK_RULES"] != "1" {
+		t.Fatalf("expected refresh-config to enable task refresh in common invocation, got %#v", invocations[0].Env)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -1182,6 +1182,37 @@ func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 	}
 }
 
+func TestRunInstallRefreshConfigCleansUpSingleLanguageStaleSelections(t *testing.T) {
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"opencode","agents":["linting"],"skills":[]}`)
+	staleSkill := filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md")
+	mustWriteFile(t, staleSkill, "# Skill\n\n<!-- Created by [Ballast](https://github.com/everydaydevopsio/ballast). Do not edit this section. -->\n")
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--refresh-config"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if _, err := os.Stat(staleSkill); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale single-language managed skill to be removed, stat err=%v", err)
+	}
+}
+
 func TestRunInstallCLICommand(t *testing.T) {
 	originalRun := runCommandFunc
 	t.Cleanup(func() {
@@ -3336,6 +3367,28 @@ func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
 	}
 	if plan.Invocations[0].Env["BALLAST_REFRESH_TASK_RULES"] != "1" {
 		t.Fatalf("expected task-system updates to refresh existing task rules, got %#v", plan.Invocations[0].Env)
+	}
+}
+
+func TestResolveMonorepoPlanRejectsMissingTaskSystemValue(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+
+	_, err := resolveMonorepoPlan(root, []string{"install", "--target", "cursor", "--agent", "tasks", "--task-system", "--yes"})
+	if err == nil || !strings.Contains(err.Error(), "missing value for --task-system") {
+		t.Fatalf("expected missing-value error, got %v", err)
+	}
+}
+
+func TestResolveMonorepoPlanRejectsInvalidTaskSystemValue(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+
+	_, err := resolveMonorepoPlan(root, []string{"install", "--target", "cursor", "--agent", "tasks", "--task-system=notion", "--yes"})
+	if err == nil || !strings.Contains(err.Error(), "invalid --task-system") {
+		t.Fatalf("expected invalid task-system error, got %v", err)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -3068,6 +3068,32 @@ func TestRemoveStaleManagedFilesDeletesConfigBackedOpencodeSkill(t *testing.T) {
 	}
 }
 
+func TestRemoveStaleManagedFilesPreservesUnmanagedOpencodeSkillNotInPreviousConfig(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, ".opencode", "skills", "github-health-check.md")
+	mustWriteFile(t, skillPath, "user-authored skill at canonical path\n")
+
+	previous := &monorepoConfig{
+		Targets:   []string{"opencode"},
+		Agents:    []string{"local-dev"},
+		Skills:    []string{"owasp-security-scan"},
+		Languages: []string{"typescript"},
+	}
+	next := &monorepoConfig{
+		Targets:   []string{"opencode"},
+		Agents:    []string{"local-dev"},
+		Skills:    []string{"owasp-security-scan"},
+		Languages: []string{"typescript"},
+	}
+
+	if err := removeStaleManagedFiles(root, "opencode", previous, next); err != nil {
+		t.Fatalf("removeStaleManagedFiles(opencode): %v", err)
+	}
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("expected unmanaged opencode skill to remain, got %v", err)
+	}
+}
+
 func TestRunMonorepoRemoveTargetCleansManagedRulesAndSupportFiles(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -1156,7 +1156,7 @@ func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 	ensureInstalledFunc = func(tool toolConfig) error { return nil }
 	var invocation backendInvocation
 	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
-		invocation = backendInvocation{Binary: binary, Args: append([]string(nil), args...)}
+		invocation = backendInvocation{Binary: binary, Args: append([]string(nil), args...), Env: cloneEnvMap(env)}
 		return 0, nil
 	}
 
@@ -1173,6 +1173,9 @@ func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 
 	if got := strings.Join(invocation.Args, " "); got != "install --yes" {
 		t.Fatalf("expected refresh-config to forward install --yes, got %q", got)
+	}
+	if invocation.Env["BALLAST_REFRESH_SKILLS"] != "1" {
+		t.Fatalf("expected refresh-config to enable managed skill refresh, got %#v", invocation.Env)
 	}
 }
 
@@ -2936,6 +2939,69 @@ func TestUpdateMonorepoSupportFilesCreatesClaudeMdAtRoot(t *testing.T) {
 	}
 }
 
+func TestUpdateMonorepoSupportFilesPreservesUnmanagedSectionsWithoutPatch(t *testing.T) {
+	root := t.TempDir()
+	plan := &monorepoPlan{
+		Targets:  []string{"claude"},
+		Common:   []string{"local-dev"},
+		Language: []string{"linting"},
+		Config: monorepoConfig{
+			Languages: []string{"typescript"},
+			Skills:    []string{"owasp-security-scan"},
+		},
+	}
+	mustWriteFile(t, filepath.Join(root, "CLAUDE.md"), "# CLAUDE.md\n\n## Team Notes\n\nKeep this section.\n\n## Installed agent rules\n\nCustom unmanaged rules section.\n\n## Installed skills\n\nCustom unmanaged skills section.\n")
+
+	if err := updateMonorepoSupportFiles(root, plan, []string{"install", "--target", "claude", "--all", "--yes"}); err != nil {
+		t.Fatalf("updateMonorepoSupportFiles returned error: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "Custom unmanaged rules section.") {
+		t.Fatalf("expected unmanaged rules section to remain, got %q", text)
+	}
+	if !strings.Contains(text, "Custom unmanaged skills section.") {
+		t.Fatalf("expected unmanaged skills section to remain, got %q", text)
+	}
+	if strings.Contains(text, "`.claude/rules/common/local-dev-env.md`") {
+		t.Fatalf("expected unmanaged support file sections to avoid silent replacement, got %q", text)
+	}
+}
+
+func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
+	root := t.TempDir()
+	rulePath := filepath.Join(root, ".codex", "rules", "common", "docs.md")
+	skillPath := filepath.Join(root, ".claude", "skills", "github-health-check.skill")
+	mustWriteFile(t, rulePath, "user-authored file at canonical path\n")
+	mustWriteFile(t, skillPath, "not-a-ballast-skill\n")
+
+	next := &monorepoConfig{
+		Targets:    []string{"codex", "claude"},
+		Agents:     []string{"local-dev"},
+		Skills:     []string{"owasp-security-scan"},
+		Languages:  []string{"typescript"},
+		TaskSystem: "",
+	}
+
+	if err := removeStaleManagedFiles(root, "codex", next); err != nil {
+		t.Fatalf("removeStaleManagedFiles(codex): %v", err)
+	}
+	if err := removeStaleManagedFiles(root, "claude", next); err != nil {
+		t.Fatalf("removeStaleManagedFiles(claude): %v", err)
+	}
+
+	if _, err := os.Stat(rulePath); err != nil {
+		t.Fatalf("expected unmanaged rule file to remain, got %v", err)
+	}
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("expected unmanaged skill archive to remain, got %v", err)
+	}
+}
+
 func TestRunMonorepoRemoveTargetCleansManagedRulesAndSupportFiles(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
@@ -3158,6 +3224,33 @@ func TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig(t *testing.T) {
 	}
 	if !strings.Contains(string(config), `"taskSystem": "linear"`) {
 		t.Fatalf("expected taskSystem to be preserved from existing config, got %q", string(config))
+	}
+}
+
+func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+
+	plan, err := resolveMonorepoPlan(root, []string{"install", "--target", "cursor", "--agent", "tasks", "--task-system=linear", "--yes"})
+	if err != nil {
+		t.Fatalf("resolveMonorepoPlan returned error: %v", err)
+	}
+	if plan == nil || len(plan.Invocations) != 1 {
+		t.Fatalf("expected one common invocation, got %#v", plan)
+	}
+	got := strings.Join(plan.Invocations[0].Args, " ")
+	if strings.Contains(got, "--task-system=linear") {
+		t.Fatalf("expected normalized task-system flag, got %q", got)
+	}
+	if !strings.Contains(got, "--task-system linear") {
+		t.Fatalf("expected spaced task-system flag for backend, got %q", got)
+	}
+	if strings.Contains(got, "--force") {
+		t.Fatalf("expected task-system forwarding to avoid synthetic force, got %q", got)
+	}
+	if plan.Invocations[0].Env["BALLAST_REFRESH_TASK_RULES"] != "1" {
+		t.Fatalf("expected task-system updates to refresh existing task rules, got %#v", plan.Invocations[0].Env)
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -774,6 +774,7 @@ func install(opts installOptions) installResult {
 	result := installResult{}
 	opts.agents = withImplicitAgents(opts.agents)
 	disableSupportFiles := os.Getenv("BALLAST_DISABLE_SUPPORT_FILES") == "1"
+	refreshManagedSkills := os.Getenv("BALLAST_REFRESH_SKILLS") == "1"
 	hookMode := resolveTsHookMode(opts.projectRoot, opts.language)
 	targets := normalizeTargets(opts.targets)
 	if len(targets) == 0 {
@@ -886,6 +887,9 @@ func install(opts installOptions) installResult {
 			}
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				result.errors = append(result.errors, agentError{agent: skillID, err: err.Error()})
+				continue
+			}
+			if exists(file) && !opts.force && !opts.patch && !refreshManagedSkills {
 				continue
 			}
 			switch target {

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -75,6 +75,7 @@ type rulesConfig struct {
 	BallastVersion string              `json:"ballastVersion,omitempty"`
 	Languages      []string            `json:"languages,omitempty"`
 	Paths          map[string][]string `json:"paths,omitempty"`
+	TaskSystem     string              `json:"taskSystem,omitempty"`
 }
 
 type rawRulesConfig struct {
@@ -85,6 +86,7 @@ type rawRulesConfig struct {
 	BallastVersion string              `json:"ballastVersion,omitempty"`
 	Languages      []string            `json:"languages,omitempty"`
 	Paths          map[string][]string `json:"paths,omitempty"`
+	TaskSystem     string              `json:"taskSystem,omitempty"`
 }
 
 type installResult struct {
@@ -621,6 +623,9 @@ func buildDoctorReport(currentCLI, currentVersion string, configPath string, con
 		if formattedPaths := formatDoctorConfigPaths(config.Languages, config.Paths); formattedPaths != "" {
 			lines = append(lines, fmt.Sprintf("- paths: %s", formattedPaths))
 		}
+		if strings.TrimSpace(config.TaskSystem) != "" {
+			lines = append(lines, fmt.Sprintf("- taskSystem: %s", config.TaskSystem))
+		}
 		if configVersion == "" || compareVersions(configVersion, targetVersion) < 0 {
 			recommendations = append(
 				recommendations,
@@ -883,9 +888,6 @@ func install(opts installOptions) installResult {
 				result.errors = append(result.errors, agentError{agent: skillID, err: err.Error()})
 				continue
 			}
-			if exists(file) && !opts.force && !opts.patch {
-				continue
-			}
 			switch target {
 			case "cursor":
 				content, buildErr := buildCursorSkillFormat(skillID, opts.language)
@@ -913,10 +915,10 @@ func install(opts installOptions) installResult {
 				if exists(file) && !opts.force && opts.patch {
 					existing, readErr := readClaudeSkillContent(file)
 					if readErr != nil {
-						result.errors = append(result.errors, agentError{agent: skillID, err: readErr.Error()})
-						continue
+						nextContent = skillContent
+					} else {
+						nextContent = patchRuleContent(existing, skillContent, target)
 					}
-					nextContent = patchRuleContent(existing, skillContent, target)
 				}
 				content, buildErr := buildClaudeSkill(skillID, opts.language, nextContent)
 				if buildErr != nil {

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -1386,7 +1386,7 @@ func buildCursorSkillFormat(skillID, language string) (string, error) {
 		return "", err
 	}
 	_, body := splitSkillDocument(content)
-	return fmt.Sprintf("---\ndescription: %q\nalwaysApply: false\n---\n\n%s\n", skillDescription(skillID, language), strings.TrimRight(body, "\n")), nil
+	return fmt.Sprintf("---\ndescription: %q\nalwaysApply: false\n---\n\n<!-- %s -->\n\n%s\n", skillDescription(skillID, language), ballastNotice(), strings.TrimRight(body, "\n")), nil
 }
 
 func buildSkillMarkdown(skillID, language string) (string, error) {
@@ -1395,7 +1395,7 @@ func buildSkillMarkdown(skillID, language string) (string, error) {
 		return "", err
 	}
 	_, body := splitSkillDocument(content)
-	return strings.TrimRight(body, "\n") + "\n", nil
+	return "<!-- " + ballastNotice() + " -->\n\n" + strings.TrimRight(body, "\n") + "\n", nil
 }
 
 func buildClaudeSkill(skillID, language string, skillContent ...string) ([]byte, error) {
@@ -2182,6 +2182,7 @@ func loadConfig(projectRoot, language string) *rulesConfig {
 		BallastVersion: raw.BallastVersion,
 		Languages:      raw.Languages,
 		Paths:          raw.Paths,
+		TaskSystem:     raw.TaskSystem,
 	}
 }
 
@@ -2195,6 +2196,9 @@ func saveConfig(projectRoot, language string, cfg rulesConfig) error {
 	if existing != nil {
 		if cfg.BallastVersion == "" {
 			cfg.BallastVersion = existing.BallastVersion
+		}
+		if strings.TrimSpace(cfg.TaskSystem) == "" {
+			cfg.TaskSystem = existing.TaskSystem
 		}
 		cfg.Targets = mergeStringLists(existing.Targets, cfg.Targets)
 		cfg.Languages = mergeLanguageList(existing.Languages, cfg.Languages)

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -645,6 +645,9 @@ func TestBuildCursorSkillFormatIncludesOnDemandFrontmatter(t *testing.T) {
 	if strings.Contains(content, "description: >") {
 		t.Fatalf("expected folded YAML description to be resolved: %s", content)
 	}
+	if !strings.Contains(content, "Created by [Ballast]") {
+		t.Fatalf("expected managed skill marker: %s", content)
+	}
 	if strings.Contains(content, "description: Run OWASP-aligned security scans across Go, TypeScript, and Python codebases.") {
 		t.Fatalf("expected description to remain quoted: %s", content)
 	}
@@ -1173,6 +1176,9 @@ func TestInstallPatchCreatesMissingSkill(t *testing.T) {
 	if !strings.Contains(string(content), "## Scan Architecture") {
 		t.Fatalf("expected canonical skill content, got %q", string(content))
 	}
+	if !strings.Contains(string(content), "Created by [Ballast]") {
+		t.Fatalf("expected managed skill marker, got %q", string(content))
+	}
 }
 
 func TestInstallPatchMergesExistingSkill(t *testing.T) {
@@ -1690,7 +1696,7 @@ func TestNormalizeTargetsDetailedReturnsInvalidTokens(t *testing.T) {
 
 func TestLoadConfigSupportsLegacyTargetField(t *testing.T) {
 	tmpDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmpDir, ".rulesrc.json"), []byte(`{"target":"cursor","agents":["linting"]}`), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, ".rulesrc.json"), []byte(`{"target":"cursor","agents":["linting"],"taskSystem":"jira"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1700,6 +1706,9 @@ func TestLoadConfigSupportsLegacyTargetField(t *testing.T) {
 	}
 	if !slices.Equal(cfg.Targets, []string{"cursor"}) {
 		t.Fatalf("expected legacy target to normalize into targets, got %#v", cfg.Targets)
+	}
+	if cfg.TaskSystem != "jira" {
+		t.Fatalf("expected taskSystem to be loaded from config, got %#v", cfg)
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -129,6 +129,7 @@ func TestBuildDoctorReportRecommendsUpgrades(t *testing.T) {
 				"typescript": {"apps/web"},
 				"ansible":    {"infra/ansible"},
 			},
+			TaskSystem: "jira",
 		},
 		[]installedCLIStatus{
 			{Name: "ballast-typescript", Version: "5.0.2", Path: "/tmp/ballast-typescript"},
@@ -151,6 +152,9 @@ func TestBuildDoctorReportRecommendsUpgrades(t *testing.T) {
 	}
 	if !strings.Contains(output, "- paths: typescript=apps/web; ansible=infra/ansible") {
 		t.Fatalf("expected paths in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "- taskSystem: jira") {
+		t.Fatalf("expected task system in doctor output, got %q", output)
 	}
 }
 
@@ -1116,7 +1120,7 @@ func TestInstallCreatesCodexSupportFileForSkillOnlyInstall(t *testing.T) {
 	}
 }
 
-func TestInstallSkipsExistingSkillWithoutForceOrPatch(t *testing.T) {
+func TestInstallRefreshOverwritesExistingOpencodeSkillWithoutForceOrPatch(t *testing.T) {
 	tmpDir := t.TempDir()
 	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")
 	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
@@ -1134,15 +1138,19 @@ func TestInstallSkipsExistingSkillWithoutForceOrPatch(t *testing.T) {
 		force:       false,
 		saveConfig:  false,
 	})
-	if len(result.installedSkills) != 0 {
-		t.Fatalf("expected existing skill to be skipped, got %+v", result.installedSkills)
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected existing skill to be refreshed, got %+v", result.installedSkills)
 	}
 	content, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("read existing skill: %v", err)
 	}
-	if string(content) != "stale skill content" {
-		t.Fatalf("expected existing skill content to remain, got %q", string(content))
+	text := string(content)
+	if strings.Contains(text, "stale skill content") {
+		t.Fatalf("expected stale skill content to be replaced, got %q", text)
+	}
+	if !strings.Contains(text, "# OWASP Security Scan Skill") {
+		t.Fatalf("expected canonical skill content after refresh, got %q", text)
 	}
 }
 
@@ -1260,6 +1268,75 @@ func TestInstallPatchMergesClaudeSkillArchive(t *testing.T) {
 	}
 	if !strings.Contains(skillMd, "## Scan Architecture") {
 		t.Fatalf("expected canonical skill content to be merged: %s", skillMd)
+	}
+}
+
+func TestInstallPatchOverwritesUnreadableClaudeSkillArchive(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".claude", "skills", "owasp-security-scan.skill")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("not-a-zip-archive"), 0o644); err != nil {
+		t.Fatalf("seed unreadable skill archive: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"claude"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       false,
+		patch:       true,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected patched skill install, got %+v", result.installedSkills)
+	}
+	skillMd, err := readClaudeSkillContent(skillPath)
+	if err != nil {
+		t.Fatalf("read overwritten skill archive: %v", err)
+	}
+	if strings.Contains(skillMd, "not-a-zip-archive") {
+		t.Fatalf("expected unreadable archive to be replaced with canonical content: %s", skillMd)
+	}
+	if !strings.Contains(skillMd, "## Scan Architecture") {
+		t.Fatalf("expected canonical skill content after overwrite fallback: %s", skillMd)
+	}
+}
+
+func TestInstallRefreshOverwritesExistingCodexSkill(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillPath := filepath.Join(tmpDir, ".codex", "rules", "owasp-security-scan.md")
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("create skill dir: %v", err)
+	}
+	if err := os.WriteFile(skillPath, []byte("stale skill content\n"), 0o644); err != nil {
+		t.Fatalf("seed stale skill: %v", err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"codex"},
+		skills:      []string{"owasp-security-scan"},
+		language:    "go",
+		force:       false,
+		patch:       false,
+		saveConfig:  false,
+	})
+	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
+		t.Fatalf("expected refreshed skill install, got %+v", result.installedSkills)
+	}
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read refreshed skill: %v", err)
+	}
+	text := string(content)
+	if strings.Contains(text, "stale skill content") {
+		t.Fatalf("expected stale skill content to be replaced: %s", text)
+	}
+	if !strings.Contains(text, "# OWASP Security Scan Skill") {
+		t.Fatalf("expected canonical skill content after refresh: %s", text)
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -1120,7 +1120,7 @@ func TestInstallCreatesCodexSupportFileForSkillOnlyInstall(t *testing.T) {
 	}
 }
 
-func TestInstallRefreshOverwritesExistingOpencodeSkillWithoutForceOrPatch(t *testing.T) {
+func TestInstallSkipsExistingOpencodeSkillWithoutForceOrPatch(t *testing.T) {
 	tmpDir := t.TempDir()
 	skillPath := filepath.Join(tmpDir, ".opencode", "skills", "owasp-security-scan.md")
 	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
@@ -1138,19 +1138,16 @@ func TestInstallRefreshOverwritesExistingOpencodeSkillWithoutForceOrPatch(t *tes
 		force:       false,
 		saveConfig:  false,
 	})
-	if !slices.Equal(result.installedSkills, []string{"owasp-security-scan"}) {
-		t.Fatalf("expected existing skill to be refreshed, got %+v", result.installedSkills)
+	if len(result.installedSkills) != 0 {
+		t.Fatalf("expected existing skill to be skipped, got %+v", result.installedSkills)
 	}
 	content, err := os.ReadFile(skillPath)
 	if err != nil {
 		t.Fatalf("read existing skill: %v", err)
 	}
 	text := string(content)
-	if strings.Contains(text, "stale skill content") {
-		t.Fatalf("expected stale skill content to be replaced, got %q", text)
-	}
-	if !strings.Contains(text, "# OWASP Security Scan Skill") {
-		t.Fatalf("expected canonical skill content after refresh, got %q", text)
+	if text != "stale skill content" {
+		t.Fatalf("expected stale skill content to remain unchanged, got %q", text)
 	}
 }
 
@@ -1314,6 +1311,8 @@ func TestInstallRefreshOverwritesExistingCodexSkill(t *testing.T) {
 	if err := os.WriteFile(skillPath, []byte("stale skill content\n"), 0o644); err != nil {
 		t.Fatalf("seed stale skill: %v", err)
 	}
+
+	t.Setenv("BALLAST_REFRESH_SKILLS", "1")
 
 	result := install(installOptions{
 		projectRoot: tmpDir,

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -846,6 +846,7 @@ def build_cursor_skill_format(skill: str, language: str) -> str:
     description = skill_description(skill, language).replace('"', '\\"')
     return (
         f'---\ndescription: "{description}"\nalwaysApply: false\n---\n\n'
+        + f"<!-- {ballast_notice()} -->\n\n"
         + body.rstrip()
         + "\n"
     )
@@ -853,7 +854,7 @@ def build_cursor_skill_format(skill: str, language: str) -> str:
 
 def build_skill_markdown(skill: str, language: str) -> str:
     _, body = split_skill_document(read_skill(skill, language))
-    return body.rstrip() + "\n"
+    return f"<!-- {ballast_notice()} -->\n\n" + body.rstrip() + "\n"
 
 
 def build_claude_skill(

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -22,6 +22,7 @@ COMMON_AGENTS = [
     "observability",
     "publishing",
     "git-hooks",
+    "tasks",
 ]
 LANGUAGE_AGENTS = ["linting", "logging", "testing"]
 AGENTS_BY_LANGUAGE = {
@@ -875,6 +876,17 @@ def read_claude_skill_content(archive_path: Path) -> str:
             return skill_file.read().decode("utf-8")
 
 
+def patch_claude_skill_content(
+    archive_path: Path, canonical_skill_content: str, target: str
+) -> str:
+    try:
+        existing_skill_content = read_claude_skill_content(archive_path)
+    except Exception:
+        # Fall back to a clean overwrite when an existing archive is unreadable.
+        return canonical_skill_content
+    return patch_rule_content(existing_skill_content, canonical_skill_content, target)
+
+
 def destination(root: Path, target: str, basename: str) -> Path:
     rule_subdir = os.environ.get("BALLAST_RULE_SUBDIR", "").strip()
     if rule_subdir and not re.fullmatch(r"[A-Za-z0-9_-]+", rule_subdir):
@@ -1673,9 +1685,7 @@ def install(
             elif target == "claude":
                 skill_content = read_skill(skill, language)
                 next_content = (
-                    patch_rule_content(
-                        read_claude_skill_content(dst), skill_content, target
-                    )
+                    patch_claude_skill_content(dst, skill_content, target)
                     if file_exists and not force and patch
                     else skill_content
                 )

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -478,6 +478,7 @@ def build_doctor_report(
         skills = config.get("skills")
         languages = config.get("languages")
         paths = config.get("paths")
+        task_system = config.get("taskSystem")
         if isinstance(targets, list) and all(
             isinstance(target, str) for target in targets
         ):
@@ -507,6 +508,8 @@ def build_doctor_report(
             )
             if formatted_paths:
                 lines.append(f"- paths: {formatted_paths}")
+        if isinstance(task_system, str) and task_system.strip():
+            lines.append(f"- taskSystem: {task_system}")
 
     lines.extend(["", "Recommendations:"])
     if recommendations:

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -22,7 +22,6 @@ COMMON_AGENTS = [
     "observability",
     "publishing",
     "git-hooks",
-    "tasks",
 ]
 LANGUAGE_AGENTS = ["linting", "logging", "testing"]
 AGENTS_BY_LANGUAGE = {
@@ -1608,6 +1607,7 @@ def install(
     processed_agents: list[str] = []
     processed_skills: list[str] = []
     disable_support_files = os.environ.get("BALLAST_DISABLE_SUPPORT_FILES") == "1"
+    refresh_managed_skills = os.environ.get("BALLAST_REFRESH_SKILLS") == "1"
 
     try:
         ensure_gitignore_entry(root, ".ballast/")
@@ -1675,7 +1675,7 @@ def install(
             dst = skill_destination(root, target, skill)
             file_exists = dst.exists()
             dst.parent.mkdir(parents=True, exist_ok=True)
-            if file_exists and not force and not patch:
+            if file_exists and not force and not patch and not refresh_managed_skills:
                 continue
             if target == "cursor":
                 content = build_cursor_skill_format(skill, language)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -384,6 +384,10 @@ class PatchInstallTests(unittest.TestCase):
                 "## Scan Architecture",
                 skill.read_text(encoding="utf-8"),
             )
+            self.assertIn(
+                "Created by [Ballast]",
+                skill.read_text(encoding="utf-8"),
+            )
 
     def test_install_adds_ballast_to_gitignore(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -525,6 +529,7 @@ class PatchInstallTests(unittest.TestCase):
             'description: "Run OWASP-aligned security scans across Go, TypeScript, and Python codebases.',
             content,
         )
+        self.assertIn("Created by [Ballast]", content)
         self.assertNotIn("description: >", content)
 
     def test_build_cursor_skill_format_supports_ballast_audit(self) -> None:

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -749,6 +749,30 @@ Keep team-specific usage notes.
             self.assertIn("Team Custom Section", skill_md)
             self.assertIn("## Scan Architecture", skill_md)
 
+    def test_install_patch_overwrites_unreadable_claude_skill_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill_path = root / ".claude" / "skills" / "owasp-security-scan.skill"
+            skill_path.parent.mkdir(parents=True, exist_ok=True)
+            skill_path.write_bytes(b"not-a-zip-archive")
+
+            result = cli.install(
+                root,
+                "claude",
+                [],
+                ["owasp-security-scan"],
+                "python",
+                False,
+                True,
+                False,
+            )
+
+            self.assertEqual(result.errors, [])
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            skill_md = cli.read_claude_skill_content(skill_path)
+            self.assertIn("## Scan Architecture", skill_md)
+            self.assertNotIn("not-a-zip-archive", skill_md)
+
     def test_install_force_overwrites_existing_claude_skill_archive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -360,6 +360,31 @@ class PatchInstallTests(unittest.TestCase):
             self.assertEqual(result.installed_skills, [])
             self.assertEqual(skill.read_text(encoding="utf-8"), "stale skill content")
 
+    def test_install_refresh_overwrites_existing_managed_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill = root / ".opencode" / "skills" / "owasp-security-scan.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("stale skill content", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"BALLAST_REFRESH_SKILLS": "1"}):
+                result = cli.install(
+                    root,
+                    "opencode",
+                    [],
+                    ["owasp-security-scan"],
+                    "python",
+                    False,
+                    False,
+                    False,
+                )
+
+            self.assertEqual(result.installed_skills, ["owasp-security-scan"])
+            self.assertIn(
+                "## Scan Architecture",
+                skill.read_text(encoding="utf-8"),
+            )
+
     def test_install_adds_ballast_to_gitignore(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -36,6 +36,7 @@ class PatchInstallTests(unittest.TestCase):
                     "typescript": ["apps/web"],
                     "ansible": ["infra/ansible"],
                 },
+                "taskSystem": "jira",
             },
             [
                 {
@@ -64,6 +65,7 @@ class PatchInstallTests(unittest.TestCase):
         self.assertIn("- skills: owasp-security-scan", output)
         self.assertIn("- languages: typescript, ansible", output)
         self.assertIn("- paths: typescript=apps/web; ansible=infra/ansible", output)
+        self.assertIn("- taskSystem: jira", output)
 
     def test_parser_top_level_help_flag_exits_zero(self) -> None:
         with self.assertRaises(SystemExit) as exc:

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -16,6 +16,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const SOURCE_AGENTS_ROOT = path.join(REPO_ROOT, 'agents');
 const GIT_HOOKS_GUIDANCE_TOKEN = '{{BALLAST_GIT_HOOKS_GUIDANCE}}';
 const BALLAST_REPO_URL = 'https://github.com/everydaydevopsio/ballast';
+const BALLAST_MANAGED_COMMENT = `<!-- Created by [Ballast](${BALLAST_REPO_URL}) v${pkg.version}. Do not edit this section. -->`;
 
 type HookMode = 'standalone' | 'monorepo';
 
@@ -469,12 +470,20 @@ export function buildCursorSkillFormat(skillId: string): string {
     'alwaysApply: false',
     '---',
     '',
+    BALLAST_MANAGED_COMMENT,
+    '',
     skill.body.trimEnd()
   ].join('\n');
 }
 
 export function buildSkillMarkdown(skillId: string): string {
-  return parseSkillMetadata(skillId).body.trimEnd() + '\n';
+  return (
+    [
+      BALLAST_MANAGED_COMMENT,
+      '',
+      parseSkillMetadata(skillId).body.trimEnd()
+    ].join('\n') + '\n'
+  );
 }
 
 export function buildClaudeSkill(

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -15,6 +15,7 @@ describe('doctor', () => {
       [],
       [],
       {},
+      null,
       [
         {
           name: 'ballast-typescript',
@@ -56,6 +57,7 @@ describe('doctor', () => {
         typescript: ['apps/web'],
         ansible: ['infra/ansible']
       },
+      'jira',
       [
         {
           name: 'ballast-typescript',
@@ -80,6 +82,7 @@ describe('doctor', () => {
     expect(output).toContain(
       '- paths: typescript=apps/web; ansible=infra/ansible'
     );
+    expect(output).toContain('- taskSystem: jira');
     expect(output).toContain('- No action needed.');
   });
 
@@ -94,6 +97,7 @@ describe('doctor', () => {
       [],
       [],
       {},
+      null,
       [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
       'cli'
     );
@@ -112,6 +116,7 @@ describe('doctor', () => {
       [],
       [],
       {},
+      null,
       [],
       'unknown'
     );
@@ -130,6 +135,7 @@ describe('doctor', () => {
       [],
       [],
       {},
+      null,
       [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
       'web'
     );
@@ -151,6 +157,7 @@ describe('doctor', () => {
       [],
       [],
       {},
+      null,
       [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
       'api'
     );

--- a/packages/ballast-typescript/src/doctor.ts
+++ b/packages/ballast-typescript/src/doctor.ts
@@ -22,6 +22,7 @@ export interface DoctorReport {
   configSkills: string[];
   configLanguages: string[];
   configPaths: Record<string, string[]>;
+  configTaskSystem: string | null;
   installed: InstalledCliStatus[];
   detectedAppType: AppType;
   recommendations: string[];
@@ -203,6 +204,7 @@ export function buildDoctorReport(
   configSkills: string[],
   configLanguages: string[],
   configPaths: Record<string, string[]>,
+  configTaskSystem: string | null,
   installed: InstalledCliStatus[],
   detectedAppType: AppType = 'unknown'
 ): DoctorReport {
@@ -264,6 +266,7 @@ export function buildDoctorReport(
     configSkills,
     configLanguages,
     configPaths,
+    configTaskSystem,
     installed,
     detectedAppType,
     recommendations
@@ -334,6 +337,9 @@ export function formatDoctorReport(report: DoctorReport): string {
     if (formattedPaths) {
       lines.push(`- paths: ${formattedPaths}`);
     }
+    if (report.configTaskSystem) {
+      lines.push(`- taskSystem: ${report.configTaskSystem}`);
+    }
   }
 
   lines.push('', 'Recommendations:');
@@ -362,6 +368,7 @@ export function runDoctor(): number {
     config?.skills ?? [],
     config?.languages ?? [],
     config?.paths ?? {},
+    config?.taskSystem ?? null,
     CLI_NAMES.map((name) => detectInstalledCli(name)),
     detectAppType(projectRoot)
   );

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -509,6 +509,58 @@ Keep this team-specific section.
       expect(skillMd).toContain('## Scan Architecture');
     });
 
+    test('patch falls back to overwrite when an existing claude .skill archive is unreadable', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(skillFile, Buffer.from('not-a-zip-archive', 'utf8'));
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.installedSkills).toContain('owasp-security-scan');
+
+      const archive = fs.readFileSync(skillFile);
+      function readStoredZipEntryLocal(
+        buf: Buffer,
+        entry: string
+      ): string | undefined {
+        let offset = 0;
+        while (offset + 30 <= buf.length) {
+          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
+          const compressedSize = buf.readUInt32LE(offset + 18);
+          const fileNameLength = buf.readUInt16LE(offset + 26);
+          const extraLength = buf.readUInt16LE(offset + 28);
+          const fileName = buf.toString(
+            'utf8',
+            offset + 30,
+            offset + 30 + fileNameLength
+          );
+          const dataStart = offset + 30 + fileNameLength + extraLength;
+          if (fileName === entry)
+            return buf.toString('utf8', dataStart, dataStart + compressedSize);
+          offset = dataStart + compressedSize;
+        }
+        return undefined;
+      }
+
+      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      expect(skillMd).toContain('## Scan Architecture');
+      expect(skillMd).not.toContain('not-a-zip-archive');
+    });
+
     test('force-overwrites an existing claude .skill archive without patching', () => {
       const skillFile = path.join(
         tmpDir,

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -84,6 +84,102 @@ describe('install', () => {
     ]);
   }
 
+  function buildClaudeSkillWithDataDescriptorComment(
+    skillMd: string,
+    comment: Buffer
+  ): Buffer {
+    const archive = buildClaudeSkillWithDataDescriptor(skillMd);
+    const eocdOffset = archive.length - 22;
+    const eocd = Buffer.from(archive.subarray(eocdOffset));
+    eocd.writeUInt16LE(comment.length, 20);
+    return Buffer.concat([archive.subarray(0, eocdOffset), eocd, comment]);
+  }
+
+  function readSkillMdFromArchive(archive: Buffer): string | undefined {
+    const eocdSignature = 0x06054b50;
+    const centralDirectorySignature = 0x02014b50;
+    const localFileHeaderSignature = 0x04034b50;
+    const minEocdSize = 22;
+    const maxCommentLength = 0xffff;
+    const searchStart = Math.max(
+      0,
+      archive.length - minEocdSize - maxCommentLength
+    );
+
+    eocdLoop: for (
+      let eocdOffset = archive.length - minEocdSize;
+      eocdOffset >= searchStart;
+      eocdOffset--
+    ) {
+      if (archive.readUInt32LE(eocdOffset) !== eocdSignature) {
+        continue;
+      }
+
+      const centralDirectorySize = archive.readUInt32LE(eocdOffset + 12);
+      const centralDirectoryOffset = archive.readUInt32LE(eocdOffset + 16);
+      const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
+      if (
+        centralDirectoryOffset < 0 ||
+        centralDirectoryEnd > archive.length ||
+        centralDirectoryOffset > centralDirectoryEnd
+      ) {
+        continue;
+      }
+
+      let entryOffset = centralDirectoryOffset;
+      while (entryOffset + 46 <= centralDirectoryEnd) {
+        if (archive.readUInt32LE(entryOffset) !== centralDirectorySignature) {
+          break;
+        }
+
+        const compressionMethod = archive.readUInt16LE(entryOffset + 10);
+        const compressedSize = archive.readUInt32LE(entryOffset + 20);
+        const fileNameLength = archive.readUInt16LE(entryOffset + 28);
+        const extraLength = archive.readUInt16LE(entryOffset + 30);
+        const commentLength = archive.readUInt16LE(entryOffset + 32);
+        const localHeaderOffset = archive.readUInt32LE(entryOffset + 42);
+        const fileNameStart = entryOffset + 46;
+        const fileNameEnd = fileNameStart + fileNameLength;
+        if (fileNameEnd > centralDirectoryEnd) {
+          continue eocdLoop;
+        }
+        const fileName = archive.toString('utf8', fileNameStart, fileNameEnd);
+        if (fileName === 'SKILL.md') {
+          if (localHeaderOffset + 30 > archive.length) {
+            continue eocdLoop;
+          }
+          if (
+            archive.readUInt32LE(localHeaderOffset) !== localFileHeaderSignature
+          ) {
+            continue eocdLoop;
+          }
+          const localFileNameLength = archive.readUInt16LE(
+            localHeaderOffset + 26
+          );
+          const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+          const dataStart =
+            localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+          const dataEnd = dataStart + compressedSize;
+          if (dataEnd > archive.length) {
+            continue eocdLoop;
+          }
+          const data = archive.subarray(dataStart, dataEnd);
+          if (compressionMethod === 0) {
+            return data.toString('utf8');
+          }
+          if (compressionMethod === 8) {
+            return zlib.inflateRawSync(data).toString('utf8');
+          }
+          return undefined;
+        }
+
+        entryOffset = fileNameEnd + extraLength + commentLength;
+      }
+    }
+
+    return undefined;
+  }
+
   describe('resolveTargetAndAgents', () => {
     test('with target and agents from options returns them', async () => {
       const result = await resolveTargetAndAgents({
@@ -377,6 +473,12 @@ describe('install', () => {
           path.join(tmpDir, '.cursor', 'rules', 'owasp-security-scan.mdc')
         )
       ).toBe(true);
+      expect(
+        fs.readFileSync(
+          path.join(tmpDir, '.cursor', 'rules', 'owasp-security-scan.mdc'),
+          'utf8'
+        )
+      ).toContain('Created by [Ballast]');
     });
 
     test('skips an existing skill file when force and patch are false', () => {
@@ -424,6 +526,9 @@ describe('install', () => {
       expect(result.installedSkills).toContain('owasp-security-scan');
       expect(fs.readFileSync(skillFile, 'utf8')).toContain(
         '## Scan Architecture'
+      );
+      expect(fs.readFileSync(skillFile, 'utf8')).toContain(
+        'Created by [Ballast]'
       );
     });
 
@@ -523,8 +628,7 @@ Keep team-specific usage notes.
       );
     });
 
-    test('task-system refresh mode rewrites existing task rules without force or patch', () => {
-      process.env.BALLAST_REFRESH_TASK_RULES = '1';
+    test('changing taskSystem rewrites existing task rules without force or patch', () => {
       const taskRule = path.join(
         tmpDir,
         '.codex',
@@ -536,6 +640,15 @@ Keep team-specific usage notes.
         taskRule,
         'Use jira as the system of record for work items.\n',
         'utf8'
+      );
+      saveConfig(
+        {
+          targets: ['codex'],
+          agents: ['tasks'],
+          skills: [],
+          taskSystem: 'jira'
+        },
+        tmpDir
       );
 
       const result = install({
@@ -587,31 +700,8 @@ Keep this team-specific section.
 
       expect(result.installedSkills).toContain('owasp-security-scan');
 
-      // Read SKILL.md from output archive (stored/no-compression ZIP)
       const archive = fs.readFileSync(skillFile);
-      function readStoredZipEntry(
-        buf: Buffer,
-        entry: string
-      ): string | undefined {
-        let offset = 0;
-        while (offset + 30 <= buf.length) {
-          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
-          const compressedSize = buf.readUInt32LE(offset + 18);
-          const fileNameLength = buf.readUInt16LE(offset + 26);
-          const extraLength = buf.readUInt16LE(offset + 28);
-          const fileName = buf.toString(
-            'utf8',
-            offset + 30,
-            offset + 30 + fileNameLength
-          );
-          const dataStart = offset + 30 + fileNameLength + extraLength;
-          if (fileName === entry)
-            return buf.toString('utf8', dataStart, dataStart + compressedSize);
-          offset = dataStart + compressedSize;
-        }
-        return undefined;
-      }
-      const skillMd = readStoredZipEntry(archive, 'SKILL.md');
+      const skillMd = readSkillMdFromArchive(archive);
       expect(skillMd).toContain('Team intro preserved by patch.');
       expect(skillMd).toContain('Team Custom Section');
       expect(skillMd).toContain('## Scan Architecture');
@@ -641,30 +731,7 @@ Keep this team-specific section.
       expect(result.installedSkills).toContain('owasp-security-scan');
 
       const archive = fs.readFileSync(skillFile);
-      function readStoredZipEntryLocal(
-        buf: Buffer,
-        entry: string
-      ): string | undefined {
-        let offset = 0;
-        while (offset + 30 <= buf.length) {
-          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
-          const compressedSize = buf.readUInt32LE(offset + 18);
-          const fileNameLength = buf.readUInt16LE(offset + 26);
-          const extraLength = buf.readUInt16LE(offset + 28);
-          const fileName = buf.toString(
-            'utf8',
-            offset + 30,
-            offset + 30 + fileNameLength
-          );
-          const dataStart = offset + 30 + fileNameLength + extraLength;
-          if (fileName === entry)
-            return buf.toString('utf8', dataStart, dataStart + compressedSize);
-          offset = dataStart + compressedSize;
-        }
-        return undefined;
-      }
-
-      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      const skillMd = readSkillMdFromArchive(archive);
       expect(skillMd).toContain('## Scan Architecture');
       expect(skillMd).not.toContain('not-a-zip-archive');
     });
@@ -709,30 +776,7 @@ Keep this team-specific section.
       expect(result.installedSkills).toContain('owasp-security-scan');
 
       const archive = fs.readFileSync(skillFile);
-      function readStoredZipEntryLocal(
-        buf: Buffer,
-        entry: string
-      ): string | undefined {
-        let offset = 0;
-        while (offset + 30 <= buf.length) {
-          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
-          const compressedSize = buf.readUInt32LE(offset + 18);
-          const fileNameLength = buf.readUInt16LE(offset + 26);
-          const extraLength = buf.readUInt16LE(offset + 28);
-          const fileName = buf.toString(
-            'utf8',
-            offset + 30,
-            offset + 30 + fileNameLength
-          );
-          const dataStart = offset + 30 + fileNameLength + extraLength;
-          if (fileName === entry)
-            return buf.toString('utf8', dataStart, dataStart + compressedSize);
-          offset = dataStart + compressedSize;
-        }
-        return undefined;
-      }
-
-      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      const skillMd = readSkillMdFromArchive(archive);
       expect(skillMd).toContain('## Scan Architecture');
     });
 
@@ -770,30 +814,48 @@ Keep this team-specific section.
       expect(result.installedSkills).toContain('owasp-security-scan');
 
       const archive = fs.readFileSync(skillFile);
-      function readStoredZipEntryLocal(
-        buf: Buffer,
-        entry: string
-      ): string | undefined {
-        let offset = 0;
-        while (offset + 30 <= buf.length) {
-          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
-          const compressedSize = buf.readUInt32LE(offset + 18);
-          const fileNameLength = buf.readUInt16LE(offset + 26);
-          const extraLength = buf.readUInt16LE(offset + 28);
-          const fileName = buf.toString(
-            'utf8',
-            offset + 30,
-            offset + 30 + fileNameLength
-          );
-          const dataStart = offset + 30 + fileNameLength + extraLength;
-          if (fileName === entry)
-            return buf.toString('utf8', dataStart, dataStart + compressedSize);
-          offset = dataStart + compressedSize;
-        }
-        return undefined;
-      }
+      const skillMd = readSkillMdFromArchive(archive);
+      expect(skillMd).toContain('Team intro preserved by patch.');
+      expect(skillMd).toContain('Team Custom Section');
+      expect(skillMd).toContain('## Scan Architecture');
+    });
 
-      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+    test('patch preserves team content when the zip comment contains an EOCD signature', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(
+        skillFile,
+        buildClaudeSkillWithDataDescriptorComment(
+          `# owasp-security-scan
+
+Team intro preserved by patch.
+
+## Team Custom Section
+
+Keep this team-specific section.
+`,
+          Buffer.from('comment-\x50\x4b\x05\x06-tail', 'binary')
+        )
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.installedSkills).toContain('owasp-security-scan');
+      const skillMd = readSkillMdFromArchive(fs.readFileSync(skillFile));
       expect(skillMd).toContain('Team intro preserved by patch.');
       expect(skillMd).toContain('Team Custom Section');
       expect(skillMd).toContain('## Scan Architecture');
@@ -832,30 +894,7 @@ This section should be gone after force.
 
       expect(result.installedSkills).toContain('owasp-security-scan');
 
-      const archive = fs.readFileSync(skillFile);
-      function readStoredZipEntryLocal(
-        buf: Buffer,
-        entry: string
-      ): string | undefined {
-        let offset = 0;
-        while (offset + 30 <= buf.length) {
-          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
-          const compressedSize = buf.readUInt32LE(offset + 18);
-          const fileNameLength = buf.readUInt16LE(offset + 26);
-          const extraLength = buf.readUInt16LE(offset + 28);
-          const fileName = buf.toString(
-            'utf8',
-            offset + 30,
-            offset + 30 + fileNameLength
-          );
-          const dataStart = offset + 30 + fileNameLength + extraLength;
-          if (fileName === entry)
-            return buf.toString('utf8', dataStart, dataStart + compressedSize);
-          offset = dataStart + compressedSize;
-        }
-        return undefined;
-      }
-      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      const skillMd = readSkillMdFromArchive(fs.readFileSync(skillFile));
       expect(skillMd).not.toContain(
         'Team intro that should be discarded on force.'
       );

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import readline from 'readline';
+import zlib from 'zlib';
 import { install, resolveTargetAndAgents, runInstall } from './install';
 import {
   buildClaudeSkill,
@@ -32,6 +33,56 @@ describe('install', () => {
     jest.restoreAllMocks();
     process.env = origEnv;
   });
+
+  function buildClaudeSkillWithDataDescriptor(skillMd: string): Buffer {
+    const fileName = Buffer.from('SKILL.md', 'utf8');
+    const content = Buffer.from(skillMd, 'utf8');
+    const compressed = zlib.deflateRawSync(content);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0x0008, 6);
+    localHeader.writeUInt16LE(8, 8);
+    localHeader.writeUInt16LE(fileName.length, 26);
+
+    const dataDescriptor = Buffer.alloc(16);
+    dataDescriptor.writeUInt32LE(0x08074b50, 0);
+    dataDescriptor.writeUInt32LE(compressed.length, 8);
+    dataDescriptor.writeUInt32LE(content.length, 12);
+
+    const centralDirectory = Buffer.alloc(46);
+    centralDirectory.writeUInt32LE(0x02014b50, 0);
+    centralDirectory.writeUInt16LE(20, 4);
+    centralDirectory.writeUInt16LE(20, 6);
+    centralDirectory.writeUInt16LE(0x0008, 8);
+    centralDirectory.writeUInt16LE(8, 10);
+    centralDirectory.writeUInt32LE(compressed.length, 20);
+    centralDirectory.writeUInt32LE(content.length, 24);
+    centralDirectory.writeUInt16LE(fileName.length, 28);
+
+    const centralDirectoryOffset =
+      localHeader.length +
+      fileName.length +
+      compressed.length +
+      dataDescriptor.length;
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(1, 8);
+    eocd.writeUInt16LE(1, 10);
+    eocd.writeUInt32LE(centralDirectory.length + fileName.length, 12);
+    eocd.writeUInt32LE(centralDirectoryOffset, 16);
+
+    return Buffer.concat([
+      localHeader,
+      fileName,
+      compressed,
+      dataDescriptor,
+      centralDirectory,
+      fileName,
+      eocd
+    ]);
+  }
 
   describe('resolveTargetAndAgents', () => {
     test('with target and agents from options returns them', async () => {
@@ -446,6 +497,63 @@ Keep team-specific usage notes.
       );
     });
 
+    test('refresh mode overwrites an existing skill file without force or patch', () => {
+      process.env.BALLAST_REFRESH_SKILLS = '1';
+      const skillFile = path.join(
+        tmpDir,
+        '.opencode',
+        'skills',
+        'owasp-security-scan.md'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(skillFile, 'stale skill content', 'utf8');
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'opencode',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installedSkills).toContain('owasp-security-scan');
+      expect(fs.readFileSync(skillFile, 'utf8')).toContain(
+        '## Scan Architecture'
+      );
+    });
+
+    test('task-system refresh mode rewrites existing task rules without force or patch', () => {
+      process.env.BALLAST_REFRESH_TASK_RULES = '1';
+      const taskRule = path.join(
+        tmpDir,
+        '.codex',
+        'rules',
+        'tasks-task-system.md'
+      );
+      fs.mkdirSync(path.dirname(taskRule), { recursive: true });
+      fs.writeFileSync(
+        taskRule,
+        'Use jira as the system of record for work items.\n',
+        'utf8'
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'codex',
+        agents: ['tasks'],
+        skills: [],
+        taskSystem: 'linear',
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installed).toContain('tasks');
+      const content = fs.readFileSync(taskRule, 'utf8');
+      expect(content).toContain('linear');
+      expect(content).not.toContain('Use jira as the system of record');
+    });
+
     test('patches SKILL.md inside an existing claude .skill archive when patch is true', () => {
       const skillFile = path.join(
         tmpDir,
@@ -559,6 +667,136 @@ Keep this team-specific section.
       const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
       expect(skillMd).toContain('## Scan Architecture');
       expect(skillMd).not.toContain('not-a-zip-archive');
+    });
+
+    test('patch falls back to overwrite when reading an existing claude archive throws', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(
+        skillFile,
+        buildClaudeSkill('owasp-security-scan', '# existing skill\n')
+      );
+
+      const originalReadFileSync = fs.readFileSync;
+      let injectedFailure = false;
+      jest.spyOn(fs, 'readFileSync').mockImplementation(((
+        file: fs.PathOrFileDescriptor,
+        options?: unknown
+      ) => {
+        if (file === skillFile && options === undefined && !injectedFailure) {
+          injectedFailure = true;
+          throw new Error('permission denied');
+        }
+        return originalReadFileSync(file as never, options as never);
+      }) as typeof fs.readFileSync);
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.installedSkills).toContain('owasp-security-scan');
+
+      const archive = fs.readFileSync(skillFile);
+      function readStoredZipEntryLocal(
+        buf: Buffer,
+        entry: string
+      ): string | undefined {
+        let offset = 0;
+        while (offset + 30 <= buf.length) {
+          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
+          const compressedSize = buf.readUInt32LE(offset + 18);
+          const fileNameLength = buf.readUInt16LE(offset + 26);
+          const extraLength = buf.readUInt16LE(offset + 28);
+          const fileName = buf.toString(
+            'utf8',
+            offset + 30,
+            offset + 30 + fileNameLength
+          );
+          const dataStart = offset + 30 + fileNameLength + extraLength;
+          if (fileName === entry)
+            return buf.toString('utf8', dataStart, dataStart + compressedSize);
+          offset = dataStart + compressedSize;
+        }
+        return undefined;
+      }
+
+      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      expect(skillMd).toContain('## Scan Architecture');
+    });
+
+    test('patch preserves team content from valid claude archives that use data descriptors', () => {
+      const skillFile = path.join(
+        tmpDir,
+        '.claude',
+        'skills',
+        'owasp-security-scan.skill'
+      );
+      fs.mkdirSync(path.dirname(skillFile), { recursive: true });
+      fs.writeFileSync(
+        skillFile,
+        buildClaudeSkillWithDataDescriptor(`# owasp-security-scan
+
+Team intro preserved by patch.
+
+## Team Custom Section
+
+Keep this team-specific section.
+`)
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'claude',
+        agents: [],
+        skills: ['owasp-security-scan'],
+        patch: true,
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.installedSkills).toContain('owasp-security-scan');
+
+      const archive = fs.readFileSync(skillFile);
+      function readStoredZipEntryLocal(
+        buf: Buffer,
+        entry: string
+      ): string | undefined {
+        let offset = 0;
+        while (offset + 30 <= buf.length) {
+          if (buf.readUInt32LE(offset) !== 0x04034b50) break;
+          const compressedSize = buf.readUInt32LE(offset + 18);
+          const fileNameLength = buf.readUInt16LE(offset + 26);
+          const extraLength = buf.readUInt16LE(offset + 28);
+          const fileName = buf.toString(
+            'utf8',
+            offset + 30,
+            offset + 30 + fileNameLength
+          );
+          const dataStart = offset + 30 + fileNameLength + extraLength;
+          if (fileName === entry)
+            return buf.toString('utf8', dataStart, dataStart + compressedSize);
+          offset = dataStart + compressedSize;
+        }
+        return undefined;
+      }
+
+      const skillMd = readStoredZipEntryLocal(archive, 'SKILL.md');
+      expect(skillMd).toContain('Team intro preserved by patch.');
+      expect(skillMd).toContain('Team Custom Section');
+      expect(skillMd).toContain('## Scan Architecture');
     });
 
     test('force-overwrites an existing claude .skill archive without patching', () => {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -398,47 +398,97 @@ function readStoredZipEntry(
   archive: Buffer,
   entryName: string
 ): string | undefined {
-  let offset = 0;
-  while (offset + 30 <= archive.length) {
-    const signature = archive.readUInt32LE(offset);
-    if (signature !== 0x04034b50) {
-      break;
+  const eocdSignature = 0x06054b50;
+  const centralDirectorySignature = 0x02014b50;
+  const localFileHeaderSignature = 0x04034b50;
+  const minEocdSize = 22;
+  const maxCommentLength = 0xffff;
+  const searchStart = Math.max(
+    0,
+    archive.length - minEocdSize - maxCommentLength
+  );
+
+  for (
+    let eocdOffset = archive.length - minEocdSize;
+    eocdOffset >= searchStart;
+    eocdOffset--
+  ) {
+    if (archive.readUInt32LE(eocdOffset) !== eocdSignature) {
+      continue;
     }
-    const compressionMethod = archive.readUInt16LE(offset + 8);
-    const compressedSize = archive.readUInt32LE(offset + 18);
-    const fileNameLength = archive.readUInt16LE(offset + 26);
-    const extraLength = archive.readUInt16LE(offset + 28);
-    const fileName = archive.toString(
-      'utf8',
-      offset + 30,
-      offset + 30 + fileNameLength
-    );
-    const dataStart = offset + 30 + fileNameLength + extraLength;
-    const dataEnd = dataStart + compressedSize;
-    if (dataEnd > archive.length) {
-      break;
-    }
-    if (fileName === entryName) {
-      const data = archive.subarray(dataStart, dataEnd);
-      if (compressionMethod === 0) {
-        return data.toString('utf8');
-      }
-      if (compressionMethod === 8) {
-        return zlib.inflateRawSync(data).toString('utf8');
-      }
+
+    const centralDirectorySize = archive.readUInt32LE(eocdOffset + 12);
+    const centralDirectoryOffset = archive.readUInt32LE(eocdOffset + 16);
+    const centralDirectoryEnd = centralDirectoryOffset + centralDirectorySize;
+    if (
+      centralDirectoryOffset < 0 ||
+      centralDirectoryEnd > archive.length ||
+      centralDirectoryOffset > centralDirectoryEnd
+    ) {
       return undefined;
     }
-    offset = dataEnd;
+
+    let entryOffset = centralDirectoryOffset;
+    while (entryOffset + 46 <= centralDirectoryEnd) {
+      if (archive.readUInt32LE(entryOffset) !== centralDirectorySignature) {
+        break;
+      }
+
+      const compressionMethod = archive.readUInt16LE(entryOffset + 10);
+      const compressedSize = archive.readUInt32LE(entryOffset + 20);
+      const fileNameLength = archive.readUInt16LE(entryOffset + 28);
+      const extraLength = archive.readUInt16LE(entryOffset + 30);
+      const commentLength = archive.readUInt16LE(entryOffset + 32);
+      const localHeaderOffset = archive.readUInt32LE(entryOffset + 42);
+      const fileNameStart = entryOffset + 46;
+      const fileNameEnd = fileNameStart + fileNameLength;
+      if (fileNameEnd > centralDirectoryEnd) {
+        return undefined;
+      }
+      const fileName = archive.toString('utf8', fileNameStart, fileNameEnd);
+      if (fileName === entryName) {
+        if (localHeaderOffset + 30 > archive.length) {
+          return undefined;
+        }
+        if (
+          archive.readUInt32LE(localHeaderOffset) !== localFileHeaderSignature
+        ) {
+          return undefined;
+        }
+        const localFileNameLength = archive.readUInt16LE(
+          localHeaderOffset + 26
+        );
+        const localExtraLength = archive.readUInt16LE(localHeaderOffset + 28);
+        const dataStart =
+          localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+        const dataEnd = dataStart + compressedSize;
+        if (dataEnd > archive.length) {
+          return undefined;
+        }
+        const data = archive.subarray(dataStart, dataEnd);
+        if (compressionMethod === 0) {
+          return data.toString('utf8');
+        }
+        if (compressionMethod === 8) {
+          return zlib.inflateRawSync(data).toString('utf8');
+        }
+        return undefined;
+      }
+
+      entryOffset = fileNameEnd + extraLength + commentLength;
+    }
   }
+
   return undefined;
 }
 
 function patchClaudeSkillContent(
-  archive: Buffer,
+  archivePath: string,
   canonicalSkillContent: string,
   target: Target
 ): string {
   try {
+    const archive = fs.readFileSync(archivePath);
     return patchRuleContent(
       readStoredZipEntry(archive, 'SKILL.md') ?? '',
       canonicalSkillContent,
@@ -568,6 +618,8 @@ export function install(options: InstallOptions): InstallResult {
   const processedAgentIds = new Set<string>();
   const processedSkillIds = new Set<string>();
   const disableSupportFiles = process.env.BALLAST_DISABLE_SUPPORT_FILES === '1';
+  const refreshManagedSkills = process.env.BALLAST_REFRESH_SKILLS === '1';
+  const refreshTaskRules = process.env.BALLAST_REFRESH_TASK_RULES === '1';
 
   try {
     ensureGitignoreEntry(projectRoot, '.ballast/');
@@ -644,7 +696,12 @@ export function install(options: InstallOptions): InstallResult {
                 : undefined
           }
         );
-        if (fileExists && !force && !patch) {
+        if (
+          fileExists &&
+          !force &&
+          !patch &&
+          !(refreshTaskRules && agentId === 'tasks')
+        ) {
           agentSkipped = true;
           agentProcessed = true;
           continue;
@@ -680,7 +737,7 @@ export function install(options: InstallOptions): InstallResult {
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
-      if (fileExists && !force && !patch) {
+      if (fileExists && !force && !patch && !refreshManagedSkills) {
         continue;
       }
       switch (target) {
@@ -697,11 +754,7 @@ export function install(options: InstallOptions): InstallResult {
           const skillContent = getSkillContent(skillId);
           const nextSkillContent =
             fileExists && !force && patch
-              ? patchClaudeSkillContent(
-                  fs.readFileSync(file),
-                  skillContent,
-                  target
-                )
+              ? patchClaudeSkillContent(file, skillContent, target)
               : skillContent;
           fs.writeFileSync(file, buildClaudeSkill(skillId, nextSkillContent));
           const skillSettings = getSkillClaudeSettings(skillId);

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -433,6 +433,23 @@ function readStoredZipEntry(
   return undefined;
 }
 
+function patchClaudeSkillContent(
+  archive: Buffer,
+  canonicalSkillContent: string,
+  target: Target
+): string {
+  try {
+    return patchRuleContent(
+      readStoredZipEntry(archive, 'SKILL.md') ?? '',
+      canonicalSkillContent,
+      target
+    );
+  } catch {
+    // Fall back to a clean overwrite when an existing archive is unreadable.
+    return canonicalSkillContent;
+  }
+}
+
 function getSupportFilePath(
   target: Target,
   projectRoot: string
@@ -680,8 +697,8 @@ export function install(options: InstallOptions): InstallResult {
           const skillContent = getSkillContent(skillId);
           const nextSkillContent =
             fileExists && !force && patch
-              ? patchRuleContent(
-                  readStoredZipEntry(fs.readFileSync(file), 'SKILL.md') ?? '',
+              ? patchClaudeSkillContent(
+                  fs.readFileSync(file),
                   skillContent,
                   target
                 )

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -408,7 +408,7 @@ function readStoredZipEntry(
     archive.length - minEocdSize - maxCommentLength
   );
 
-  for (
+  eocdLoop: for (
     let eocdOffset = archive.length - minEocdSize;
     eocdOffset >= searchStart;
     eocdOffset--
@@ -425,7 +425,7 @@ function readStoredZipEntry(
       centralDirectoryEnd > archive.length ||
       centralDirectoryOffset > centralDirectoryEnd
     ) {
-      return undefined;
+      continue;
     }
 
     let entryOffset = centralDirectoryOffset;
@@ -443,17 +443,17 @@ function readStoredZipEntry(
       const fileNameStart = entryOffset + 46;
       const fileNameEnd = fileNameStart + fileNameLength;
       if (fileNameEnd > centralDirectoryEnd) {
-        return undefined;
+        continue eocdLoop;
       }
       const fileName = archive.toString('utf8', fileNameStart, fileNameEnd);
       if (fileName === entryName) {
         if (localHeaderOffset + 30 > archive.length) {
-          return undefined;
+          continue eocdLoop;
         }
         if (
           archive.readUInt32LE(localHeaderOffset) !== localFileHeaderSignature
         ) {
-          return undefined;
+          continue eocdLoop;
         }
         const localFileNameLength = archive.readUInt16LE(
           localHeaderOffset + 26
@@ -463,7 +463,7 @@ function readStoredZipEntry(
           localHeaderOffset + 30 + localFileNameLength + localExtraLength;
         const dataEnd = dataStart + compressedSize;
         if (dataEnd > archive.length) {
-          return undefined;
+          continue eocdLoop;
         }
         const data = archive.subarray(dataStart, dataEnd);
         if (compressionMethod === 0) {
@@ -619,7 +619,8 @@ export function install(options: InstallOptions): InstallResult {
   const processedSkillIds = new Set<string>();
   const disableSupportFiles = process.env.BALLAST_DISABLE_SUPPORT_FILES === '1';
   const refreshManagedSkills = process.env.BALLAST_REFRESH_SKILLS === '1';
-  const refreshTaskRules = process.env.BALLAST_REFRESH_TASK_RULES === '1';
+  const refreshTaskRulesFromEnv =
+    process.env.BALLAST_REFRESH_TASK_RULES === '1';
 
   try {
     ensureGitignoreEntry(projectRoot, '.ballast/');
@@ -634,6 +635,11 @@ export function install(options: InstallOptions): InstallResult {
   const existingConfig = loadConfig(projectRoot, language);
   const resolvedTaskSystem =
     taskSystem ?? existingConfig?.taskSystem ?? DEFAULT_TASK_SYSTEM;
+  const refreshTaskRules =
+    refreshTaskRulesFromEnv ||
+    (effectiveAgents.includes('tasks') &&
+      taskSystem !== undefined &&
+      taskSystem !== (existingConfig?.taskSystem ?? DEFAULT_TASK_SYSTEM));
 
   if (persist) {
     saveConfig(

--- a/scripts/e2e-add-agent-existing-install.sh
+++ b/scripts/e2e-add-agent-existing-install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/add-agent-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": [],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --agent docs --yes >/dev/null
+)
+
+assert_contains '"linting"' "${PROJECT}/.rulesrc.json"
+assert_contains '"docs"' "${PROJECT}/.rulesrc.json"
+assert_file_exists "${PROJECT}/.codex/rules/common/docs.md"
+assert_file_exists "${PROJECT}/.claude/rules/common/docs.md"
+assert_file_exists "${PROJECT}/.codex/rules/python/python-linting.md"
+assert_contains '`.codex/rules/common/docs.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.codex/rules/python/python-linting.md`' "${PROJECT}/AGENTS.md"
+
+echo "PASS: add-agent-existing-install-e2e"

--- a/scripts/e2e-add-skill-existing-install.sh
+++ b/scripts/e2e-add-skill-existing-install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/add-skill-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --skill github-health-check --yes >/dev/null
+)
+
+assert_contains '"owasp-security-scan"' "${PROJECT}/.rulesrc.json"
+assert_contains '"github-health-check"' "${PROJECT}/.rulesrc.json"
+assert_file_exists "${PROJECT}/.codex/rules/github-health-check.md"
+assert_file_exists "${PROJECT}/.claude/skills/github-health-check.skill"
+assert_file_exists "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_contains '`.codex/rules/owasp-security-scan.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.codex/rules/github-health-check.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.codex/rules/python/python-linting.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.claude/skills/github-health-check.skill`' "${PROJECT}/CLAUDE.md"
+
+echo "PASS: add-skill-existing-install-e2e"

--- a/scripts/e2e-add-target-existing-install.sh
+++ b/scripts/e2e-add-target-existing-install.sh
@@ -30,7 +30,7 @@ materialize_saved_install "${PROJECT}"
 
 (
   cd "${PROJECT}"
-  ballast install --target codex --agent linting --yes >/dev/null
+  ballast install --target codex --yes >/dev/null
 )
 
 assert_contains '"claude"' "${PROJECT}/.rulesrc.json"

--- a/scripts/e2e-add-target-existing-install.sh
+++ b/scripts/e2e-add-target-existing-install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/add-target-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --target codex --agent linting --yes >/dev/null
+)
+
+assert_contains '"claude"' "${PROJECT}/.rulesrc.json"
+assert_contains '"codex"' "${PROJECT}/.rulesrc.json"
+assert_file_exists "${PROJECT}/.codex/rules/python/python-linting.md"
+assert_file_exists "${PROJECT}/.codex/rules/go/go-linting.md"
+assert_file_exists "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_file_exists "${PROJECT}/.claude/rules/python/python-linting.md"
+assert_file_exists "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+assert_contains '`.codex/rules/python/python-linting.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.claude/rules/python/python-linting.md`' "${PROJECT}/CLAUDE.md"
+
+echo "PASS: add-target-existing-install-e2e"

--- a/scripts/e2e-add-task-system.sh
+++ b/scripts/e2e-add-task-system.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+BALLAST_E2E_TYPESCRIPT=1
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/add-task-system"
+create_monorepo_fixture "${PROJECT}"
+add_typescript_profile "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": [],
+  "languages": ["typescript", "python", "go"],
+  "paths": {
+    "typescript": ["apps/web"],
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --agent tasks --yes >/dev/null
+)
+
+assert_contains '"taskSystem": "github"' "${PROJECT}/.rulesrc.json"
+assert_file_exists "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_file_exists "${PROJECT}/.codex/rules/common/tasks-todo.md"
+assert_file_exists "${PROJECT}/.claude/rules/common/tasks-task-system.md"
+assert_contains 'github' "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_not_contains '{{taskSystem}}' "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_not_contains '{{taskSystem}}' "${PROJECT}/.claude/rules/common/tasks-task-system.md"
+assert_file_exists "${PROJECT}/.codex/rules/python/python-linting.md"
+
+echo "PASS: add-task-system-e2e"

--- a/scripts/e2e-change-task-system.sh
+++ b/scripts/e2e-change-task-system.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+BALLAST_E2E_TYPESCRIPT=1
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/change-task-system"
+create_monorepo_fixture "${PROJECT}"
+add_typescript_profile "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting", "tasks"],
+  "skills": [],
+  "languages": ["typescript", "python", "go"],
+  "paths": {
+    "typescript": ["apps/web"],
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2",
+  "taskSystem": "jira"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --agent tasks --task-system linear --yes >/dev/null
+)
+
+assert_contains '"taskSystem": "linear"' "${PROJECT}/.rulesrc.json"
+assert_not_contains '"taskSystem": "jira"' "${PROJECT}/.rulesrc.json"
+assert_contains 'linear' "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_not_contains 'Use jira as the system of record for work items.' "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_not_contains 'This repository uses **jira** as the system of record' "${PROJECT}/.codex/rules/common/tasks-task-system.md"
+assert_file_exists "${PROJECT}/.codex/rules/python/python-linting.md"
+
+echo "PASS: change-task-system-e2e"

--- a/scripts/e2e-doctor-after-lifecycle-change.sh
+++ b/scripts/e2e-doctor-after-lifecycle-change.sh
@@ -11,14 +11,16 @@ setup_ballast_e2e
 
 PROJECT="${WORKDIR}/doctor-after-lifecycle-change"
 create_monorepo_fixture "${PROJECT}"
+add_typescript_profile "${PROJECT}"
 
 cat > "${PROJECT}/.rulesrc.json" <<'EOF'
 {
   "targets": ["claude", "codex"],
   "agents": ["linting", "docs", "tasks"],
   "skills": ["owasp-security-scan", "github-health-check"],
-  "languages": ["python", "go"],
+  "languages": ["typescript", "python", "go"],
   "paths": {
+    "typescript": ["apps/web"],
     "python": ["services/api"],
     "go": ["tools/worker"]
   },
@@ -39,8 +41,9 @@ cat > "${PROJECT}/.rulesrc.json" <<'EOF'
   "targets": ["claude"],
   "agents": ["linting", "tasks"],
   "skills": ["owasp-security-scan"],
-  "languages": ["python", "go"],
+  "languages": ["typescript", "python", "go"],
   "paths": {
+    "typescript": ["apps/web"],
     "python": ["services/api"],
     "go": ["tools/worker"]
   },
@@ -62,8 +65,8 @@ DOCTOR_OUTPUT="$(
 assert_doctor_contains "${DOCTOR_OUTPUT}" "- targets: claude"
 assert_doctor_contains "${DOCTOR_OUTPUT}" "- skills: owasp-security-scan"
 assert_doctor_contains "${DOCTOR_OUTPUT}" "- agents: linting, tasks"
-assert_doctor_contains "${DOCTOR_OUTPUT}" "- languages: python, go"
-assert_doctor_contains "${DOCTOR_OUTPUT}" "- paths: python=services/api; go=tools/worker"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- languages: typescript, python, go"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- paths: typescript=apps/web; python=services/api; go=tools/worker"
 assert_doctor_contains "${DOCTOR_OUTPUT}" "- taskSystem: linear"
 assert_doctor_not_contains "${DOCTOR_OUTPUT}" "codex"
 assert_doctor_not_contains "${DOCTOR_OUTPUT}" "github-health-check"

--- a/scripts/e2e-doctor-after-lifecycle-change.sh
+++ b/scripts/e2e-doctor-after-lifecycle-change.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/doctor-after-lifecycle-change"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting", "docs", "tasks"],
+  "skills": ["owasp-security-scan", "github-health-check"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2",
+  "taskSystem": "jira"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --remove-target codex --yes >/dev/null
+)
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude"],
+  "agents": ["linting", "tasks"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2",
+  "taskSystem": "linear"
+}
+EOF
+
+(
+  cd "${PROJECT}"
+  ballast install --refresh-config >/dev/null
+)
+
+DOCTOR_OUTPUT="$(
+  cd "${PROJECT}" &&
+  ballast doctor
+)"
+
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- targets: claude"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- skills: owasp-security-scan"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- agents: linting, tasks"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- languages: python, go"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- paths: python=services/api; go=tools/worker"
+assert_doctor_contains "${DOCTOR_OUTPUT}" "- taskSystem: linear"
+assert_doctor_not_contains "${DOCTOR_OUTPUT}" "codex"
+assert_doctor_not_contains "${DOCTOR_OUTPUT}" "github-health-check"
+assert_doctor_not_contains "${DOCTOR_OUTPUT}" "docs"
+
+echo "PASS: doctor-after-lifecycle-change-e2e"

--- a/scripts/e2e-doctor-after-lifecycle-change.sh
+++ b/scripts/e2e-doctor-after-lifecycle-change.sh
@@ -7,6 +7,7 @@ trap 'rm -rf "${WORKDIR}"' EXIT
 
 # shellcheck source=./e2e/helpers.sh
 source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+export BALLAST_E2E_TYPESCRIPT=1
 setup_ballast_e2e
 
 PROJECT="${WORKDIR}/doctor-after-lifecycle-change"

--- a/scripts/e2e-refresh-after-target-removal.sh
+++ b/scripts/e2e-refresh-after-target-removal.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/refresh-after-target-removal"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --remove-target codex --yes >/dev/null
+  ballast install --refresh-config >/dev/null
+  ballast --language go upgrade >/dev/null
+)
+
+assert_not_contains '"codex"' "${PROJECT}/.rulesrc.json"
+assert_file_absent "${PROJECT}/.codex/rules/python/python-linting.md"
+assert_file_absent "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_file_exists "${PROJECT}/.claude/rules/python/python-linting.md"
+assert_file_exists "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+
+echo "PASS: refresh-after-target-removal-e2e"

--- a/scripts/e2e-remove-agent-existing-install.sh
+++ b/scripts/e2e-remove-agent-existing-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/remove-agent-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting", "docs"],
+  "skills": [],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": [],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+(
+  cd "${PROJECT}"
+  ballast install --refresh-config >/dev/null
+)
+
+assert_file_absent "${PROJECT}/.codex/rules/common/docs.md"
+assert_file_absent "${PROJECT}/.claude/rules/common/docs.md"
+assert_not_contains '`.codex/rules/common/docs.md`' "${PROJECT}/AGENTS.md"
+assert_not_contains '`.claude/rules/common/docs.md`' "${PROJECT}/CLAUDE.md"
+assert_file_exists "${PROJECT}/.codex/rules/python/python-linting.md"
+assert_file_exists "${PROJECT}/.claude/rules/python/python-linting.md"
+
+echo "PASS: remove-agent-existing-install-e2e"

--- a/scripts/e2e-remove-skill-existing-install.sh
+++ b/scripts/e2e-remove-skill-existing-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/remove-skill-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan", "github-health-check"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+(
+  cd "${PROJECT}"
+  ballast install --refresh-config >/dev/null
+)
+
+assert_file_absent "${PROJECT}/.codex/rules/github-health-check.md"
+assert_file_absent "${PROJECT}/.claude/skills/github-health-check.skill"
+assert_not_contains '`.codex/rules/github-health-check.md`' "${PROJECT}/AGENTS.md"
+assert_not_contains '`.claude/skills/github-health-check.skill`' "${PROJECT}/CLAUDE.md"
+assert_file_exists "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_file_exists "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+
+echo "PASS: remove-skill-existing-install-e2e"

--- a/scripts/e2e-remove-target-existing-install.sh
+++ b/scripts/e2e-remove-target-existing-install.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/remove-target-existing-install"
+create_monorepo_fixture "${PROJECT}"
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "codex"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+materialize_saved_install "${PROJECT}"
+
+(
+  cd "${PROJECT}"
+  ballast install --remove-target codex --yes >/dev/null
+)
+
+assert_not_contains '"codex"' "${PROJECT}/.rulesrc.json"
+assert_contains '"claude"' "${PROJECT}/.rulesrc.json"
+assert_file_absent "${PROJECT}/.codex/rules/python/python-linting.md"
+assert_file_absent "${PROJECT}/.codex/rules/go/go-linting.md"
+assert_file_absent "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_not_contains '`.codex/rules/' "${PROJECT}/AGENTS.md"
+assert_contains '`.claude/rules/python/python-linting.md`' "${PROJECT}/CLAUDE.md"
+assert_file_exists "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+
+echo "PASS: remove-target-existing-install-e2e"

--- a/scripts/e2e-upgrade-patch-unreadable-claude-skill.sh
+++ b/scripts/e2e-upgrade-patch-unreadable-claude-skill.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/upgrade-patch-unreadable-claude-skill"
+mkdir -p "${PROJECT}/.claude/skills"
+
+cat > "${PROJECT}/go.mod" <<'EOF'
+module example.com/upgrade-patch-unreadable-claude-skill
+
+go 1.24
+EOF
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["go"],
+  "paths": {
+    "go": ["."]
+  },
+  "ballastVersion": "0.0.1"
+}
+EOF
+
+printf 'not-a-zip-archive' > "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+
+(
+  cd "${PROJECT}"
+  ballast --language go upgrade --patch >/dev/null
+)
+
+assert_valid_claude_skill_archive "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+assert_contains '"owasp-security-scan"' "${PROJECT}/.rulesrc.json"
+assert_contains '`.claude/skills/owasp-security-scan.skill`' "${PROJECT}/CLAUDE.md"
+
+echo "PASS: upgrade-patch-unreadable-claude-skill-e2e"

--- a/scripts/e2e-upgrade-refresh-skills.sh
+++ b/scripts/e2e-upgrade-refresh-skills.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/upgrade-refresh-skills"
+mkdir -p "${PROJECT}/.codex/rules" "${PROJECT}/.claude/rules"
+
+cat > "${PROJECT}/go.mod" <<'EOF'
+module example.com/upgrade-refresh-skills
+
+go 1.24
+EOF
+
+cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["codex", "claude"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["go"],
+  "paths": {
+    "go": ["."]
+  },
+  "ballastVersion": "0.0.1"
+}
+EOF
+
+cat > "${PROJECT}/.codex/rules/owasp-security-scan.md" <<'EOF'
+stale skill content
+EOF
+
+cat > "${PROJECT}/.codex/rules/go-linting.md" <<'EOF'
+existing linting rule
+EOF
+
+(
+  cd "${PROJECT}"
+  ballast --language go upgrade >/dev/null
+)
+
+assert_contains "# OWASP Security Scan Skill" "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_not_contains "stale skill content" "${PROJECT}/.codex/rules/owasp-security-scan.md"
+assert_contains '"owasp-security-scan"' "${PROJECT}/.rulesrc.json"
+assert_not_contains '"ballastVersion": "0.0.1"' "${PROJECT}/.rulesrc.json"
+assert_contains '`.codex/rules/owasp-security-scan.md`' "${PROJECT}/AGENTS.md"
+assert_contains '`.claude/skills/owasp-security-scan.skill`' "${PROJECT}/CLAUDE.md"
+assert_contains "existing linting rule" "${PROJECT}/.codex/rules/go-linting.md"
+
+echo "PASS: upgrade-refresh-skills-e2e"

--- a/scripts/e2e/helpers.sh
+++ b/scripts/e2e/helpers.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+setup_ballast_e2e() {
+  if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+    make -C "${REPO_ROOT}" build-go build-cli >/dev/null
+  fi
+
+  E2E_BIN_DIR="${E2E_BIN_DIR:-${WORKDIR}/bin}"
+  mkdir -p "${E2E_BIN_DIR}"
+
+  cat > "${E2E_BIN_DIR}/ballast-python" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+PYTHONPATH="${REPO_ROOT}/packages/ballast-python\${PYTHONPATH:+:\$PYTHONPATH}" python3 -m ballast "\$@"
+EOF
+  chmod +x "${E2E_BIN_DIR}/ballast-python"
+
+  if [[ "${BALLAST_E2E_TYPESCRIPT:-0}" == "1" ]]; then
+    if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+      pnpm -C "${REPO_ROOT}" run build >/dev/null
+    fi
+    cat > "${E2E_BIN_DIR}/ballast-typescript" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+node "${REPO_ROOT}/packages/ballast-typescript/dist/cli.js" "\$@"
+EOF
+    chmod +x "${E2E_BIN_DIR}/ballast-typescript"
+  fi
+
+  export BALLAST_REPO_ROOT="${REPO_ROOT}"
+  export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv-cache}"
+  mkdir -p "${UV_CACHE_DIR}"
+  export PATH="${REPO_ROOT}/cli/ballast:${REPO_ROOT}/packages/ballast-go:${E2E_BIN_DIR}:${PATH}"
+}
+
+create_monorepo_fixture() {
+  local root="$1"
+  mkdir -p "${root}/services/api/ballast_api" "${root}/tools/worker"
+
+  cat > "${root}/package.json" <<'EOF'
+{
+  "name": "ballast-e2e-fixture",
+  "private": true
+}
+EOF
+
+  cat > "${root}/services/api/pyproject.toml" <<'EOF'
+[project]
+name = "ballast-api"
+version = "0.0.0"
+requires-python = ">=3.10"
+EOF
+
+  cat > "${root}/services/api/ballast_api/__init__.py" <<'EOF'
+"""ballast fixture package."""
+EOF
+
+  cat > "${root}/tools/worker/go.mod" <<'EOF'
+module example.com/ballast-worker
+
+go 1.24
+EOF
+
+  cat > "${root}/tools/worker/main.go" <<'EOF'
+package main
+
+func main() {}
+EOF
+}
+
+add_typescript_profile() {
+  local root="$1"
+  mkdir -p "${root}/apps/web/src"
+
+  cat > "${root}/apps/web/package.json" <<'EOF'
+{
+  "name": "ballast-web",
+  "private": true
+}
+EOF
+
+  cat > "${root}/apps/web/tsconfig.json" <<'EOF'
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext"
+  }
+}
+EOF
+
+  cat > "${root}/apps/web/src/index.ts" <<'EOF'
+export {};
+EOF
+}
+
+materialize_saved_install() {
+  local root="$1"
+  (
+    cd "${root}"
+    ballast install --refresh-config >/dev/null
+  )
+}
+
+assert_file_exists() {
+  local path="$1"
+  [[ -f "${path}" ]] || fail "expected file ${path}"
+}
+
+assert_file_absent() {
+  local path="$1"
+  [[ ! -e "${path}" ]] || fail "expected ${path} to be absent"
+}
+
+assert_dir_absent() {
+  local path="$1"
+  [[ ! -d "${path}" ]] || fail "expected directory ${path} to be absent"
+}
+
+assert_contains() {
+  local needle="$1"
+  local path="$2"
+  grep -Fq "${needle}" "${path}" || fail "expected '${needle}' in ${path}"
+}
+
+assert_not_contains() {
+  local needle="$1"
+  local path="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected '${needle}' to be absent in ${path}"
+  fi
+}
+
+assert_valid_claude_skill_archive() {
+  local path="$1"
+  unzip -tqq "${path}" >/dev/null || fail "expected valid zip archive at ${path}"
+  unzip -l "${path}" | grep -Fq "SKILL.md" || fail "expected SKILL.md inside ${path}"
+}
+
+assert_doctor_contains() {
+  local output="$1"
+  local needle="$2"
+  grep -Fq -- "${needle}" <<<"${output}" || fail "expected '${needle}' in doctor output"
+}
+
+assert_doctor_not_contains() {
+  local output="$1"
+  local needle="$2"
+  if grep -Fq -- "${needle}" <<<"${output}"; then
+    fail "expected '${needle}' to be absent from doctor output"
+  fi
+}


### PR DESCRIPTION
## Summary
- add standalone `scripts/e2e-*.sh` coverage for existing-install lifecycle and upgrade flows
- reconcile stale managed agent/skill artifacts and keep support-file sections in sync during wrapper refreshes
- extend doctor output to report `taskSystem` and update backend coverage for skill refresh and unreadable Claude archive recovery

## Testing
- `./scripts/run-unit-tests-pre-push.sh` except the final CLI `go test` step needed `GOCACHE=/tmp/go-build-cli` because the default cache path was read-only in this environment
- `env GOCACHE=/tmp/go-build-cli go test ./...` in `cli/ballast`
- `go test ./...` in `packages/ballast-go`
- `uv run --python 3.12 python -m unittest tests.test_cli` in `packages/ballast-python`
- `pnpm --filter @everydaydevopsio/ballast run test -- doctor.test.ts`
- `for script in ./scripts/e2e-*.sh; do "$script"; done`

## Follow-up
- closes #184