### PR TITLE
fix(update): use fully-qualified tap name for brew upgrade on macOS

### DIFF
--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -639,7 +639,10 @@ func runUpdate(args []string) int {
 		if wrong, err := detectWrongBrewCask(); err == nil && wrong {
 			fmt.Println("WARNING: The core Homebrew cask \"ballast\" (an unrelated audio-balance app) is installed.")
 			fmt.Println("This conflicts with everydaydevopsio/ballast. Fixing automatically...")
-			_ = runCommandFunc("brew", []string{"uninstall", "--cask", "ballast"})
+			if err := runCommandFunc("brew", []string{"uninstall", "--cask", "ballast"}); err != nil {
+				fmt.Printf("brew uninstall of wrong cask failed: %v\n", err)
+				return 1
+			}
 			fmt.Println("Installing the correct cask from everydaydevopsio/ballast tap...")
 			if err := runCommandFunc("brew", []string{"install", "--cask", "everydaydevopsio/ballast/ballast"}); err != nil {
 				fmt.Printf("brew install failed: %v\n", err)
@@ -1102,24 +1105,32 @@ func detectBrewInstall() bool {
 
 // detectWrongBrewCask checks whether the core Homebrew cask "ballast" (an
 // unrelated audio-balance app) is installed instead of the tap cask.  It
-// runs `brew info --cask ballast` and inspects the "From:" line; the core
-// cask comes from homebrew/homebrew-cask while the correct one comes from
-// everydaydevopsio/homebrew-ballast.
+// runs `brew info --cask ballast` and inspects both the installed status
+// and the "From:" line; the core cask comes from homebrew/homebrew-cask
+// while the correct one comes from everydaydevopsio/homebrew-ballast.
 func detectWrongBrewCask() (bool, error) {
 	out, err := runCommandOutputFunc("brew", []string{"info", "--cask", "ballast"})
 	if err != nil {
 		return false, err
 	}
-	for _, line := range strings.Split(out, "\n") {
+	lines := strings.Split(out, "\n")
+	installed := false
+	fromCore := false
+	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "From:") {
-			if strings.Contains(trimmed, "homebrew/homebrew-cask") || strings.Contains(trimmed, "Homebrew/homebrew-cask") {
-				return true, nil
-			}
+		if strings.HasPrefix(trimmed, "Not installed") {
 			return false, nil
 		}
+		if strings.HasPrefix(trimmed, "Installed") {
+			installed = true
+		}
+		if strings.HasPrefix(trimmed, "From:") {
+			if strings.Contains(trimmed, "homebrew/homebrew-cask") || strings.Contains(trimmed, "Homebrew/homebrew-cask") {
+				fromCore = true
+			}
+		}
 	}
-	return false, nil
+	return installed && fromCore, nil
 }
 
 // brewUpgradeArgs returns the brew subcommand arguments needed to upgrade

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -635,6 +635,20 @@ func runUpdate(args []string) int {
 		fmt.Println("To upgrade a non-Homebrew install, download the latest release from GitHub.")
 		return 1
 	}
+	if runtime.GOOS == "darwin" {
+		if wrong, err := detectWrongBrewCask(); err == nil && wrong {
+			fmt.Println("WARNING: The core Homebrew cask \"ballast\" (an unrelated audio-balance app) is installed.")
+			fmt.Println("This conflicts with everydaydevopsio/ballast. Fixing automatically...")
+			_ = runCommandFunc("brew", []string{"uninstall", "--cask", "ballast"})
+			fmt.Println("Installing the correct cask from everydaydevopsio/ballast tap...")
+			if err := runCommandFunc("brew", []string{"install", "--cask", "everydaydevopsio/ballast/ballast"}); err != nil {
+				fmt.Printf("brew install failed: %v\n", err)
+				return 1
+			}
+			fmt.Println("ballast reinstalled from the correct tap. Run `ballast upgrade` to update .rulesrc.json and sync backend CLIs.")
+			return 0
+		}
+	}
 	fmt.Println("Updating Homebrew...")
 	if err := runCommandFunc("brew", []string{"update"}); err != nil {
 		fmt.Printf("brew update failed: %v\n", err)
@@ -1086,11 +1100,35 @@ func detectBrewInstall() bool {
 	return execPath == prefix || strings.HasPrefix(execPath, prefix+string(os.PathSeparator))
 }
 
+// detectWrongBrewCask checks whether the core Homebrew cask "ballast" (an
+// unrelated audio-balance app) is installed instead of the tap cask.  It
+// runs `brew info --cask ballast` and inspects the "From:" line; the core
+// cask comes from homebrew/homebrew-cask while the correct one comes from
+// everydaydevopsio/homebrew-ballast.
+func detectWrongBrewCask() (bool, error) {
+	out, err := runCommandOutputFunc("brew", []string{"info", "--cask", "ballast"})
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "From:") {
+			if strings.Contains(trimmed, "homebrew/homebrew-cask") || strings.Contains(trimmed, "Homebrew/homebrew-cask") {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
 // brewUpgradeArgs returns the brew subcommand arguments needed to upgrade
-// the ballast CLI: formula on Linux, cask on macOS.
+// the ballast CLI: formula on Linux, cask on macOS.  Both paths use the
+// fully-qualified tap name so Homebrew never resolves to the unrelated
+// core cask "ballast" (an audio-balance app).
 func brewUpgradeArgs() []string {
 	if runtime.GOOS == "darwin" {
-		return []string{"upgrade", "--cask", "ballast"}
+		return []string{"upgrade", "--cask", "everydaydevopsio/ballast/ballast"}
 	}
 	return []string{"upgrade", "--formula", "everydaydevopsio/ballast/ballast"}
 }

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -827,6 +828,9 @@ func TestRunUpdateRunsBrewWhenBrewInstalled(t *testing.T) {
 
 	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		if len(args) >= 3 && args[0] == "info" && args[1] == "--cask" {
+			return "==> ballast\nFrom: https://github.com/everydaydevopsio/homebrew-ballast/blob/HEAD/Casks/ballast.rb", nil
+		}
 		return "/opt/homebrew", nil
 	}
 	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
@@ -853,6 +857,13 @@ func TestRunUpdateRunsBrewWhenBrewInstalled(t *testing.T) {
 	}
 	if got := commands[1][1]; got != "upgrade" {
 		t.Fatalf("expected second command to be 'brew upgrade ...', got %v", commands[1])
+	}
+	// Verify fully-qualified tap name is used on macOS
+	if runtime.GOOS == "darwin" {
+		upgradeArgs := strings.Join(commands[1], " ")
+		if !strings.Contains(upgradeArgs, "everydaydevopsio/ballast/ballast") {
+			t.Fatalf("expected fully-qualified cask name, got %q", upgradeArgs)
+		}
 	}
 }
 
@@ -987,6 +998,9 @@ func TestRunUpdateSuccessMessage(t *testing.T) {
 
 	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		if len(args) >= 3 && args[0] == "info" && args[1] == "--cask" {
+			return "==> ballast\nFrom: https://github.com/everydaydevopsio/homebrew-ballast/blob/HEAD/Casks/ballast.rb", nil
+		}
 		return "/opt/homebrew", nil
 	}
 	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
@@ -1142,6 +1156,135 @@ func TestBrewUpgradeArgsReturnsNonEmpty(t *testing.T) {
 	}
 	if args[0] != "upgrade" {
 		t.Fatalf("expected first arg to be 'upgrade', got %q", args[0])
+	}
+}
+
+func TestBrewUpgradeArgsUsesFullyQualifiedName(t *testing.T) {
+	args := brewUpgradeArgs()
+	// Both darwin and linux should use the fully-qualified tap name
+	found := false
+	for _, a := range args {
+		if a == "everydaydevopsio/ballast/ballast" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected fully-qualified tap name in args, got %v", args)
+	}
+}
+
+func TestDetectWrongBrewCaskReturnsTrueForCoreCask(t *testing.T) {
+	originalOutput := runCommandOutputFunc
+	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
+
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "==> ballast (ballast): 2.0.0\nStatus Bar app\nhttps://jamsinclair.nz/ballast\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
+	}
+
+	wrong, err := detectWrongBrewCask()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wrong {
+		t.Fatal("expected detectWrongBrewCask to return true for core cask")
+	}
+}
+
+func TestDetectWrongBrewCaskReturnsFalseForTapCask(t *testing.T) {
+	originalOutput := runCommandOutputFunc
+	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
+
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "==> ballast (ballast): 5.10.3\nCLI that installs AI agent rules\nFrom: https://github.com/everydaydevopsio/homebrew-ballast/blob/HEAD/Casks/ballast.rb", nil
+	}
+
+	wrong, err := detectWrongBrewCask()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wrong {
+		t.Fatal("expected detectWrongBrewCask to return false for tap cask")
+	}
+}
+
+func TestDetectWrongBrewCaskReturnsFalseOnError(t *testing.T) {
+	originalOutput := runCommandOutputFunc
+	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
+
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "", errors.New("not installed")
+	}
+
+	wrong, err := detectWrongBrewCask()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if wrong {
+		t.Fatal("expected false on error")
+	}
+}
+
+func TestRunUpdateFixesWrongCaskOnDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only test")
+	}
+
+	originalRun := runCommandFunc
+	originalLookPath := execLookPathFunc
+	originalOutput := runCommandOutputFunc
+	originalExe := osExecutableFunc
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		execLookPathFunc = originalLookPath
+		runCommandOutputFunc = originalOutput
+		osExecutableFunc = originalExe
+	})
+
+	execLookPathFunc = func(file string) (string, error) { return "/opt/homebrew/bin/brew", nil }
+	osExecutableFunc = func() (string, error) { return "/opt/homebrew/bin/ballast", nil }
+
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		if len(args) >= 3 && args[0] == "info" && args[1] == "--cask" {
+			return "==> ballast\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
+		}
+		return "/opt/homebrew", nil
+	}
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	output := captureStdout(t, func() {
+		exitCode := run([]string{"update"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if !strings.Contains(output, "unrelated audio-balance app") {
+		t.Fatalf("expected wrong-cask warning, got %q", output)
+	}
+
+	// Should uninstall wrong cask then install correct one
+	foundUninstall := false
+	foundInstall := false
+	for _, cmd := range commands {
+		joined := strings.Join(cmd, " ")
+		if strings.Contains(joined, "uninstall --cask ballast") {
+			foundUninstall = true
+		}
+		if strings.Contains(joined, "install --cask everydaydevopsio/ballast/ballast") {
+			foundInstall = true
+		}
+	}
+	if !foundUninstall {
+		t.Fatalf("expected uninstall of wrong cask, commands: %v", commands)
+	}
+	if !foundInstall {
+		t.Fatalf("expected install of correct cask, commands: %v", commands)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -1179,7 +1179,7 @@ func TestDetectWrongBrewCaskReturnsTrueForCoreCask(t *testing.T) {
 	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
 
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
-		return "==> ballast (ballast): 2.0.0\nStatus Bar app\nhttps://jamsinclair.nz/ballast\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
+		return "==> ballast (ballast): 2.0.0\nStatus Bar app\nhttps://jamsinclair.nz/ballast\nInstalled\n/opt/homebrew/Caskroom/ballast/2.0.0 (2.3MB)\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
 	}
 
 	wrong, err := detectWrongBrewCask()
@@ -1196,7 +1196,7 @@ func TestDetectWrongBrewCaskReturnsFalseForTapCask(t *testing.T) {
 	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
 
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
-		return "==> ballast (ballast): 5.10.3\nCLI that installs AI agent rules\nFrom: https://github.com/everydaydevopsio/homebrew-ballast/blob/HEAD/Casks/ballast.rb", nil
+		return "==> ballast (ballast): 5.10.3\nCLI that installs AI agent rules\nInstalled\n/opt/homebrew/Caskroom/ballast/5.10.3\nFrom: https://github.com/everydaydevopsio/homebrew-ballast/blob/HEAD/Casks/ballast.rb", nil
 	}
 
 	wrong, err := detectWrongBrewCask()
@@ -1205,6 +1205,23 @@ func TestDetectWrongBrewCaskReturnsFalseForTapCask(t *testing.T) {
 	}
 	if wrong {
 		t.Fatal("expected detectWrongBrewCask to return false for tap cask")
+	}
+}
+
+func TestDetectWrongBrewCaskReturnsFalseWhenNotInstalled(t *testing.T) {
+	originalOutput := runCommandOutputFunc
+	t.Cleanup(func() { runCommandOutputFunc = originalOutput })
+
+	runCommandOutputFunc = func(name string, args []string) (string, error) {
+		return "==> ballast (ballast): 2.0.0\nStatus Bar app\nhttps://jamsinclair.nz/ballast\nNot installed\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
+	}
+
+	wrong, err := detectWrongBrewCask()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wrong {
+		t.Fatal("expected detectWrongBrewCask to return false when core cask is not installed")
 	}
 }
 
@@ -1246,7 +1263,7 @@ func TestRunUpdateFixesWrongCaskOnDarwin(t *testing.T) {
 
 	runCommandOutputFunc = func(name string, args []string) (string, error) {
 		if len(args) >= 3 && args[0] == "info" && args[1] == "--cask" {
-			return "==> ballast\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
+			return "==> ballast\nInstalled\n/opt/homebrew/Caskroom/ballast/2.0.0\nFrom: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/b/ballast.rb", nil
 		}
 		return "/opt/homebrew", nil
 	}


### PR DESCRIPTION
## Summary

- **Fix `brewUpgradeArgs()` on macOS** to use fully-qualified `everydaydevopsio/ballast/ballast` instead of bare `ballast`, preventing Homebrew from resolving to the unrelated core cask (an audio-balance status bar app by jamsinclair.nz)
- **Add `detectWrongBrewCask()`** that checks `brew info --cask ballast` output to detect if the wrong core cask is installed
- **Auto-fix in `runUpdate()`** on macOS: if the wrong cask is detected, automatically uninstall it and reinstall from the correct tap

### Root cause

There is a naming collision in Homebrew — `homebrew/homebrew-cask` has a `ballast` cask (audio balance app, v2.0.0) and our tap has `everydaydevopsio/ballast/ballast` (CLI tool). Running `brew upgrade --cask ballast` without qualification resolved to the core cask, replacing the real CLI with a completely different application.

## Test plan

- [x] `TestBrewUpgradeArgsUsesFullyQualifiedName` — verifies both platforms use the tap-qualified name
- [x] `TestDetectWrongBrewCaskReturnsTrueForCoreCask` — detects core cask via `From:` line
- [x] `TestDetectWrongBrewCaskReturnsFalseForTapCask` — correct tap cask not flagged
- [x] `TestDetectWrongBrewCaskReturnsFalseOnError` — graceful error handling
- [x] `TestRunUpdateFixesWrongCaskOnDarwin` — full end-to-end auto-fix flow (darwin-only)
- [x] All existing `TestRunUpdate*` and `TestDetectBrewInstall*` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)