### PR TITLE
Auto-populate Repository Facts via wrapper handoff

### DIFF
--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -287,6 +287,8 @@ jobs:
           - name: change-task-system-e2e
             script: ./scripts/e2e-change-task-system.sh
             needs_typescript: true
+          - name: repository-facts-populated-e2e
+            script: ./scripts/e2e-repository-facts-populated.sh
 
     steps:
       - name: Checkout ballast repo

--- a/.github/workflows/examples-smoke.yml
+++ b/.github/workflows/examples-smoke.yml
@@ -289,6 +289,7 @@ jobs:
             needs_typescript: true
           - name: repository-facts-populated-e2e
             script: ./scripts/e2e-repository-facts-populated.sh
+            needs_typescript: true
 
     steps:
       - name: Checkout ballast repo

--- a/PRD.md
+++ b/PRD.md
@@ -167,3 +167,26 @@ Running `ballast install` from a directory that is its own git repository but do
 3. TypeScript, Python, and Go automated tests cover the git-boundary stop condition.
 4. Wrapper tests cover root resolution when a repo is anchored by `.rulesrc.json` and legacy Ballast config files.
 5. The examples smoke workflow runs an end-to-end git-boundary scenario that fails if install output is written to the parent directory.
+
+## Repository Facts Auto-Population
+
+### Problem
+
+Ballast scaffolds `AGENTS.md` and `CLAUDE.md` with a `Repository Facts` section, but currently leaves placeholder values. Agents then re-derive stable repository metadata repeatedly instead of using durable facts captured during install.
+
+### Requirements
+
+1. The `ballast` wrapper must discover repository facts once per invocation and pass them to backend installers through a temporary JSON file path provided in environment (`BALLAST_REPOSITORY_FACTS_FILE`) and optional backend CLI flag support (`--repository-facts-file`).
+2. TypeScript, Python, and Go backends must consume the wrapper-provided facts section when present and valid.
+3. On first-time support-file creation and on `--force` regeneration, generated `AGENTS.md`/`CLAUDE.md` content must include discovered values for detectable fields.
+4. Monorepo support-file generation in the wrapper must render the same discovered repository facts content.
+5. When a fact cannot be detected, the generated value must remain an explicit placeholder marker.
+6. Discovery and rendering must remain non-destructive and read-only outside writing Ballast-managed outputs.
+
+### Acceptance Criteria
+
+1. Given a repository with detectable git origin, default branch, and package-manager signals, running install produces `AGENTS.md` with detected values instead of `<OWNER/REPO>`, `<main>`, and package-manager placeholders.
+2. Given wrapper-driven monorepo install flows, generated support files include the same discovered facts.
+3. Given missing signals, generated support files retain placeholder markers for undetected fields.
+4. TypeScript, Python, and Go backends accept `--repository-facts-file` and honor `BALLAST_REPOSITORY_FACTS_FILE` when present.
+5. E2E coverage verifies populated repository facts in generated support files.

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1564,7 +1564,7 @@ func detectCanonicalRepo(root string) string {
 	if strings.HasPrefix(url, "ssh://git@github.com/") {
 		return strings.TrimPrefix(url, "ssh://git@github.com/")
 	}
-	return url
+	return ""
 }
 
 func detectDefaultBranch(root string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"slices"
@@ -1591,9 +1592,19 @@ func detectPackageManager(root string) string {
 		return "uv"
 	case fileExists(filepath.Join(root, "go.mod")):
 		return "go"
-	default:
+	}
+	metadata, ok := loadPackageJSONMetadata(root)
+	if !ok {
 		return ""
 	}
+	packageManager := strings.TrimSpace(metadata.PackageManager)
+	if packageManager == "" {
+		return ""
+	}
+	if index := strings.Index(packageManager, "@"); index > 0 {
+		return strings.TrimSpace(packageManager[:index])
+	}
+	return packageManager
 }
 
 func detectVersionFiles(root string) string {
@@ -1644,27 +1655,86 @@ func detectWorkflows(root string) (string, string) {
 }
 
 func detectPreferredCommands(root string) string {
-	makefile := filepath.Join(root, "Makefile")
-	if fileExists(makefile) {
-		return "make test, make lint, make build"
+	commands := []string{}
+	targets := parseMakeTargets(root)
+	for _, target := range []string{"test", "lint", "build"} {
+		if containsString(targets, target) {
+			commands = append(commands, "make "+target)
+		}
 	}
-	if fileExists(filepath.Join(root, "package.json")) {
-		return "npm/pnpm scripts: test, lint, build"
+	if metadata, ok := loadPackageJSONMetadata(root); ok {
+		for _, script := range []string{"test", "lint", "build", "format"} {
+			if _, exists := metadata.Scripts[script]; exists {
+				commands = append(commands, "package.json:"+script)
+			}
+		}
 	}
-	if fileExists(filepath.Join(root, "pyproject.toml")) {
-		return "uv run pytest, uv run ruff check"
-	}
-	if fileExists(filepath.Join(root, "go.mod")) {
-		return "go test ./..., gofmt -w"
+	return strings.Join(uniqueStrings(commands), ", ")
+}
+
+func detectCoverageThreshold(root string) string {
+	for _, candidate := range []string{
+		filepath.Join(root, "vitest.config.ts"),
+		filepath.Join(root, "vitest.config.js"),
+		filepath.Join(root, "jest.config.ts"),
+		filepath.Join(root, "jest.config.js"),
+	} {
+		content, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+		if threshold := parseCoverageThreshold(string(content)); threshold != "" {
+			return threshold
+		}
 	}
 	return ""
 }
 
-func detectCoverageThreshold(root string) string {
-	if fileExists(filepath.Join(root, "vitest.config.ts")) || fileExists(filepath.Join(root, "jest.config.js")) {
-		return "check test config"
+func parseCoverageThreshold(content string) string {
+	for _, pattern := range []string{
+		`(?m)lines\s*:\s*([0-9]{1,3})`,
+		`(?m)statements\s*:\s*([0-9]{1,3})`,
+		`(?m)functions\s*:\s*([0-9]{1,3})`,
+	} {
+		match := regexp.MustCompile(pattern).FindStringSubmatch(content)
+		if len(match) == 2 {
+			return match[1] + "%"
+		}
 	}
 	return ""
+}
+
+func parseMakeTargets(root string) []string {
+	content, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	if err != nil {
+		return nil
+	}
+	targets := []string{}
+	for _, line := range strings.Split(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ".") || strings.Contains(trimmed, "=") {
+			continue
+		}
+		index := strings.Index(trimmed, ":")
+		if index <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(trimmed[:index])
+		if name == "" || strings.Contains(name, " ") {
+			continue
+		}
+		targets = append(targets, name)
+	}
+	return uniqueStrings(targets)
+}
+
+func containsString(values []string, value string) bool {
+	for _, current := range values {
+		if current == value {
+			return true
+		}
+	}
+	return false
 }
 
 func detectGeneratedPaths(root string) string {
@@ -1680,6 +1750,7 @@ func detectGeneratedPaths(root string) string {
 
 type packageJSONMetadata struct {
 	Scripts              map[string]any `json:"scripts"`
+	PackageManager       string         `json:"packageManager"`
 	Dependencies         map[string]any `json:"dependencies"`
 	DevDependencies      map[string]any `json:"devDependencies"`
 	PeerDependencies     map[string]any `json:"peerDependencies"`
@@ -1689,6 +1760,22 @@ type packageJSONMetadata struct {
 	Browser              any            `json:"browser"`
 	Bin                  any            `json:"bin"`
 	Exports              any            `json:"exports"`
+}
+
+func loadPackageJSONMetadata(root string) (packageJSONMetadata, bool) {
+	packageJSONPath := filepath.Join(root, "package.json")
+	if !fileExists(packageJSONPath) {
+		return packageJSONMetadata{}, false
+	}
+	content, err := os.ReadFile(packageJSONPath)
+	if err != nil {
+		return packageJSONMetadata{}, false
+	}
+	var metadata packageJSONMetadata
+	if err := json.Unmarshal(content, &metadata); err != nil {
+		return packageJSONMetadata{}, false
+	}
+	return metadata, true
 }
 
 func javascriptComponentWarning(root string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -175,6 +175,11 @@ type monorepoPlan struct {
 	Previous    *monorepoConfig
 }
 
+type repositoryFactsPayload struct {
+	Version                int      `json:"version"`
+	RepositoryFactsSection []string `json:"repositoryFactsSection"`
+}
+
 func main() {
 	os.Exit(run(os.Args[1:]))
 }
@@ -221,6 +226,12 @@ func run(args []string) int {
 	}
 
 	root := findProjectRoot("")
+	repositoryFactsEnv, cleanupRepositoryFacts, err := prepareRepositoryFactsEnv(root)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	defer cleanupRepositoryFacts()
 	refreshConfigRequested := len(forwardedArgs) > 0 && forwardedArgs[0] == "install" && hasFlag(forwardedArgs, "--refresh-config", "")
 	normalizedArgs, err := normalizeInstallArgs(forwardedArgs, root)
 	if err != nil {
@@ -247,6 +258,7 @@ func run(args []string) int {
 					invocation.Env["BALLAST_REFRESH_SKILLS"] = "1"
 					invocation.Env["BALLAST_REFRESH_TASK_RULES"] = "1"
 				}
+				invocation.Env = mergeResolvedEnv(invocation.Env, repositoryFactsEnv)
 				resolved := resolveBackendCommand(invocation.Language, tool, invocation.Args, invocation.Env)
 				if !resolved.UseLocal {
 					if err := ensureInstalledFunc(tool); err != nil {
@@ -311,6 +323,7 @@ func run(args []string) int {
 			"BALLAST_REFRESH_TASK_RULES": "1",
 		}
 	}
+	singleEnv = mergeResolvedEnv(singleEnv, repositoryFactsEnv)
 	resolved := resolveBackendCommand(selectedLanguage, tool, forwardedArgs, singleEnv)
 	if !resolved.UseLocal {
 		if err := ensureInstalledFunc(tool); err != nil {
@@ -1459,6 +1472,212 @@ func cloneEnvMap(env map[string]string) map[string]string {
 	return cloned
 }
 
+func prepareRepositoryFactsEnv(root string) (map[string]string, func(), error) {
+	section := discoverRepositoryFactsSection(root)
+	payload := repositoryFactsPayload{
+		Version:                1,
+		RepositoryFactsSection: section,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("marshal repository facts payload: %w", err)
+	}
+	file, err := os.CreateTemp("", "ballast-repository-facts-*.json")
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("create repository facts file: %w", err)
+	}
+	path := file.Name()
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return nil, func() {}, fmt.Errorf("write repository facts file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, func() {}, fmt.Errorf("close repository facts file: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = os.Remove(path)
+		return nil, func() {}, fmt.Errorf("set repository facts file permissions: %w", err)
+	}
+	return map[string]string{"BALLAST_REPOSITORY_FACTS_FILE": path}, func() {
+		_ = os.Remove(path)
+	}, nil
+}
+
+func discoverRepositoryFactsSection(root string) []string {
+	canonicalRepo := detectCanonicalRepo(root)
+	defaultBranch := detectDefaultBranch(root)
+	packageManager := detectPackageManager(root)
+	versionFiles := detectVersionFiles(root)
+	configFiles := detectConfigFiles(root)
+	ciWorkflows, releaseWorkflows := detectWorkflows(root)
+	preferredCommands := detectPreferredCommands(root)
+	coverageThreshold := detectCoverageThreshold(root)
+	generatedPaths := detectGeneratedPaths(root)
+
+	withPlaceholder := func(value string, placeholder string) string {
+		if strings.TrimSpace(value) == "" {
+			return "<" + placeholder + ">"
+		}
+		return value
+	}
+
+	return []string{
+		"## Repository Facts",
+		"",
+		"Use this section for durable repo-specific facts that agents repeatedly need. Prefer facts stored here over re-deriving them with shell commands on every task.",
+		"",
+		"Keep only stable, reviewable metadata here. Do not store secrets, credentials, or ephemeral runtime state.",
+		"",
+		"Suggested facts to record:",
+		"",
+		fmt.Sprintf("- Canonical GitHub repo: `%s`", withPlaceholder(canonicalRepo, "OWNER/REPO")),
+		fmt.Sprintf("- Default branch: `%s`", withPlaceholder(defaultBranch, "main")),
+		fmt.Sprintf("- Primary package manager: `%s`", withPlaceholder(packageManager, "pnpm | npm | yarn | uv | go")),
+		fmt.Sprintf("- Version-file locations agents should check first: `%s`", withPlaceholder(versionFiles, ".nvmrc, packageManager, pyproject.toml, go.mod, etc.")),
+		fmt.Sprintf("- Canonical config files: `%s`", withPlaceholder(configFiles, "paths agents should read before falling back to discovery")),
+		fmt.Sprintf("- Primary CI workflows: `%s`", withPlaceholder(ciWorkflows, "workflow filenames")),
+		fmt.Sprintf("- Primary release/publish workflows: `%s`", withPlaceholder(releaseWorkflows, "workflow filenames")),
+		fmt.Sprintf("- Preferred build/test/lint/format/coverage commands: `%s`", withPlaceholder(preferredCommands, "commands")),
+		fmt.Sprintf("- Coverage threshold: `%s`", withPlaceholder(coverageThreshold, "value")),
+		fmt.Sprintf("- Generated or protected paths agents should avoid editing directly: `%s`", withPlaceholder(generatedPaths, "paths")),
+		"",
+		"Update this section when those facts change. If live runtime state is required, discover it separately instead of treating it as a durable repo fact.",
+	}
+}
+
+func detectCanonicalRepo(root string) string {
+	output, err := runCommandOutputFunc("git", []string{"-C", root, "remote", "get-url", "origin"})
+	if err != nil {
+		return ""
+	}
+	url := strings.TrimSpace(output)
+	url = strings.TrimSuffix(url, ".git")
+	if strings.HasPrefix(url, "git@github.com:") {
+		return strings.TrimPrefix(url, "git@github.com:")
+	}
+	if strings.HasPrefix(url, "https://github.com/") {
+		return strings.TrimPrefix(url, "https://github.com/")
+	}
+	if strings.HasPrefix(url, "ssh://git@github.com/") {
+		return strings.TrimPrefix(url, "ssh://git@github.com/")
+	}
+	return url
+}
+
+func detectDefaultBranch(root string) string {
+	output, err := runCommandOutputFunc("git", []string{"-C", root, "symbolic-ref", "refs/remotes/origin/HEAD"})
+	if err != nil {
+		return ""
+	}
+	trimmed := strings.TrimSpace(output)
+	const prefix = "refs/remotes/origin/"
+	if strings.HasPrefix(trimmed, prefix) {
+		return strings.TrimPrefix(trimmed, prefix)
+	}
+	return trimmed
+}
+
+func detectPackageManager(root string) string {
+	switch {
+	case fileExists(filepath.Join(root, "pnpm-lock.yaml")):
+		return "pnpm"
+	case fileExists(filepath.Join(root, "yarn.lock")):
+		return "yarn"
+	case fileExists(filepath.Join(root, "package-lock.json")):
+		return "npm"
+	case fileExists(filepath.Join(root, "uv.lock")):
+		return "uv"
+	case fileExists(filepath.Join(root, "go.mod")):
+		return "go"
+	default:
+		return ""
+	}
+}
+
+func detectVersionFiles(root string) string {
+	candidates := []string{".nvmrc", "package.json", "pyproject.toml", "uv.lock", "go.mod", ".python-version"}
+	found := []string{}
+	for _, candidate := range candidates {
+		if fileExists(filepath.Join(root, candidate)) {
+			found = append(found, candidate)
+		}
+	}
+	return strings.Join(found, ", ")
+}
+
+func detectConfigFiles(root string) string {
+	candidates := []string{"eslint.config.mjs", ".eslintrc", ".prettierrc", "tsconfig.json", "pyproject.toml", "ruff.toml", "go.mod"}
+	found := []string{}
+	for _, candidate := range candidates {
+		if fileExists(filepath.Join(root, candidate)) {
+			found = append(found, candidate)
+		}
+	}
+	return strings.Join(found, ", ")
+}
+
+func detectWorkflows(root string) (string, string) {
+	workflowDir := filepath.Join(root, ".github", "workflows")
+	entries, err := os.ReadDir(workflowDir)
+	if err != nil {
+		return "", ""
+	}
+	ci := []string{}
+	release := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := strings.ToLower(entry.Name())
+		if strings.Contains(name, "ci") || strings.Contains(name, "test") || strings.Contains(name, "lint") || strings.Contains(name, "build") {
+			ci = append(ci, entry.Name())
+		}
+		if strings.Contains(name, "release") || strings.Contains(name, "publish") {
+			release = append(release, entry.Name())
+		}
+	}
+	sort.Strings(ci)
+	sort.Strings(release)
+	return strings.Join(ci, ", "), strings.Join(release, ", ")
+}
+
+func detectPreferredCommands(root string) string {
+	makefile := filepath.Join(root, "Makefile")
+	if fileExists(makefile) {
+		return "make test, make lint, make build"
+	}
+	if fileExists(filepath.Join(root, "package.json")) {
+		return "npm/pnpm scripts: test, lint, build"
+	}
+	if fileExists(filepath.Join(root, "pyproject.toml")) {
+		return "uv run pytest, uv run ruff check"
+	}
+	if fileExists(filepath.Join(root, "go.mod")) {
+		return "go test ./..., gofmt -w"
+	}
+	return ""
+}
+
+func detectCoverageThreshold(root string) string {
+	if fileExists(filepath.Join(root, "vitest.config.ts")) || fileExists(filepath.Join(root, "jest.config.js")) {
+		return "check test config"
+	}
+	return ""
+}
+
+func detectGeneratedPaths(root string) string {
+	candidates := []string{"dist/", "build/", "coverage/", "generated/", ".ballast/"}
+	found := []string{}
+	for _, candidate := range candidates {
+		if fileExists(filepath.Join(root, strings.TrimSuffix(candidate, "/"))) {
+			found = append(found, candidate)
+		}
+	}
+	return strings.Join(found, ", ")
+}
+
 type packageJSONMetadata struct {
 	Scripts              map[string]any `json:"scripts"`
 	Dependencies         map[string]any `json:"dependencies"`
@@ -2266,7 +2485,7 @@ func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) 
 			continue
 		}
 		path := supportFilePath(root, target)
-		content := buildMonorepoSupportFile(plan, target)
+		content := buildMonorepoSupportFile(root, plan, target)
 		if !fileExists(path) {
 			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 				return err
@@ -2289,7 +2508,7 @@ func updateMonorepoSupportFiles(root string, plan *monorepoPlan, args []string) 
 		if target == "gemini" {
 			agentsPath := supportFilePath(root, "codex")
 			if !fileExists(agentsPath) {
-				if err := os.WriteFile(agentsPath, []byte(buildMonorepoSupportFile(plan, "codex")), 0o644); err != nil {
+				if err := os.WriteFile(agentsPath, []byte(buildMonorepoSupportFile(root, plan, "codex")), 0o644); err != nil {
 					return err
 				}
 			}
@@ -2529,7 +2748,7 @@ func supportFilePath(root string, target string) string {
 	return filepath.Join(root, "AGENTS.md")
 }
 
-func buildMonorepoSupportFile(plan *monorepoPlan, target string) string {
+func buildMonorepoSupportFile(root string, plan *monorepoPlan, target string) string {
 	title := "# AGENTS.md"
 	intro := "This file provides shared repository guidance for agent tools that read AGENTS.md."
 	rulesDir := ".codex/rules"
@@ -2555,29 +2774,8 @@ func buildMonorepoSupportFile(plan *monorepoPlan, target string) string {
 	if target == "gemini" {
 		lines = append(lines, "@./AGENTS.md", "")
 	} else {
-		lines = append(lines,
-			"## Repository Facts",
-			"",
-			"Use this section for durable repo-specific facts that agents repeatedly need. Prefer facts stored here over re-deriving them with shell commands on every task.",
-			"",
-			"Keep only stable, reviewable metadata here. Do not store secrets, credentials, or ephemeral runtime state.",
-			"",
-			"Suggested facts to record:",
-			"",
-			"- Canonical GitHub repo: `<OWNER/REPO>`",
-			"- Default branch: `<main>`",
-			"- Primary package manager: `<pnpm | npm | yarn | uv | go>`",
-			"- Version-file locations agents should check first: `<.nvmrc, packageManager, pyproject.toml, go.mod, etc.>`",
-			"- Canonical config files: `<paths agents should read before falling back to discovery>`",
-			"- Primary CI workflows: `<workflow filenames>`",
-			"- Primary release/publish workflows: `<workflow filenames>`",
-			"- Preferred build/test/lint/format/coverage commands: `<commands>`",
-			"- Coverage threshold: `<value>`",
-			"- Generated or protected paths agents should avoid editing directly: `<paths>`",
-			"",
-			"Update this section when those facts change. If live runtime state is required, discover it separately instead of treating it as a durable repo fact.",
-			"",
-		)
+		lines = append(lines, discoverRepositoryFactsSection(root)...)
+		lines = append(lines, "")
 	}
 
 	lines = append(lines,

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -3460,7 +3460,8 @@ func TestBuildMonorepoSupportFileIncludesPublishingAndSkillsForCodex(t *testing.
 		},
 	}
 
-	content := buildMonorepoSupportFile(plan, "codex")
+	root := t.TempDir()
+	content := buildMonorepoSupportFile(root, plan, "codex")
 
 	if !strings.Contains(content, "## Repository Facts") {
 		t.Fatalf("expected repository facts section in codex support file, got %q", content)
@@ -3495,7 +3496,8 @@ func TestBuildMonorepoSupportFileIncludesSkillsForClaude(t *testing.T) {
 		},
 	}
 
-	content := buildMonorepoSupportFile(plan, "claude")
+	root := t.TempDir()
+	content := buildMonorepoSupportFile(root, plan, "claude")
 
 	if !strings.Contains(content, "## Installed skills") {
 		t.Fatalf("expected installed skills section in claude support file, got %q", content)
@@ -3514,7 +3516,8 @@ func TestBuildMonorepoSupportFileIncludesDocsForCodex(t *testing.T) {
 		},
 	}
 
-	content := buildMonorepoSupportFile(plan, "codex")
+	root := t.TempDir()
+	content := buildMonorepoSupportFile(root, plan, "codex")
 
 	if !strings.Contains(content, "`.codex/rules/common/docs.md`") {
 		t.Fatalf("expected docs rule entry in codex support file, got %q", content)

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -424,6 +424,7 @@ Options:
   --force                   Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
+  --repository-facts-file   Optional path to wrapper-generated repository facts JSON
   --help, -h                Show this help
   --version, -v             Show version
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -205,6 +205,7 @@ func runInstall(args []string) int {
 	fs.BoolVar(patch, "p", false, "merge upstream rule and skill updates into existing files")
 	yes := fs.Bool("yes", false, "non-interactive mode")
 	fs.BoolVar(yes, "y", false, "non-interactive mode")
+	repositoryFactsFile := fs.String("repository-facts-file", "", "optional path to wrapper-generated repository facts JSON")
 	if err := fs.Parse(trimCommand(args)); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -218,6 +219,9 @@ func runInstall(args []string) int {
 	}
 
 	lang := strings.ToLower(strings.TrimSpace(*language))
+	if strings.TrimSpace(*repositoryFactsFile) != "" {
+		_ = os.Setenv("BALLAST_REPOSITORY_FACTS_FILE", strings.TrimSpace(*repositoryFactsFile))
+	}
 	if !contains(languages, lang) {
 		fmt.Printf("Invalid --language. Use: %s\n", strings.Join(languages, ", "))
 		return 1
@@ -1237,6 +1241,18 @@ func ballastNotice() string {
 }
 
 func repositoryFactsSection() []string {
+	if overridePath := strings.TrimSpace(os.Getenv("BALLAST_REPOSITORY_FACTS_FILE")); overridePath != "" {
+		type factsPayload struct {
+			RepositoryFactsSection []string `json:"repositoryFactsSection"`
+		}
+		content, err := os.ReadFile(overridePath)
+		if err == nil {
+			var payload factsPayload
+			if json.Unmarshal(content, &payload) == nil && len(payload.RepositoryFactsSection) > 0 {
+				return payload.RepositoryFactsSection
+			}
+		}
+	}
 	return []string{
 		"## Repository Facts",
 		"",

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1024,6 +1024,17 @@ def ballast_notice() -> str:
 
 
 def repository_facts_section() -> list[str]:
+    override_path = os.environ.get("BALLAST_REPOSITORY_FACTS_FILE", "").strip()
+    if override_path:
+        try:
+            payload = json.loads(Path(override_path).read_text(encoding="utf-8"))
+            lines = payload.get("repositoryFactsSection")
+            if isinstance(lines, list):
+                normalized = [line for line in lines if isinstance(line, str)]
+                if normalized:
+                    return normalized
+        except Exception:
+            pass
     return [
         "## Repository Facts",
         "",
@@ -1858,6 +1869,8 @@ def print_install_result(
 
 
 def run_install(args: argparse.Namespace) -> int:
+    if getattr(args, "repository_facts_file", None):
+        os.environ["BALLAST_REPOSITORY_FACTS_FILE"] = args.repository_facts_file
     language = (args.language or "python").strip().lower()
     if language not in LANGUAGES:
         print(f"Invalid --language. Use: {', '.join(LANGUAGES)}")
@@ -1998,6 +2011,10 @@ def parser() -> argparse.ArgumentParser:
         help="Merge upstream rule and skill updates into existing files",
     )
     install_cmd.add_argument("--yes", "-y", action="store_true")
+    install_cmd.add_argument(
+        "--repository-facts-file",
+        help="Optional path to wrapper-generated repository facts JSON",
+    )
     sub.add_parser(
         "doctor", help="Check local Ballast CLI versions and .rulesrc.json metadata"
     )

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -313,7 +313,9 @@ def save_config(
                             and all(isinstance(item, str) for item in value)
                         ):
                             paths[key] = list(value)
-        except Exception:
+        except (OSError, json.JSONDecodeError):
+            # Invalid/unreadable override payload should fall back to the
+            # built-in repository facts scaffold.
             pass
 
     if language not in languages:

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -314,8 +314,8 @@ def save_config(
                         ):
                             paths[key] = list(value)
         except (OSError, json.JSONDecodeError):
-            # Invalid/unreadable override payload should fall back to the
-            # built-in repository facts scaffold.
+            # Invalid/unreadable existing config should fall back to defaults
+            # while preserving current save behavior.
             pass
 
     if language not in languages:
@@ -1031,11 +1031,15 @@ def repository_facts_section() -> list[str]:
         try:
             payload = json.loads(Path(override_path).read_text(encoding="utf-8"))
             lines = payload.get("repositoryFactsSection")
-            if isinstance(lines, list):
-                normalized = [line for line in lines if isinstance(line, str)]
-                if normalized:
-                    return normalized
-        except Exception:
+            if (
+                isinstance(lines, list)
+                and lines
+                and all(isinstance(line, str) for line in lines)
+            ):
+                return lines
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            # Invalid/unreadable override payload should fall back to the
+            # built-in repository facts scaffold.
             pass
     return [
         "## Repository Facts",

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -739,10 +739,16 @@ function loadRepositoryFactsSection(): string[] | null {
       repositoryFactsSection?: unknown;
     };
     if (!Array.isArray(parsed.repositoryFactsSection)) return null;
-    const lines = parsed.repositoryFactsSection.filter(
-      (line): line is string => typeof line === 'string'
-    );
-    return lines.length > 0 ? lines : null;
+    if (
+      !parsed.repositoryFactsSection.every(
+        (line): line is string => typeof line === 'string'
+      )
+    ) {
+      return null;
+    }
+    return parsed.repositoryFactsSection.length > 0
+      ? parsed.repositoryFactsSection
+      : null;
   } catch {
     return null;
   }

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -705,6 +705,8 @@ export function getSkillDescription(skillId: string): string {
 }
 
 function getRepositoryFactsSection(): string[] {
+  const fromEnv = loadRepositoryFactsSection();
+  if (fromEnv) return fromEnv;
   return [
     '## Repository Facts',
     '',
@@ -727,6 +729,23 @@ function getRepositoryFactsSection(): string[] {
     '',
     'Update this section when those facts change. If live runtime state is required, discover it separately instead of treating it as a durable repo fact.'
   ];
+}
+
+function loadRepositoryFactsSection(): string[] | null {
+  const path = process.env.BALLAST_REPOSITORY_FACTS_FILE?.trim();
+  if (!path) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(path, 'utf8')) as {
+      repositoryFactsSection?: unknown;
+    };
+    if (!Array.isArray(parsed.repositoryFactsSection)) return null;
+    const lines = parsed.repositoryFactsSection.filter(
+      (line): line is string => typeof line === 'string'
+    );
+    return lines.length > 0 ? lines : null;
+  } catch {
+    return null;
+  }
 }
 
 export function buildCodexAgentsMd(

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -17,6 +17,7 @@ export interface CliOptions {
   patch: boolean;
   yes: boolean;
   taskSystem: string;
+  repositoryFactsFile?: string;
 }
 
 export type ParseArgsResult =
@@ -117,6 +118,12 @@ export function parseArgs(argv: string[]): ParseArgsResult {
       i++;
       continue;
     }
+    if (arg === '--repository-facts-file') {
+      const value = args[++i];
+      if (value) options.repositoryFactsFile = value.trim();
+      i++;
+      continue;
+    }
     if (arg === '--help' || arg === '-h') {
       return { help: true };
     }
@@ -151,6 +158,7 @@ Options:
   --force, -f               Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
+  --repository-facts-file   Optional path to wrapper-generated repository facts JSON
   --help, -h                Show this help
   --version, -v             Show version
 
@@ -236,7 +244,8 @@ export async function main(): Promise<void> {
     targets: cliOptions.targets,
     agents: cliOptions.agents.length > 0 ? cliOptions.agents : undefined,
     skills: cliOptions.skills.length > 0 ? cliOptions.skills : undefined,
-    taskSystem: cliOptions.taskSystem || undefined
+    taskSystem: cliOptions.taskSystem || undefined,
+    repositoryFactsFile: cliOptions.repositoryFactsFile
   };
 
   const exitCode = await runInstall(normalizedOptions);

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -911,6 +911,7 @@ export interface RunInstallOptions {
   patch?: boolean;
   yes?: boolean;
   taskSystem?: string;
+  repositoryFactsFile?: string;
 }
 
 async function promptYesNo(
@@ -956,6 +957,9 @@ async function confirmSupportFileOverwrite(
 export async function runInstall(
   options: RunInstallOptions = {}
 ): Promise<number> {
+  if (options.repositoryFactsFile) {
+    process.env.BALLAST_REPOSITORY_FACTS_FILE = options.repositoryFactsFile;
+  }
   const projectRoot = options.projectRoot ?? findProjectRoot();
   const language = options.language ?? 'typescript';
   const priorConfig = loadConfig(projectRoot, language);

--- a/scripts/e2e-repository-facts-populated.sh
+++ b/scripts/e2e-repository-facts-populated.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/repository-facts-populated"
+create_monorepo_fixture "${PROJECT}"
+add_typescript_profile "${PROJECT}"
+
+cat > "${PROJECT}/pnpm-lock.yaml" <<'LOCK'
+lockfileVersion: '9.0'
+LOCK
+
+cat > "${PROJECT}/.rulesrc.json" <<'JSON'
+{
+  "targets": ["codex"],
+  "agents": ["linting"],
+  "skills": [],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+JSON
+
+(
+  cd "${PROJECT}"
+  git init -q
+  git config user.name "Ballast E2E"
+  git config user.email "ballast-e2e@example.com"
+  git remote add origin git@github.com:everydaydevopsio/ballast.git
+  git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+  ballast install --refresh-config --yes >/dev/null
+)
+
+assert_file_exists "${PROJECT}/AGENTS.md"
+assert_contains 'Canonical GitHub repo: `everydaydevopsio/ballast`' "${PROJECT}/AGENTS.md"
+assert_contains 'Default branch: `main`' "${PROJECT}/AGENTS.md"
+assert_contains 'Primary package manager: `pnpm`' "${PROJECT}/AGENTS.md"
+assert_not_contains 'Canonical GitHub repo: `<OWNER/REPO>`' "${PROJECT}/AGENTS.md"
+
+echo "PASS: repository-facts-populated-e2e"


### PR DESCRIPTION
## Summary
- implement wrapper-side repository facts discovery and write a per-invocation temp JSON payload
- pass payload path to backends via BALLAST_REPOSITORY_FACTS_FILE
- add backend support for optional --repository-facts-file (typescript/python/go) and consume payload when rendering Repository Facts
- update wrapper monorepo support-file generation to render discovered repository facts
- add e2e coverage for populated repository facts in generated AGENTS.md
- update PRD with requirements and acceptance criteria for repository-facts auto-population

## Validation
- scripts/run-unit-tests-pre-push.sh
- scripts/e2e-repository-facts-populated.sh

## Issue
- Closes #131