### PR TITLE
fix(tests): resolve /tmp symlink for macOS test compatibility

### DIFF
--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -112,7 +112,7 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 		}
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "ballastVersion":"5.0.2",
   "target":"claude",
@@ -167,7 +167,7 @@ func TestFindProjectRootUsesBallastConfigMarkers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			root := t.TempDir()
+			root := resolvedTempDir(t)
 			nested := filepath.Join(root, "apps", "child")
 			if err := os.MkdirAll(nested, 0o755); err != nil {
 				t.Fatalf("mkdir nested: %v", err)
@@ -192,7 +192,7 @@ func TestRunDoctorFixPrintsMode(t *testing.T) {
 	version = "5.0.2"
 	runCommandFunc = func(name string, args []string) error { return nil }
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	output := captureStdout(t, func() {
 		withWorkingDir(t, root, func() {
@@ -245,7 +245,7 @@ func TestRunDoctorFixInstallsBackendsAndRefreshesConfig(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"claude","agents":["local-dev"]}`)
 
@@ -287,7 +287,7 @@ func TestRunDoctorFixUsesConfigVersionForBackendInstallsInsideSourceCheckout(t *
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -333,7 +333,7 @@ func TestRunDoctorFixUsesConfigVersionForBackendInstallsInsideSourceCheckout(t *
 }
 
 func TestEnsureLocalToolDirsAddsBallastToGitignore(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 
 	if err := ensureLocalToolDirs(root); err != nil {
 		t.Fatalf("ensureLocalToolDirs failed: %v", err)
@@ -349,7 +349,7 @@ func TestEnsureLocalToolDirsAddsBallastToGitignore(t *testing.T) {
 }
 
 func TestEnsureLocalToolDirsContinuesWhenGitignoreCannotBeUpdated(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	if err := os.Mkdir(filepath.Join(root, ".gitignore"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestRunUpgradeUpdatesConfigVersionAndInstallsMatchingBackends(t *testing.T)
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -449,7 +449,7 @@ func TestRunUpgradePatchForwardsPatchToRefreshInstall(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -489,8 +489,8 @@ func TestRunUpgradeUsesLocalSourcesInsideSourceCheckout(t *testing.T) {
 	})
 	version = "5.0.6"
 
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -566,7 +566,7 @@ func TestRunUpgradeForceForwardsForceToRefreshInstall(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(root, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -616,7 +616,7 @@ func TestRunDoctorFixForwardsSelectedLanguageToRefreshInstall(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/project\n\ngo 1.24\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "ballastVersion":"5.0.5",
@@ -662,7 +662,7 @@ func TestRunDoctorFixSkipsRefreshWhenConfigIsMissing(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 
 	if exitCode := runDoctorFix(root, langGo, false, false); exitCode != 0 {
@@ -691,9 +691,9 @@ func TestRunUpgradeRefreshesSelectedBackendOnceOutsideSourceCheckout(t *testing.
 	runCommandFunc = func(name string, args []string) error { return nil }
 	ensureInstalledFunc = func(tool toolConfig) error { return nil }
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "outside-ballast", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "outside-ballast", "ballast"), nil
 	}
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	refreshCount := 0
 	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
 		refreshCount++
@@ -742,7 +742,7 @@ func TestRunUpgradeRejectsUnknownOption(t *testing.T) {
 }
 
 func TestRunUpgradeRequiresExistingConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	makeGitBoundary(t, root)
 	output := captureStdout(t, func() {
 		withWorkingDir(t, root, func() {
@@ -1032,7 +1032,7 @@ func TestRunUpgradeDoesNotRunBrew(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "ballastVersion":"5.0.5",
@@ -1160,7 +1160,7 @@ func TestRunInstallRefreshConfigUsesSavedConfig(t *testing.T) {
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"claude","agents":["local-dev"]}`)
 
@@ -1195,7 +1195,7 @@ func TestRunInstallRefreshConfigCleansUpSingleLanguageStaleSelections(t *testing
 		return 0, nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"opencode","agents":["linting"],"skills":[]}`)
 	staleSkill := filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md")
@@ -1225,7 +1225,7 @@ func TestRunInstallCLICommand(t *testing.T) {
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli", "--language", "python", "--version", "5.0.2"})
@@ -1254,7 +1254,7 @@ func TestRunInstallCLIGoUsesReleaseArchiveForPinnedVersion(t *testing.T) {
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.24\n")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli", "--language", "go", "--version", "5.0.2"})
@@ -1296,7 +1296,7 @@ func TestRunInstallCLICommandInstallsAllLanguagesByDefault(t *testing.T) {
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli"})
@@ -1328,7 +1328,7 @@ func TestRunInstallCLICommandInstallsGoBackendForAnsibleLanguage(t *testing.T) {
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "ansible.cfg"), "[defaults]\n")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli", "--language", "ansible", "--version", "5.0.2"})
@@ -1361,7 +1361,7 @@ func TestRunInstallCLICommandInstallsGoBackendForTerraformLanguage(t *testing.T)
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".terraform-version"), "1.8.5\n")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli", "--language", "terraform", "--version", "5.0.2"})
@@ -1387,7 +1387,7 @@ func TestRunInstallCLICreatesLocalBallastDirectories(t *testing.T) {
 
 	runCommandFunc = func(name string, args []string) error { return nil }
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	withWorkingDir(t, root, func() {
 		exitCode := run([]string{"install-cli", "--language", "go", "--version", "5.0.2"})
@@ -1411,10 +1411,10 @@ func TestPythonInstallCommandErrorsForDevVersionOutsideSourceTree(t *testing.T) 
 
 	version = "dev"
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "outside-ballast", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "outside-ballast", "ballast"), nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	command, err := toolsByLanguage[langPython].installCommand("", root)
 	if err == nil {
 		t.Fatalf("expected dev version outside source tree to error, got command %#v", command)
@@ -1435,8 +1435,8 @@ func TestRunInstallCLIUsesLocalSourcesForDevWrapper(t *testing.T) {
 	})
 
 	version = "dev"
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
@@ -1483,13 +1483,13 @@ func TestRunInstallCLIUsesLocalSourcesInsideSourceCheckoutForReleaseWrapper(t *t
 	})
 
 	version = "5.0.4"
-	sourceRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bin", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "bin", "ballast"), nil
 	}
 
 	var commands [][]string
@@ -1520,7 +1520,7 @@ func TestRunInstallCLIUsesLocalSourcesInsideSourceCheckoutForReleaseWrapper(t *t
 }
 
 func TestResolveLocalBackendCommandUsesGoBinaryForTerraform(t *testing.T) {
-	repoRoot := t.TempDir()
+	repoRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(repoRoot, "packages", "ballast-go", "ballast-go"), "")
 
 	resolved := resolveLocalBackendCommand(repoRoot, langTerraform)
@@ -1530,7 +1530,7 @@ func TestResolveLocalBackendCommandUsesGoBinaryForTerraform(t *testing.T) {
 }
 
 func TestProjectLocalBackendCommandUsesGoBinaryForTerraform(t *testing.T) {
-	projectRoot := t.TempDir()
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(projectRoot, ".ballast", "bin", "ballast-go"), "")
 
 	resolved := projectLocalBackendCommand(projectRoot, langTerraform)
@@ -1545,7 +1545,7 @@ func TestSiblingBackendBinaryUsesGoBinaryForTerraform(t *testing.T) {
 		osExecutableFunc = originalExecutable
 	})
 
-	binDir := t.TempDir()
+	binDir := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(binDir, "ballast-go"), "")
 	osExecutableFunc = func() (string, error) {
 		return filepath.Join(binDir, "ballast"), nil
@@ -1571,13 +1571,13 @@ func TestRunInstallCLIUsesPinnedReleaseVersionsInsideSourceCheckout(t *testing.T
 	})
 
 	version = "5.0.6"
-	sourceRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bin", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "bin", "ballast"), nil
 	}
 
 	var commands [][]string
@@ -1619,14 +1619,14 @@ func TestRunInstallCLIUsesLocalSourcesFromNestedPackageDirForReleaseWrapper(t *t
 	})
 
 	version = "5.0.4"
-	sourceRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
 	nestedRoot := filepath.Join(sourceRoot, "packages", "ballast-python")
 	mustWriteFile(t, filepath.Join(sourceRoot, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), `{"name":"@everydaydevopsio/ballast"}`)
 	mustWriteFile(t, filepath.Join(nestedRoot, "pyproject.toml"), "[project]\nname='ballast-python'\n")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-go", "go.mod"), "module example.com/ballast-go\n\ngo 1.24\n")
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bin", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "bin", "ballast"), nil
 	}
 
 	var commands [][]string
@@ -1657,7 +1657,7 @@ func TestRunInstallCLIUsesLocalSourcesFromNestedPackageDirForReleaseWrapper(t *t
 }
 
 func TestDetectRepoProfilesFindsMultiLanguageMonorepo(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, "tools", "worker", "go.mod"), "module example.com/worker\n\ngo 1.24\n")
@@ -1682,7 +1682,7 @@ func TestDetectRepoProfilesFindsMultiLanguageMonorepo(t *testing.T) {
 }
 
 func TestDetectRepoProfilesFindsAnsibleProfile(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "infra", "ansible", "ansible.cfg"), "[defaults]\n")
 	mustWriteFile(t, filepath.Join(root, "infra", "ansible", "playbook.yml"), "---\n")
 
@@ -1700,7 +1700,7 @@ func TestDetectRepoProfilesFindsAnsibleProfile(t *testing.T) {
 }
 
 func TestDetectRepoProfilesFindsAnsibleProfileFromRequirementsYaml(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "infra", "ansible", "requirements.yaml"), "---\n")
 
 	profiles, err := detectRepoProfiles(root)
@@ -1717,7 +1717,7 @@ func TestDetectRepoProfilesFindsAnsibleProfileFromRequirementsYaml(t *testing.T)
 }
 
 func TestDetectRepoProfilesFindsTerraformProfile(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "infra", "terraform", ".terraform-version"), "1.8.5\n")
 	mustWriteFile(t, filepath.Join(root, "infra", "terraform", "versions.tf"), "terraform {}\n")
 
@@ -1735,7 +1735,7 @@ func TestDetectRepoProfilesFindsTerraformProfile(t *testing.T) {
 }
 
 func TestDetectRepoProfilesSkipsTerraformCaches(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "infra", "terraform", ".terraform-version"), "1.8.5\n")
 	mustWriteFile(t, filepath.Join(root, "infra", "terraform", "versions.tf"), "terraform {}\n")
 	mustWriteFile(t, filepath.Join(root, "infra", "terraform", ".terraform", "modules", "cached", "main.tf"), "terraform {}\n")
@@ -1755,7 +1755,7 @@ func TestDetectRepoProfilesSkipsTerraformCaches(t *testing.T) {
 }
 
 func TestDetectRepoProfilesSkipsDotPrefixedDirectories(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".codex", "hidden-app", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 
@@ -1773,7 +1773,7 @@ func TestDetectRepoProfilesSkipsDotPrefixedDirectories(t *testing.T) {
 }
 
 func TestDetectLanguageSupportsAnsibleRequirementsYaml(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "requirements.yaml"), "---\n")
 
 	got := detectLanguage(root)
@@ -1783,7 +1783,7 @@ func TestDetectLanguageSupportsAnsibleRequirementsYaml(t *testing.T) {
 }
 
 func TestDetectLanguagePrefersAnsibleMarkers(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "ansible.cfg"), "[defaults]\n")
 	mustWriteFile(t, filepath.Join(root, "playbook.yml"), "---\n")
 
@@ -1794,7 +1794,7 @@ func TestDetectLanguagePrefersAnsibleMarkers(t *testing.T) {
 }
 
 func TestDetectLanguageSupportsTerraformMarkers(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".terraform-version"), "1.8.5\n")
 	mustWriteFile(t, filepath.Join(root, "versions.tf"), "terraform {}\n")
 
@@ -1805,7 +1805,7 @@ func TestDetectLanguageSupportsTerraformMarkers(t *testing.T) {
 }
 
 func TestDetectLanguageSupportsTerraformRulesConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.terraform.json"), `{"target":"cursor","agents":["linting"]}`)
 
 	got := detectLanguage(root)
@@ -1815,7 +1815,7 @@ func TestDetectLanguageSupportsTerraformRulesConfig(t *testing.T) {
 }
 
 func TestDetectLanguageWarnsForJavaScriptPackageWithoutTsconfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), `{
   "name": "novnc-desktop",
   "private": true,
@@ -1840,7 +1840,7 @@ func TestDetectLanguageWarnsForJavaScriptPackageWithoutTsconfig(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanWarnsForJavaScriptRootWithoutTypeScriptProfile(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), `{
   "name": "novnc-desktop",
   "private": true,
@@ -1871,7 +1871,7 @@ func TestResolveMonorepoPlanWarnsForJavaScriptRootWithoutTypeScriptProfile(t *te
 }
 
 func TestResolveBackendCommandAddsAnsibleLanguageFlag(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "ansible.cfg"), "[defaults]\n")
 	mustWriteFile(t, filepath.Join(root, ".ballast", "bin", "ballast-go"), "")
 
@@ -1888,7 +1888,7 @@ func TestResolveBackendCommandAddsAnsibleLanguageFlag(t *testing.T) {
 }
 
 func TestResolveBackendCommandAddsTerraformLanguageFlag(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".terraform-version"), "1.8.5\n")
 	mustWriteFile(t, filepath.Join(root, ".ballast", "bin", "ballast-go"), "")
 
@@ -1905,7 +1905,7 @@ func TestResolveBackendCommandAddsTerraformLanguageFlag(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanUsesConfigAndSplitsCommonFromLanguageAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "cursor",
   "agents": ["local-dev", "linting", "testing"],
@@ -1958,7 +1958,7 @@ func TestResolveMonorepoPlanUsesConfigAndSplitsCommonFromLanguageAgents(t *testi
 }
 
 func TestResolveMonorepoPlanInvokesOncePerLanguage(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend-a", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend-b", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -1976,7 +1976,7 @@ func TestResolveMonorepoPlanInvokesOncePerLanguage(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanAllIncludesExpectedCommonAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 
@@ -2043,7 +2043,7 @@ func TestWithSkillSelectionReplacesExistingFlags(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanSupportsSkillOnlyConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "claude",
   "skills": ["owasp-security-scan"],
@@ -2077,7 +2077,7 @@ func TestResolveMonorepoPlanSupportsSkillOnlyConfig(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanSkillOnlyInstallPreservesConfigAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "claude",
   "agents": ["local-dev", "linting"],
@@ -2127,7 +2127,7 @@ func TestResolveMonorepoPlanSkillOnlyInstallPreservesConfigAgents(t *testing.T) 
 }
 
 func TestResolveMonorepoPlanAgentOnlyInstallPreservesConfigSkills(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "claude",
   "skills": ["owasp-security-scan"],
@@ -2162,7 +2162,7 @@ func TestResolveMonorepoPlanAgentOnlyInstallPreservesConfigSkills(t *testing.T) 
 }
 
 func TestResolveMonorepoPlanSkillOnlyInstallRejectsInvalidPersistedAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "claude",
   "agents": ["not-an-agent"],
@@ -2187,7 +2187,7 @@ func TestResolveMonorepoPlanSkillOnlyInstallRejectsInvalidPersistedAgents(t *tes
 }
 
 func TestResolveMonorepoPlanAgentOnlyInstallRejectsInvalidPersistedSkills(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "claude",
   "skills": ["not-a-skill"],
@@ -2212,7 +2212,7 @@ func TestResolveMonorepoPlanAgentOnlyInstallRejectsInvalidPersistedSkills(t *tes
 }
 
 func TestResolveMonorepoPlanSkillOnlyInstallRetainsConfiguredAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -2257,7 +2257,7 @@ func TestResolveMonorepoPlanSkillOnlyInstallRetainsConfiguredAgents(t *testing.T
 }
 
 func TestResolveMonorepoPlanRemoveLastTargetCleanupOnly(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "targets": ["codex"],
   "agents": ["local-dev", "linting"],
@@ -2287,7 +2287,7 @@ func TestResolveMonorepoPlanRemoveLastTargetCleanupOnly(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanRejectsInvalidConfiguredTargets(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "targets": ["cursor", "bogus"],
   "agents": ["local-dev", "linting"],
@@ -2308,7 +2308,7 @@ func TestResolveMonorepoPlanRejectsInvalidConfiguredTargets(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanIgnoresStaleRulesrcProfiles(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -2347,7 +2347,7 @@ func TestResolveMonorepoPlanIgnoresStaleRulesrcProfiles(t *testing.T) {
 }
 
 func TestRunMonorepoInstallExecutesEachBackendAtRepoRoot(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -2420,7 +2420,7 @@ func TestRunMonorepoInstallExecutesEachBackendAtRepoRoot(t *testing.T) {
 }
 
 func TestRunMonorepoInstallMergesRequestedTargetsIntoSavedConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
@@ -2463,8 +2463,8 @@ func TestRunMonorepoInstallMergesRequestedTargetsIntoSavedConfig(t *testing.T) {
 }
 
 func TestRunMonorepoInstallPrefersRepoLocalBackends(t *testing.T) {
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "dist", "cli.js"), "console.log('ts')")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), "{\"name\":\"ballast-typescript\"}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -2547,8 +2547,8 @@ func TestRunMonorepoInstallPrefersRepoLocalBackends(t *testing.T) {
 }
 
 func TestRunMonorepoInstallSupportsEnvProvidedSourceRoot(t *testing.T) {
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "dist", "cli.js"), "console.log('ts')")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), "{\"name\":\"ballast-typescript\"}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -2574,7 +2574,7 @@ func TestRunMonorepoInstallSupportsEnvProvidedSourceRoot(t *testing.T) {
 		t.Fatalf("set BALLAST_REPO_ROOT: %v", err)
 	}
 	osExecutableFunc = func() (string, error) {
-		return filepath.Join(t.TempDir(), "bin", "ballast"), nil
+		return filepath.Join(resolvedTempDir(t), "bin", "ballast"), nil
 	}
 	ensureInstalledFunc = func(tool toolConfig) error { return nil }
 
@@ -2608,8 +2608,8 @@ func TestRunMonorepoInstallSupportsEnvProvidedSourceRoot(t *testing.T) {
 }
 
 func TestRunMonorepoInstallPrefersSiblingBackendsNextToWrapper(t *testing.T) {
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "dist", "cli.js"), "console.log('ts')")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), "{\"name\":\"ballast-typescript\"}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -2671,8 +2671,8 @@ func TestRunMonorepoInstallPrefersSiblingBackendsNextToWrapper(t *testing.T) {
 }
 
 func TestRunSingleLanguageInstallPrefersLocalBackendWithoutNilEnvPanic(t *testing.T) {
-	sourceRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	sourceRoot := resolvedTempDir(t)
+	projectRoot := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "dist", "cli.js"), "console.log('ts')")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-typescript", "package.json"), "{\"name\":\"ballast-typescript\"}")
 	mustWriteFile(t, filepath.Join(sourceRoot, "packages", "ballast-python", "pyproject.toml"), "[project]\nname='ballast-python'\n")
@@ -2729,7 +2729,7 @@ func TestRunSingleLanguageInstallPrefersLocalBackendWithoutNilEnvPanic(t *testin
 }
 
 func TestRunSingleLanguageInstallReinstallsBackendWhenVersionMismatches(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "tsconfig.json"), "{}")
 
@@ -2802,7 +2802,7 @@ func TestEnsureInstalledUsesPinnedVersionWhenBackendVersionDiffers(t *testing.T)
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.24\n")
 	localBinary := filepath.Join(root, ".ballast", "bin", "ballast-go")
 	mustWriteFile(t, localBinary, "#!/usr/bin/env bash\necho 4.1.7\n")
@@ -2844,7 +2844,7 @@ func TestEnsureInstalledSkipsVersionCheckForDevWrapperBuilds(t *testing.T) {
 		return nil
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/test\n\ngo 1.24\n")
 	localBinary := filepath.Join(root, ".ballast", "bin", "ballast-go")
 	mustWriteFile(t, localBinary, "#!/usr/bin/env bash\necho 4.1.7\n")
@@ -2865,7 +2865,7 @@ func TestEnsureInstalledSkipsVersionCheckForDevWrapperBuilds(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanRejectsEscapingPathsFromConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "cursor",
   "agents": ["linting"],
@@ -2886,7 +2886,7 @@ func TestResolveMonorepoPlanRejectsEscapingPathsFromConfig(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanRejectsUnsupportedAgents(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "target": "cursor",
   "agents": ["not-an-agent"],
@@ -2907,7 +2907,7 @@ func TestResolveMonorepoPlanRejectsUnsupportedAgents(t *testing.T) {
 }
 
 func TestRunMonorepoInstallDoesNotPersistConfigOnFailure(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "package.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -2951,7 +2951,7 @@ func TestDetectRepoProfilesPropagatesWalkErrors(t *testing.T) {
 		return errors.New("walk failed")
 	}
 
-	profiles, err := detectRepoProfiles(t.TempDir())
+	profiles, err := detectRepoProfiles(resolvedTempDir(t))
 	if err == nil {
 		t.Fatalf("expected walk error, got profiles %#v", profiles)
 	}
@@ -2961,7 +2961,7 @@ func TestDetectRepoProfilesPropagatesWalkErrors(t *testing.T) {
 }
 
 func TestUpdateMonorepoSupportFilesCreatesClaudeMdAtRoot(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	plan := &monorepoPlan{
 		Targets:  []string{"claude"},
 		Common:   []string{"local-dev"},
@@ -2992,7 +2992,7 @@ func TestUpdateMonorepoSupportFilesCreatesClaudeMdAtRoot(t *testing.T) {
 }
 
 func TestUpdateMonorepoSupportFilesPreservesUnmanagedSectionsWithoutPatch(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	plan := &monorepoPlan{
 		Targets:  []string{"claude"},
 		Common:   []string{"local-dev"},
@@ -3025,7 +3025,7 @@ func TestUpdateMonorepoSupportFilesPreservesUnmanagedSectionsWithoutPatch(t *tes
 }
 
 func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	rulePath := filepath.Join(root, ".codex", "rules", "common", "docs.md")
 	skillPath := filepath.Join(root, ".claude", "skills", "github-health-check.skill")
 	mustWriteFile(t, rulePath, "user-authored file at canonical path\n")
@@ -3061,7 +3061,7 @@ func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
 }
 
 func TestRemoveStaleManagedFilesDeletesConfigBackedOpencodeSkill(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	skillPath := filepath.Join(root, ".opencode", "skills", "github-health-check.md")
 	mustWriteFile(t, skillPath, "legacy managed skill without explicit marker\n")
 
@@ -3087,7 +3087,7 @@ func TestRemoveStaleManagedFilesDeletesConfigBackedOpencodeSkill(t *testing.T) {
 }
 
 func TestRemoveStaleManagedFilesPreservesUnmanagedOpencodeSkillNotInPreviousConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	skillPath := filepath.Join(root, ".opencode", "skills", "github-health-check.md")
 	mustWriteFile(t, skillPath, "user-authored skill at canonical path\n")
 
@@ -3113,7 +3113,7 @@ func TestRemoveStaleManagedFilesPreservesUnmanagedOpencodeSkillNotInPreviousConf
 }
 
 func TestRunMonorepoRemoveTargetCleansManagedRulesAndSupportFiles(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
@@ -3192,7 +3192,7 @@ func TestRunMonorepoRemoveTargetCleansManagedRulesAndSupportFiles(t *testing.T) 
 }
 
 func TestRunMonorepoRemoveTargetDoesNotPersistConfigWhenCleanupFails(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
@@ -3245,7 +3245,7 @@ func TestRunMonorepoRemoveTargetDoesNotPersistConfigWhenCleanupFails(t *testing.
 // what ballast-typescript does after prompting the user) is not clobbered by
 // the final saveMonorepoConfig call.
 func TestRunMonorepoInstallPreservesTaskSystemWrittenByBackend(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "targets": ["cursor"],
@@ -3299,7 +3299,7 @@ func TestRunMonorepoInstallPreservesTaskSystemWrittenByBackend(t *testing.T) {
 // taskSystem already present in .rulesrc.json before the install runs is
 // carried through into the final saved config.
 func TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "targets": ["cursor"],
@@ -3338,7 +3338,7 @@ func TestRunMonorepoInstallPreservesTaskSystemFromExistingConfig(t *testing.T) {
 }
 
 func TestRunMonorepoRefreshConfigEnablesTaskAndSkillRefresh(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
@@ -3388,7 +3388,7 @@ func TestRunMonorepoRefreshConfigEnablesTaskAndSkillRefresh(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 
@@ -3415,7 +3415,7 @@ func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanRejectsMissingTaskSystemValue(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 
@@ -3426,7 +3426,7 @@ func TestResolveMonorepoPlanRejectsMissingTaskSystemValue(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanRejectsInvalidTaskSystemValue(t *testing.T) {
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
 
@@ -3478,7 +3478,7 @@ func TestBuildMonorepoSupportFileIncludesPublishingAndSkillsForCodex(t *testing.
 		},
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	content := buildMonorepoSupportFile(root, plan, "codex")
 
 	if !strings.Contains(content, "## Repository Facts") {
@@ -3514,7 +3514,7 @@ func TestBuildMonorepoSupportFileIncludesSkillsForClaude(t *testing.T) {
 		},
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	content := buildMonorepoSupportFile(root, plan, "claude")
 
 	if !strings.Contains(content, "## Installed skills") {
@@ -3534,12 +3534,24 @@ func TestBuildMonorepoSupportFileIncludesDocsForCodex(t *testing.T) {
 		},
 	}
 
-	root := t.TempDir()
+	root := resolvedTempDir(t)
 	content := buildMonorepoSupportFile(root, plan, "codex")
 
 	if !strings.Contains(content, "`.codex/rules/common/docs.md`") {
 		t.Fatalf("expected docs rule entry in codex support file, got %q", content)
 	}
+}
+
+// resolvedTempDir wraps t.TempDir and resolves symlinks so that path
+// comparisons work on macOS where /tmp is a symlink to /private/tmp.
+func resolvedTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve symlinks for %s: %v", dir, err)
+	}
+	return resolved
 }
 
 func mustWriteFile(t *testing.T, path string, content string) {


### PR DESCRIPTION
## Summary

- Add `resolvedTempDir(t)` helper that wraps `t.TempDir()` with `filepath.EvalSymlinks`
- Replace all `t.TempDir()` calls in the test file with `resolvedTempDir(t)` to prevent future regressions
- Fixes 14 tests that fail locally on macOS but pass in Linux CI

### Root cause

On macOS, `/tmp` is a symlink to `/private/tmp`. Go's `t.TempDir()` returns `/tmp/Test...` but production code resolves symlinks (via `filepath.EvalSymlinks`, `os.Executable`, or `os.Getwd`) producing `/private/tmp/Test...`. Tests that compare command strings built from temp dir paths fail because one side has the resolved path and the other does not.

### Tests fixed

- `TestRunDoctorFixUsesConfigVersionForBackendInstallsInsideSourceCheckout`
- `TestRunUpgradeUpdatesConfigVersionAndInstallsMatchingBackends`
- `TestRunUpgradeUsesLocalSourcesInsideSourceCheckout`
- `TestRunInstallCLICommand`
- `TestRunInstallCLICommandInstallsAllLanguagesByDefault`
- `TestRunInstallCLIUsesLocalSourcesForDevWrapper`
- `TestRunInstallCLIUsesLocalSourcesInsideSourceCheckoutForReleaseWrapper`
- `TestRunInstallCLIUsesPinnedReleaseVersionsInsideSourceCheckout`
- `TestRunInstallCLIUsesLocalSourcesFromNestedPackageDirForReleaseWrapper`
- `TestResolveBackendCommandAddsAnsibleLanguageFlag`
- `TestResolveBackendCommandAddsTerraformLanguageFlag`
- `TestRunMonorepoInstallExecutesEachBackendAtRepoRoot`
- `TestRunSingleLanguageInstallReinstallsBackendWhenVersionMismatches`
- `TestEnsureInstalledUsesPinnedVersionWhenBackendVersionDiffers`

## Test plan

- [x] All 14 previously failing tests now pass on macOS
- [x] Full test suite passes: `go test ./...` reports `ok`
- [x] `resolvedTempDir` is a no-op on Linux (no symlinks to resolve), so CI behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)