### PR TITLE
Define Ballast local state repair behavior

### DIFF
--- a/.claude/rules/typescript/typescript-local-dev-env.md
+++ b/.claude/rules/typescript/typescript-local-dev-env.md
@@ -13,11 +13,30 @@ You are a local development environment specialist for TypeScript/JavaScript pro
 - **Developer experience**: Recommend and configure tooling (debugging, hot reload, env validation) and conventions (branch naming, commit hooks) that keep local dev fast and consistent.
 - **Documentation**: Keep README and runbooks (e.g. "Getting started", "Troubleshooting") in sync with the actual setup so new contributors can self-serve.
 
+## Agent Startup
+
+- If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
+- Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
+- If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
+
 ## Apply This Rule When
 
 - The task is about local setup, onboarding, `.nvmrc`, env files, Docker, Compose, or dev scripts.
 - The user asks to prepare a repository for contributor use.
 - The user asks to create, update, or land a PR as part of local-development workflow.
+
+## Branch Before Code
+
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+
+- If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
+- If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.
+- Name task branches with the issue number when one exists, such as `issue-212-branch-before-code`; otherwise use a short kebab-case task name.
+- Do not make code, config, docs, or generated-output edits on the default branch unless the user explicitly requests an emergency direct change.
+- Read-only investigation, status checks, and answering questions do not require a new branch.
+- If uncommitted work already exists, inspect it and preserve it; do not overwrite or discard user changes while creating the task branch.
 
 ## Core Responsibilities
 

--- a/.codex/rules/typescript/typescript-local-dev-env.md
+++ b/.codex/rules/typescript/typescript-local-dev-env.md
@@ -15,11 +15,30 @@ You are a local development environment specialist for TypeScript/JavaScript pro
 - **Developer experience**: Recommend and configure tooling (debugging, hot reload, env validation) and conventions (branch naming, commit hooks) that keep local dev fast and consistent.
 - **Documentation**: Keep README and runbooks (e.g. "Getting started", "Troubleshooting") in sync with the actual setup so new contributors can self-serve.
 
+## Agent Startup
+
+- If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
+- Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
+- If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
+
 ## Apply This Rule When
 
 - The task is about local setup, onboarding, `.nvmrc`, env files, Docker, Compose, or dev scripts.
 - The user asks to prepare a repository for contributor use.
 - The user asks to create, update, or land a PR as part of local-development workflow.
+
+## Branch Before Code
+
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+
+- If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
+- If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.
+- Name task branches with the issue number when one exists, such as `issue-212-branch-before-code`; otherwise use a short kebab-case task name.
+- Do not make code, config, docs, or generated-output edits on the default branch unless the user explicitly requests an emergency direct change.
+- Read-only investigation, status checks, and answering questions do not require a new branch.
+- If uncommitted work already exists, inspect it and preserve it; do not overwrite or discard user changes while creating the task branch.
 
 ## Core Responsibilities
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,34 @@
 # Product Requirements
 
+## Ballast Local State Bootstrap And Repair
+
+### Problem
+
+Ballast stores project-local backend CLIs under `.ballast/`, but the product contract does not clearly say whether that directory is required source state, generated state, or disposable cache state. Operators and AI agents need deterministic behavior when `.ballast/` is absent or incomplete so they can inspect, initialize, and repair a Ballast-managed repository without guessing.
+
+### Requirements
+
+1. `.ballast/` must be treated as generated, repository-local tool state that is safe to recreate and should remain ignored by git.
+2. `ballast install` must not require `.ballast/` to exist before installing agent rules or skills.
+3. Wrapper backend dispatch must recreate missing local tool directories when it needs to install a backend CLI.
+4. `ballast install-cli` must recreate `.ballast/bin` and `.ballast/tools` before installing backend CLIs.
+5. `ballast doctor` must report whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` exist.
+6. `ballast doctor` must provide actionable remediation when `.ballast/` state is missing or incomplete.
+7. `ballast doctor --fix` must recreate missing `.ballast/` directories through the same local CLI install path.
+8. Agent guidance must explain how to check and repair Ballast local state.
+9. Ballast must ship a dedicated common skill for AI agents that covers Ballast-managed repository status, bootstrap, and repair workflows.
+10. Documentation must describe the dedicated Ballast skill and how to install it.
+
+### Acceptance Criteria
+
+1. Given a repository without `.ballast/`, `ballast doctor` reports `.ballast: missing` and recommends `ballast install-cli` or `ballast doctor --fix`.
+2. Given a repository with `.ballast/` but missing `.ballast/bin` or `.ballast/tools`, `ballast doctor` reports the incomplete state and recommends repair.
+3. Given a repository without `.ballast/`, `ballast install-cli --language go --version <version>` creates `.ballast/bin` and `.ballast/tools` before running the install command.
+4. Given a repository without `.ballast/`, `ballast doctor --fix` creates `.ballast/bin` and `.ballast/tools` before running backend install commands.
+5. Generated local-dev guidance tells agents to use `ballast doctor` to inspect Ballast local state and `ballast doctor --fix` or `ballast install-cli` to repair it.
+6. The new Ballast skill is available through `--skill ballast-project-maintenance` and `--all-skills`.
+7. README and installation docs document `.ballast/` as generated local state and list the Ballast project maintenance skill.
+
 ## Agent Development Environment Bootstrap
 
 ### Problem

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Common skills (all languages):
 - `aws-weekly-security-review`
 - `github-health-check`
 - `ballast-audit`
+- `ballast-project-maintenance`
 
 Skill sources in this repo:
 
@@ -99,6 +100,7 @@ Skills are reusable task guides that Ballast installs for the target AI tool alo
 - `aws-weekly-security-review`: run a weekly read-only AWS security baseline review with prioritized findings
 - `github-health-check`: run a comprehensive GitHub repository health check covering CI status, open PRs, Dependabot, code coverage, GitHub Code Quality findings, security feature enablement, security advisories, and alert listings
 - `ballast-audit`: audit AI rule and skill files for context density, duplication, and bloat
+- `ballast-project-maintenance`: inspect, bootstrap, and repair Ballast-managed repository state, including generated `.ballast/` local tools
 
 ### Install a skill
 
@@ -332,6 +334,8 @@ Use `--force` when you want to reset a managed rule or skill file to canonical B
 - `ballast doctor`: inspect local Ballast CLI versions and `.rulesrc.json` metadata; add `--fix` to install/upgrade backend CLIs and refresh config automatically, and add `--patch` to merge backend file updates during that refresh
 - `ballast upgrade [--patch] [--force]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` and `--force` forward to the backend refresh
 - `ballast install-cli [--language <typescript|python|go|ansible|terraform>] [--version <x.y.z>]`: install or upgrade backend CLIs into the current repo’s `.ballast/` directory; omit `--version` for the latest release. The `ansible` and `terraform` selections reuse the `ballast-go` backend.
+
+`.ballast/` is generated local tool state, is ignored by git, and is safe to recreate. Run `ballast doctor` to inspect it; run `ballast doctor --fix` or `ballast install-cli` if `.ballast/`, `.ballast/bin`, or `.ballast/tools` is missing.
 
 ## Config Files
 

--- a/agents/common/local-dev/content-env.md
+++ b/agents/common/local-dev/content-env.md
@@ -15,6 +15,8 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 ## Agent Startup
 
 - If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
 - Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
 - If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -997,7 +997,7 @@ func printDoctorLocalState(root string) {
 		fmt.Println("- remediation: Run `ballast doctor --fix` or `ballast install-cli` to recreate generated .ballast/ tool state.")
 	}
 	if state.RootStatus == localStateUnreadable || state.BinStatus == localStateUnreadable || state.ToolsStatus == localStateUnreadable {
-		fmt.Println("- remediation: Check filesystem permissions for .ballast/ before reinstalling local tool state.")
+		fmt.Println("- remediation: Check the .ballast/ filesystem path and permissions before reinstalling local tool state.")
 	}
 	fmt.Println()
 }

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -166,6 +166,12 @@ type doctorBackendStatus struct {
 	Found    bool
 }
 
+type ballastLocalState struct {
+	RootExists  bool
+	BinExists   bool
+	ToolsExists bool
+}
+
 type monorepoPlan struct {
 	Invocations []backendInvocation
 	Config      monorepoConfig
@@ -924,6 +930,8 @@ func printDoctorSummary(root string, selectedLanguage language, fix bool) {
 	}
 	fmt.Println()
 
+	printDoctorLocalState(root)
+
 	fmt.Println("Config:")
 	configPath := filepath.Join(root, ".rulesrc.json")
 	config, err := loadDoctorConfig(root)
@@ -962,6 +970,41 @@ func printDoctorSummary(root string, selectedLanguage language, fix bool) {
 		fmt.Printf("- taskSystem: %s\n", config.TaskSystem)
 	}
 	fmt.Println()
+}
+
+func printDoctorLocalState(root string) {
+	state := inspectBallastLocalState(root)
+	fmt.Println("Local state:")
+	switch {
+	case !state.RootExists:
+		fmt.Println("- .ballast: missing")
+	case state.BinExists && state.ToolsExists:
+		fmt.Println("- .ballast: present")
+	default:
+		fmt.Println("- .ballast: incomplete")
+	}
+	printLocalStatePath(".ballast/bin", state.BinExists)
+	printLocalStatePath(".ballast/tools", state.ToolsExists)
+	if !state.RootExists || !state.BinExists || !state.ToolsExists {
+		fmt.Println("- remediation: Run `ballast doctor --fix` or `ballast install-cli` to recreate generated .ballast/ tool state.")
+	}
+	fmt.Println()
+}
+
+func printLocalStatePath(path string, exists bool) {
+	if exists {
+		fmt.Printf("- %s: present\n", path)
+		return
+	}
+	fmt.Printf("- %s: missing\n", path)
+}
+
+func inspectBallastLocalState(root string) ballastLocalState {
+	return ballastLocalState{
+		RootExists:  fileExists(filepath.Join(root, ".ballast")),
+		BinExists:   fileExists(filepath.Join(root, ".ballast", "bin")),
+		ToolsExists: fileExists(filepath.Join(root, ".ballast", "tools")),
+	}
 }
 
 func formatDoctorConfigPaths(languages []string, paths map[string][]string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -167,10 +167,16 @@ type doctorBackendStatus struct {
 }
 
 type ballastLocalState struct {
-	RootExists  bool
-	BinExists   bool
-	ToolsExists bool
+	RootStatus  string
+	BinStatus   string
+	ToolsStatus string
 }
+
+const (
+	localStatePresent    = "present"
+	localStateMissing    = "missing"
+	localStateUnreadable = "unreadable"
+)
 
 type monorepoPlan struct {
 	Invocations []backendInvocation
@@ -976,35 +982,51 @@ func printDoctorLocalState(root string) {
 	state := inspectBallastLocalState(root)
 	fmt.Println("Local state:")
 	switch {
-	case !state.RootExists:
+	case state.RootStatus == localStateMissing:
 		fmt.Println("- .ballast: missing")
-	case state.BinExists && state.ToolsExists:
+	case state.RootStatus == localStateUnreadable || state.BinStatus == localStateUnreadable || state.ToolsStatus == localStateUnreadable:
+		fmt.Println("- .ballast: unreadable")
+	case state.BinStatus == localStatePresent && state.ToolsStatus == localStatePresent:
 		fmt.Println("- .ballast: present")
 	default:
 		fmt.Println("- .ballast: incomplete")
 	}
-	printLocalStatePath(".ballast/bin", state.BinExists)
-	printLocalStatePath(".ballast/tools", state.ToolsExists)
-	if !state.RootExists || !state.BinExists || !state.ToolsExists {
+	printLocalStatePath(".ballast/bin", state.BinStatus)
+	printLocalStatePath(".ballast/tools", state.ToolsStatus)
+	if state.RootStatus == localStateMissing || state.BinStatus == localStateMissing || state.ToolsStatus == localStateMissing {
 		fmt.Println("- remediation: Run `ballast doctor --fix` or `ballast install-cli` to recreate generated .ballast/ tool state.")
+	}
+	if state.RootStatus == localStateUnreadable || state.BinStatus == localStateUnreadable || state.ToolsStatus == localStateUnreadable {
+		fmt.Println("- remediation: Check filesystem permissions for .ballast/ before reinstalling local tool state.")
 	}
 	fmt.Println()
 }
 
-func printLocalStatePath(path string, exists bool) {
-	if exists {
-		fmt.Printf("- %s: present\n", path)
-		return
-	}
-	fmt.Printf("- %s: missing\n", path)
+func printLocalStatePath(path string, status string) {
+	fmt.Printf("- %s: %s\n", path, status)
 }
 
 func inspectBallastLocalState(root string) ballastLocalState {
 	return ballastLocalState{
-		RootExists:  fileExists(filepath.Join(root, ".ballast")),
-		BinExists:   fileExists(filepath.Join(root, ".ballast", "bin")),
-		ToolsExists: fileExists(filepath.Join(root, ".ballast", "tools")),
+		RootStatus:  localStatePathStatus(filepath.Join(root, ".ballast")),
+		BinStatus:   localStatePathStatus(filepath.Join(root, ".ballast", "bin")),
+		ToolsStatus: localStatePathStatus(filepath.Join(root, ".ballast", "tools")),
 	}
+}
+
+func localStatePathStatus(path string) string {
+	_, err := os.Stat(path)
+	return localStateStatusFromStatError(err)
+}
+
+func localStateStatusFromStatError(err error) string {
+	if err == nil {
+		return localStatePresent
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return localStateMissing
+	}
+	return localStateUnreadable
 }
 
 func formatDoctorConfigPaths(languages []string, paths map[string][]string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1015,12 +1015,12 @@ func inspectBallastLocalState(root string) ballastLocalState {
 }
 
 func localStatePathStatus(path string) string {
-	_, err := os.Stat(path)
-	return localStateStatusFromStatError(err)
+	info, err := os.Stat(path)
+	return localStateStatusFromStat(info, err)
 }
 
-func localStateStatusFromStatError(err error) string {
-	if err == nil {
+func localStateStatusFromStat(info os.FileInfo, err error) string {
+	if err == nil && info.IsDir() {
 		return localStatePresent
 	}
 	if errors.Is(err, os.ErrNotExist) {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -395,14 +395,28 @@ func TestRunDoctorReportsIncompleteBallastState(t *testing.T) {
 }
 
 func TestLocalStateStatusDistinguishesPermissionErrors(t *testing.T) {
-	if got := localStateStatusFromStatError(nil); got != localStatePresent {
-		t.Fatalf("expected present status, got %q", got)
-	}
-	if got := localStateStatusFromStatError(os.ErrNotExist); got != localStateMissing {
+	if got := localStateStatusFromStat(nil, os.ErrNotExist); got != localStateMissing {
 		t.Fatalf("expected missing status, got %q", got)
 	}
-	if got := localStateStatusFromStatError(os.ErrPermission); got != localStateUnreadable {
+	if got := localStateStatusFromStat(nil, os.ErrPermission); got != localStateUnreadable {
 		t.Fatalf("expected unreadable status, got %q", got)
+	}
+}
+
+func TestLocalStatePathStatusRequiresDirectory(t *testing.T) {
+	root := resolvedTempDir(t)
+	dirPath := filepath.Join(root, "dir")
+	filePath := filepath.Join(root, "file")
+	if err := os.Mkdir(dirPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filePath, "not a directory")
+
+	if got := localStatePathStatus(dirPath); got != localStatePresent {
+		t.Fatalf("expected directory to be present, got %q", got)
+	}
+	if got := localStatePathStatus(filePath); got != localStateUnreadable {
+		t.Fatalf("expected file path to be unreadable local state, got %q", got)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -328,6 +328,72 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 }
 
+func TestRunDoctorReportsMissingBallastState(t *testing.T) {
+	originalCollect := collectDoctorBackendsFunc
+	t.Cleanup(func() {
+		collectDoctorBackendsFunc = originalCollect
+	})
+	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
+		return []doctorBackendStatus{
+			{Name: "ballast-go", Found: false},
+		}
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"codex","agents":["local-dev"]}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"doctor"})
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+		})
+	})
+
+	if !strings.Contains(output, "Local state:") {
+		t.Fatalf("expected local state section, got %q", output)
+	}
+	if !strings.Contains(output, "- .ballast: missing") {
+		t.Fatalf("expected missing .ballast state, got %q", output)
+	}
+	if !strings.Contains(output, "Run `ballast doctor --fix` or `ballast install-cli` to recreate generated .ballast/ tool state.") {
+		t.Fatalf("expected local state remediation, got %q", output)
+	}
+}
+
+func TestRunDoctorReportsIncompleteBallastState(t *testing.T) {
+	originalCollect := collectDoctorBackendsFunc
+	t.Cleanup(func() {
+		collectDoctorBackendsFunc = originalCollect
+	})
+	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
+		return nil
+	}
+
+	root := resolvedTempDir(t)
+	if err := os.MkdirAll(filepath.Join(root, ".ballast", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"target":"codex","agents":["local-dev"]}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"doctor"})
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+		})
+	})
+
+	if !strings.Contains(output, "- .ballast: incomplete") {
+		t.Fatalf("expected incomplete .ballast state, got %q", output)
+	}
+	if !strings.Contains(output, "- .ballast/tools: missing") {
+		t.Fatalf("expected missing .ballast/tools state, got %q", output)
+	}
+}
+
 func TestFindProjectRootUsesBallastConfigMarkers(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1729,6 +1795,9 @@ func TestRunInstallCLICreatesLocalBallastDirectories(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(root, ".ballast", "bin")); err != nil {
 		t.Fatalf("expected .ballast/bin to exist, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".ballast", "tools")); err != nil {
+		t.Fatalf("expected .ballast/tools to exist, got %v", err)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -394,6 +394,18 @@ func TestRunDoctorReportsIncompleteBallastState(t *testing.T) {
 	}
 }
 
+func TestLocalStateStatusDistinguishesPermissionErrors(t *testing.T) {
+	if got := localStateStatusFromStatError(nil); got != localStatePresent {
+		t.Fatalf("expected present status, got %q", got)
+	}
+	if got := localStateStatusFromStatError(os.ErrNotExist); got != localStateMissing {
+		t.Fatalf("expected missing status, got %q", got)
+	}
+	if got := localStateStatusFromStatError(os.ErrPermission); got != localStateUnreadable {
+		t.Fatalf("expected unreadable status, got %q", got)
+	}
+}
+
 func TestFindProjectRootUsesBallastConfigMarkers(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/cli/ballast/registry.go
+++ b/cli/ballast/registry.go
@@ -101,6 +101,11 @@ var skillRegistry = []skillEntry{
 		Description: "audit AI rule and skill files for context density, duplication, and bloat",
 		Status:      statusActive,
 	},
+	{
+		ID:          "ballast-project-maintenance",
+		Description: "inspect, bootstrap, and repair Ballast-managed repository state including .ballast/ local tools",
+		Status:      statusActive,
+	},
 }
 
 // — Agent registry helpers —————————————————————————————————————————————————

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,10 +44,13 @@ Common skills:
 - `aws-weekly-security-review`
 - `github-health-check`
 - `ballast-audit`
+- `ballast-project-maintenance`
 
 `github-health-check` covers CI status, pull request hygiene, Dependabot, code coverage, GitHub Code Quality findings, security feature enablement, security advisories, and alert listings.
 
 `ballast-audit` audits AI rule and skill files for context density, duplication, and bloat.
+
+`ballast-project-maintenance` covers Ballast-managed repository status, `.ballast/` local tool repair, and config refresh workflows.
 
 Guide index:
 
@@ -58,6 +61,7 @@ Guide index:
 - [skills/github-health-check.md](skills/github-health-check.md)
 - [skills/owasp-security-scan.md](skills/owasp-security-scan.md)
 - [skills/ballast-audit.md](skills/ballast-audit.md)
+- [skills/ballast-project-maintenance.md](skills/ballast-project-maintenance.md)
 
 ## Installation and Monorepos
 

--- a/docs/agents/local-dev.md
+++ b/docs/agents/local-dev.md
@@ -14,6 +14,8 @@ The local-dev agent installs multiple rules:
 ## What It Provides
 
 - A canonical agent startup command: `ballast setup-dev`
+- Ballast local-state inspection with `ballast doctor`
+- Repair guidance for generated `.ballast/` tool state with `ballast doctor --fix` or `ballast install-cli`
 - `.nvmrc` for consistent Node versions
 - Dockerfile, `docker-compose.yaml`, and `docker-compose.local.yaml` with `develop.watch` for hot reload
 - A `Makefile` with `up`, `down`, and `logs` targets for both the base stack and local watch-mode stack
@@ -29,6 +31,7 @@ The local-dev agent installs multiple rules:
 ### Environment and Node
 
 - **"Prepare this repository before agent work"** — Run `ballast setup-dev` and follow its remediation output
+- **"Repair missing Ballast local tools"** — Run `ballast doctor`; if `.ballast/` is missing or incomplete, run `ballast doctor --fix` or `ballast install-cli`
 - **"Add .nvmrc with the Node version from our CI"** — Version consistency
 - **"Update the README with nvm setup instructions for new contributors"** — Onboarding
 - **"Create .env.example with all required environment variables"** — Env documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -214,6 +214,8 @@ For single-language TypeScript installs, the `git-hooks` rules should use Husky 
 - `ballast upgrade [--patch] [--force]`: rewrite `.rulesrc.json` to the running Ballast wrapper version, then sync backend CLIs to match it; `--patch` and `--force` forward to the backend refresh
 - `ballast install-cli [--language <typescript|python|go|ansible|terraform>] [--version <x.y.z>]`: install or upgrade backend CLIs into the current repo’s `.ballast/` directory; omit `--version` for the latest release. The `ansible` and `terraform` selections reuse the `ballast-go` backend.
 
+`.ballast/` is generated repository-local tool state for backend CLIs. It is safe to recreate and should remain ignored by git. `ballast install` does not require `.ballast/` to exist before installing rules or skills. Use `ballast doctor` to inspect `.ballast/`, `.ballast/bin`, and `.ballast/tools`; use `ballast doctor --fix` or `ballast install-cli` to recreate missing or incomplete local tool state.
+
 ## Config Persistence
 
 - Shared config (wrapper + TypeScript/Python/Go CLIs, current default): `.rulesrc.json`

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -41,6 +41,13 @@ Ballast ships reusable skill guides alongside its agent rules.
 - Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
 - Installed by: `--skill ballast-audit` or `--all-skills`
 
+`ballast-project-maintenance`
+
+- Type: common skill
+- Supported language profiles: TypeScript, Python, Go, Ansible, Terraform
+- Installed by: `--skill ballast-project-maintenance` or `--all-skills`
+- Focus: Ballast-managed repository status, `.ballast/` local tool repair, config refresh, and generated rule/skill maintenance
+
 ## Installation Targets
 
 Skills install to the target tool's expected location:
@@ -61,3 +68,4 @@ Codex also records installed skills in the root `AGENTS.md`. Claude records them
 - [aws-weekly-security-review.md](aws-weekly-security-review.md)
 - [github-health-check.md](github-health-check.md)
 - [ballast-audit.md](ballast-audit.md)
+- [ballast-project-maintenance.md](ballast-project-maintenance.md)

--- a/docs/skills/ballast-project-maintenance.md
+++ b/docs/skills/ballast-project-maintenance.md
@@ -1,0 +1,22 @@
+# Ballast Project Maintenance
+
+Use `ballast-project-maintenance` when an AI agent needs to inspect, bootstrap, or repair a Ballast-managed repository.
+
+## Install
+
+```bash
+ballast install --target codex --skill ballast-project-maintenance
+ballast install --target claude --skill ballast-project-maintenance
+```
+
+It is also included by `--all-skills`.
+
+## What It Covers
+
+- Confirming whether `.rulesrc.json` marks the repo as Ballast-managed.
+- Inspecting generated local `.ballast/` tool state with `ballast doctor`.
+- Recreating missing `.ballast/`, `.ballast/bin`, or `.ballast/tools` with `ballast doctor --fix` or `ballast install-cli`.
+- Refreshing generated rules and skills from saved config with `ballast install --refresh-config`.
+- Avoiding commits of `.ballast/`, which is generated local state.
+
+The source of truth for this skill is `skills/common/ballast-project-maintenance/SKILL.md`.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
@@ -15,6 +15,8 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 ## Agent Startup
 
 - If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
 - Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
 - If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -34,6 +34,7 @@ var commonSkills = []string{
 	"aws-weekly-security-review",
 	"github-health-check",
 	"ballast-audit",
+	"ballast-project-maintenance",
 }
 
 var descriptionRegex = regexp.MustCompile(`(?m)^description:\s*['\"]?(.+?)['\"]?\s*$`)
@@ -419,7 +420,7 @@ Options:
   --target, -t <platform>   AI platforms: %s (comma-separated or repeatable)
   --language, -l <lang>     Language profile: %s (default: go)
   --agent, -a <agents>      Agent(s): linting, local-dev, docs, cicd, observability, publishing, git-hooks, logging, testing (comma-separated)
-  --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check, ballast-audit (comma-separated)
+  --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check, ballast-audit, ballast-project-maintenance (comma-separated)
   --all                     Install all agents
   --all-skills              Install all skills
   --force                   Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -25,7 +25,7 @@ import (
 var targets = []string{"cursor", "claude", "opencode", "codex", "gemini"}
 var languages = []string{"typescript", "python", "go", "ansible", "terraform"}
 
-var commonAgents = []string{"local-dev", "docs", "cicd", "observability", "publishing", "git-hooks"}
+var commonAgents = []string{"local-dev", "docs", "cicd", "observability", "publishing", "git-hooks", "tasks"}
 var languageAgents = []string{"linting", "logging", "testing"}
 var commonSkills = []string{
 	"owasp-security-scan",
@@ -419,7 +419,7 @@ Commands:
 Options:
   --target, -t <platform>   AI platforms: %s (comma-separated or repeatable)
   --language, -l <lang>     Language profile: %s (default: go)
-  --agent, -a <agents>      Agent(s): linting, local-dev, docs, cicd, observability, publishing, git-hooks, logging, testing (comma-separated)
+  --agent, -a <agents>      Agent(s): linting, local-dev, docs, cicd, observability, publishing, git-hooks, tasks, logging, testing (comma-separated)
   --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check, ballast-audit, ballast-project-maintenance (comma-separated)
   --all                     Install all agents
   --all-skills              Install all skills

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -95,6 +95,7 @@ func TestListSkillsIncludesAllRegistrySkills(t *testing.T) {
 		"aws-weekly-security-review",
 		"github-health-check",
 		"ballast-audit",
+		"ballast-project-maintenance",
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("expected %v, got %v", want, got)

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -84,6 +84,28 @@ func TestRunInstallHelpFlag(t *testing.T) {
 	if !strings.Contains(output, "github-health-check") {
 		t.Fatalf("expected github-health-check in help output, got %q", output)
 	}
+	if !strings.Contains(output, "tasks") {
+		t.Fatalf("expected tasks agent in help output, got %q", output)
+	}
+}
+
+func TestListAgentsIncludesAllRegistryAgents(t *testing.T) {
+	got := listAgents("go")
+	want := []string{
+		"local-dev",
+		"docs",
+		"cicd",
+		"observability",
+		"publishing",
+		"git-hooks",
+		"tasks",
+		"linting",
+		"logging",
+		"testing",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
 }
 
 func TestListSkillsIncludesAllRegistrySkills(t *testing.T) {

--- a/packages/ballast-go/cmd/ballast-go/skills/common/ballast-project-maintenance/SKILL.md
+++ b/packages/ballast-go/cmd/ballast-go/skills/common/ballast-project-maintenance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ballast-project-maintenance
+description: >
+  Inspect, bootstrap, and repair Ballast-managed repository state. Use this
+  skill when a user asks whether a repo is Ballast-managed, why .ballast/ is
+  missing, how to repair local Ballast CLIs, or how to refresh Ballast rules
+  and skills from saved config.
+---
+
+# Ballast Project Maintenance Skill
+
+Use this skill to inspect and repair Ballast-managed repository state without guessing.
+
+## State Model
+
+- `.rulesrc.json` is the saved Ballast configuration and should be committed when the repository is Ballast-managed.
+- `.ballast/` is generated local tool state for project-local backend CLIs.
+- `.ballast/` should be ignored by git and is safe to recreate.
+- Target directories such as `.codex/`, `.claude/`, `.cursor/`, `.gemini/`, and `.opencode/` contain Ballast-managed rules and skills plus any tool-specific user files.
+
+## Inspect State
+
+From the repository root, run:
+
+```bash
+ballast doctor
+```
+
+Check:
+
+- Whether `.rulesrc.json` exists and lists expected targets, agents, skills, languages, paths, and task system.
+- Whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` are present.
+- Whether backend CLIs are found and match the expected Ballast version.
+- Whether the doctor output recommends `ballast doctor --fix` or config refresh.
+
+## Repair Missing Or Incomplete `.ballast/`
+
+If `.ballast/` is missing or incomplete, recreate it with one of:
+
+```bash
+ballast doctor --fix
+ballast install-cli
+```
+
+Use `ballast doctor --fix` when saved config should also be refreshed. Use `ballast install-cli` when only local backend CLIs need to be installed or upgraded.
+
+For a specific backend:
+
+```bash
+ballast install-cli --language typescript
+ballast install-cli --language python
+ballast install-cli --language go
+```
+
+## Refresh Managed Rules And Skills
+
+If `.rulesrc.json` exists and generated rules or skills are stale, run:
+
+```bash
+ballast install --refresh-config
+```
+
+For patch-based refresh that preserves supported user-managed sections:
+
+```bash
+ballast install --refresh-config --patch
+```
+
+For wrapper upgrades:
+
+```bash
+ballast upgrade
+ballast upgrade --patch
+```
+
+## Agent Workflow
+
+1. Read `.rulesrc.json` before changing Ballast-managed outputs.
+2. Run `ballast doctor` and use its remediation text as the source of truth.
+3. Prefer `ballast doctor --fix` for repair when saved config exists.
+4. Prefer `ballast install-cli` when only `.ballast/` local tools are missing.
+5. Do not commit `.ballast/`; it is generated local state.
+6. When source `agents/`, `skills/`, sync/build scripts, or target config change, regenerate checked-in local `.claude/` and `.codex/` outputs in the same PR.

--- a/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
@@ -15,6 +15,8 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 ## Agent Startup
 
 - If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
 - Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
 - If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 

--- a/packages/ballast-go/cmd/ballast/skills/common/ballast-project-maintenance/SKILL.md
+++ b/packages/ballast-go/cmd/ballast/skills/common/ballast-project-maintenance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ballast-project-maintenance
+description: >
+  Inspect, bootstrap, and repair Ballast-managed repository state. Use this
+  skill when a user asks whether a repo is Ballast-managed, why .ballast/ is
+  missing, how to repair local Ballast CLIs, or how to refresh Ballast rules
+  and skills from saved config.
+---
+
+# Ballast Project Maintenance Skill
+
+Use this skill to inspect and repair Ballast-managed repository state without guessing.
+
+## State Model
+
+- `.rulesrc.json` is the saved Ballast configuration and should be committed when the repository is Ballast-managed.
+- `.ballast/` is generated local tool state for project-local backend CLIs.
+- `.ballast/` should be ignored by git and is safe to recreate.
+- Target directories such as `.codex/`, `.claude/`, `.cursor/`, `.gemini/`, and `.opencode/` contain Ballast-managed rules and skills plus any tool-specific user files.
+
+## Inspect State
+
+From the repository root, run:
+
+```bash
+ballast doctor
+```
+
+Check:
+
+- Whether `.rulesrc.json` exists and lists expected targets, agents, skills, languages, paths, and task system.
+- Whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` are present.
+- Whether backend CLIs are found and match the expected Ballast version.
+- Whether the doctor output recommends `ballast doctor --fix` or config refresh.
+
+## Repair Missing Or Incomplete `.ballast/`
+
+If `.ballast/` is missing or incomplete, recreate it with one of:
+
+```bash
+ballast doctor --fix
+ballast install-cli
+```
+
+Use `ballast doctor --fix` when saved config should also be refreshed. Use `ballast install-cli` when only local backend CLIs need to be installed or upgraded.
+
+For a specific backend:
+
+```bash
+ballast install-cli --language typescript
+ballast install-cli --language python
+ballast install-cli --language go
+```
+
+## Refresh Managed Rules And Skills
+
+If `.rulesrc.json` exists and generated rules or skills are stale, run:
+
+```bash
+ballast install --refresh-config
+```
+
+For patch-based refresh that preserves supported user-managed sections:
+
+```bash
+ballast install --refresh-config --patch
+```
+
+For wrapper upgrades:
+
+```bash
+ballast upgrade
+ballast upgrade --patch
+```
+
+## Agent Workflow
+
+1. Read `.rulesrc.json` before changing Ballast-managed outputs.
+2. Run `ballast doctor` and use its remediation text as the source of truth.
+3. Prefer `ballast doctor --fix` for repair when saved config exists.
+4. Prefer `ballast install-cli` when only `.ballast/` local tools are missing.
+5. Do not commit `.ballast/`; it is generated local state.
+6. When source `agents/`, `skills/`, sync/build scripts, or target config change, regenerate checked-in local `.claude/` and `.codex/` outputs in the same PR.

--- a/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
@@ -15,6 +15,8 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 ## Agent Startup
 
 - If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
 - Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
 - If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -38,6 +38,7 @@ COMMON_SKILLS = [
     "aws-weekly-security-review",
     "github-health-check",
     "ballast-audit",
+    "ballast-project-maintenance",
 ]
 SKILLS_BY_LANGUAGE = {
     "typescript": COMMON_SKILLS,

--- a/packages/ballast-python/ballast/skills/common/ballast-project-maintenance/SKILL.md
+++ b/packages/ballast-python/ballast/skills/common/ballast-project-maintenance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ballast-project-maintenance
+description: >
+  Inspect, bootstrap, and repair Ballast-managed repository state. Use this
+  skill when a user asks whether a repo is Ballast-managed, why .ballast/ is
+  missing, how to repair local Ballast CLIs, or how to refresh Ballast rules
+  and skills from saved config.
+---
+
+# Ballast Project Maintenance Skill
+
+Use this skill to inspect and repair Ballast-managed repository state without guessing.
+
+## State Model
+
+- `.rulesrc.json` is the saved Ballast configuration and should be committed when the repository is Ballast-managed.
+- `.ballast/` is generated local tool state for project-local backend CLIs.
+- `.ballast/` should be ignored by git and is safe to recreate.
+- Target directories such as `.codex/`, `.claude/`, `.cursor/`, `.gemini/`, and `.opencode/` contain Ballast-managed rules and skills plus any tool-specific user files.
+
+## Inspect State
+
+From the repository root, run:
+
+```bash
+ballast doctor
+```
+
+Check:
+
+- Whether `.rulesrc.json` exists and lists expected targets, agents, skills, languages, paths, and task system.
+- Whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` are present.
+- Whether backend CLIs are found and match the expected Ballast version.
+- Whether the doctor output recommends `ballast doctor --fix` or config refresh.
+
+## Repair Missing Or Incomplete `.ballast/`
+
+If `.ballast/` is missing or incomplete, recreate it with one of:
+
+```bash
+ballast doctor --fix
+ballast install-cli
+```
+
+Use `ballast doctor --fix` when saved config should also be refreshed. Use `ballast install-cli` when only local backend CLIs need to be installed or upgraded.
+
+For a specific backend:
+
+```bash
+ballast install-cli --language typescript
+ballast install-cli --language python
+ballast install-cli --language go
+```
+
+## Refresh Managed Rules And Skills
+
+If `.rulesrc.json` exists and generated rules or skills are stale, run:
+
+```bash
+ballast install --refresh-config
+```
+
+For patch-based refresh that preserves supported user-managed sections:
+
+```bash
+ballast install --refresh-config --patch
+```
+
+For wrapper upgrades:
+
+```bash
+ballast upgrade
+ballast upgrade --patch
+```
+
+## Agent Workflow
+
+1. Read `.rulesrc.json` before changing Ballast-managed outputs.
+2. Run `ballast doctor` and use its remediation text as the source of truth.
+3. Prefer `ballast doctor --fix` for repair when saved config exists.
+4. Prefer `ballast install-cli` when only `.ballast/` local tools are missing.
+5. Do not commit `.ballast/`; it is generated local state.
+6. When source `agents/`, `skills/`, sync/build scripts, or target config change, regenerate checked-in local `.claude/` and `.codex/` outputs in the same PR.

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -510,6 +510,7 @@ class PatchInstallTests(unittest.TestCase):
                 "aws-weekly-security-review",
                 "github-health-check",
                 "ballast-audit",
+                "ballast-project-maintenance",
             ],
         )
         self.assertEqual(

--- a/packages/ballast-typescript/src/agents.test.ts
+++ b/packages/ballast-typescript/src/agents.test.ts
@@ -118,6 +118,7 @@ describe('agents', () => {
       expect(listSkills()).toContain('aws-live-health-review');
       expect(listSkills()).toContain('aws-weekly-security-review');
       expect(listSkills()).toContain('github-health-check');
+      expect(listSkills()).toContain('ballast-project-maintenance');
     });
 
     test('validates known skills', () => {
@@ -126,6 +127,7 @@ describe('agents', () => {
       expect(isValidSkill('aws-live-health-review')).toBe(true);
       expect(isValidSkill('aws-weekly-security-review')).toBe(true);
       expect(isValidSkill('github-health-check')).toBe(true);
+      expect(isValidSkill('ballast-project-maintenance')).toBe(true);
       expect(isValidSkill('unknown')).toBe(false);
     });
 

--- a/packages/ballast-typescript/src/agents.ts
+++ b/packages/ballast-typescript/src/agents.ts
@@ -69,7 +69,8 @@ export const COMMON_SKILL_IDS = [
   'aws-live-health-review',
   'aws-weekly-security-review',
   'github-health-check',
-  'ballast-audit'
+  'ballast-audit',
+  'ballast-project-maintenance'
 ] as const;
 export const SKILL_IDS = [...COMMON_SKILL_IDS] as const;
 export type SkillId = (typeof SKILL_IDS)[number];

--- a/plans/issue-priority-plan.md
+++ b/plans/issue-priority-plan.md
@@ -57,7 +57,7 @@ As of 2026-07-09, the repository has these open issues:
 - #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages
 - #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
 - #90: Add GitHub Actions Slack notifications for successful and failed builds
-- #81: Deploy ballast-python to the everydaydevopio organization on PyPI
+- #81: Deploy ballast-python to the everydaydevopsio organization on PyPI
 - #65: Improve ballast-go release installer portability by removing shell tool assumptions
 - #61: Support native Windows executable detection in TypeScript doctor
 - #11: First-run interview: collect project preferences (package manager, Git host, test framework, JS/TS)
@@ -67,7 +67,7 @@ As of 2026-07-09, the repository has these open issues:
 
 | Requested item | Coverage | Action |
 | --- | --- | --- |
-| What to do about a missing `.ballast` file; is there a Ballast skill? | New issue #208 | Created focused issue for missing-state behavior and skill support. |
+| What to do about a missing `.ballast/` directory; is there a Ballast skill? | New issue #208 | Created focused issue for missing-state behavior and skill support. |
 | Fix Husky so YAML and YML formatting checks run | New issue #209 | Created focused Husky YAML/YML issue. |
 | Have Husky run tests on push to GitHub | New issue #210 | Created focused Husky pre-push test issue. |
 | Install local dev environment on startup for AI agents; missing pnpm because Corepack was not enabled | Existing #94 and #128 partially cover prerequisites and package-manager detection; new issue #211 covers the startup command | Created focused setup command issue. |
@@ -136,7 +136,7 @@ This broadens Ballast from local rules into multi-agent and deployment orchestra
 13. #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
 14. #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
 15. #90: Add GitHub Actions Slack notifications for successful and failed builds
-16. #81: Deploy ballast-python to the everydaydevopio organization on PyPI
+16. #81: Deploy ballast-python to the everydaydevopsio organization on PyPI
 17. #11: First-run interview: collect project preferences
 
 ## Near-Term Execution Plan

--- a/plans/issue-priority-plan.md
+++ b/plans/issue-priority-plan.md
@@ -1,0 +1,156 @@
+# Plan: Open Issue Review and Next Priorities
+
+**Status:** Proposed
+**Created:** 2026-07-09
+**Source:** Review of open GitHub issues and requested follow-up list
+
+## Summary
+
+Reviewed all open GitHub issues for `everydaydevopsio/ballast` and compared them against the requested follow-up list. Several items were already covered by existing issues. Eight gaps were created as new GitHub issues.
+
+## Completed Work
+
+- #212: Require agents to create a new branch before modifying code — completed and merged via PR #216.
+- #211: Add a development-environment bootstrap command for AI agents — implemented and merged via PR #217.
+  - Added `ballast setup-dev` to bootstrap agent development environments from the project root.
+  - Detects Node package managers from `package.json` and lockfiles, enables Corepack for `pnpm` and `yarn`, runs the appropriate install command, and exits successfully when no setup steps are detected.
+  - Hardened package-manager execution with an allowlist so untrusted `packageManager` values are ignored.
+  - Added focused Go tests for declared package managers, lockfile fallback, no-op behavior, unsafe package-manager values, and failure output.
+  - Updated `PRD.md`, README/docs, local-dev guidance, generated `.claude/` and `.codex/` rule outputs, and package payload copies.
+- #208: Define .ballast bootstrap behavior and Ballast skill support — implemented on branch `issue-208-ballast-bootstrap-skill`.
+  - Defined `.ballast/` as generated repository-local tool state that is ignored by git and safe to recreate.
+  - Added `ballast doctor` local-state reporting for missing and incomplete `.ballast/`, `.ballast/bin`, and `.ballast/tools`.
+  - Added remediation guidance pointing operators to `ballast doctor --fix` or `ballast install-cli`.
+  - Added `ballast-project-maintenance` as a common skill for Ballast repository status, bootstrap, and repair workflows.
+  - Updated docs, local-dev guidance, package mirrors, generated local `.claude/` and `.codex/` outputs, and focused tests.
+
+## Open Issue Inventory
+
+As of 2026-07-09, the repository has these open issues:
+
+- #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config
+- #214: Add smoke and E2E test guidance for web apps and CLIs
+- #213: Codify Copilot review polling and per-thread replies
+- #212: Require agents to create a new branch before modifying code
+- #211: Add a development-environment bootstrap command for AI agents
+- #210: Configure Husky pre-push hooks to run tests before pushing to GitHub
+- #209: Add YAML and YML formatting checks to Husky hook guidance
+- #208: Define .ballast bootstrap behavior and Ballast skill support
+- #188: Re-enable OpenCode as a first-class Ballast target
+- #175: Consider TTY detection for non-interactive mode in support file confirmation
+- #166: feat(doctor): detect drift and remove stale rules files
+- #160: Review Terraform linting and testing rules for best practices alignment
+- #159: Add TDD process discipline to testing agent rules
+- #158: Reconcile tasks/todo.md format with global EXECUTION_TEMPLATES standard
+- #154: Add plan-lifecycle rule: Plan -> ADR lifecycle for non-trivial features
+- #153: feat: daily repo health check GitHub Action with structured report
+- #151: Review ansible rules: dependabot not supported, verify pre-commit linting setup
+- #149: feat: add interactive setup prompts to github-health-check skill for unconfigured sections
+- #147: Add GitHub repo setup workflow and best practices skill
+- #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps
+- #144: Bug: ballast upgrade refresh skips installed skills instead of updating them
+- #133: Create MCP server so AI agents can configure and use Ballast directly
+- #128: Detect project package manager during setup and align Node/package-manager defaults to LTS
+- #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
+- #99: Add Next.js-specific TypeScript rules based on current Next.js linting and app best practices
+- #94: Check required local tools for Ballast rules using PATH detection plus Homebrew install guidance
+- #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages
+- #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
+- #90: Add GitHub Actions Slack notifications for successful and failed builds
+- #81: Deploy ballast-python to the everydaydevopio organization on PyPI
+- #65: Improve ballast-go release installer portability by removing shell tool assumptions
+- #61: Support native Windows executable detection in TypeScript doctor
+- #11: First-run interview: collect project preferences (package manager, Git host, test framework, JS/TS)
+- #10: Add agent validation tests: Dockerfiles + rule validation per AI platform
+
+## Requested Items Mapped to Issues
+
+| Requested item | Coverage | Action |
+| --- | --- | --- |
+| What to do about a missing `.ballast` file; is there a Ballast skill? | New issue #208 | Created focused issue for missing-state behavior and skill support. |
+| Fix Husky so YAML and YML formatting checks run | New issue #209 | Created focused Husky YAML/YML issue. |
+| Have Husky run tests on push to GitHub | New issue #210 | Created focused Husky pre-push test issue. |
+| Install local dev environment on startup for AI agents; missing pnpm because Corepack was not enabled | Existing #94 and #128 partially cover prerequisites and package-manager detection; new issue #211 covers the startup command | Created focused setup command issue. |
+| Need a loop for checking Copilot comments | New issue #213 | Created focused Copilot polling issue. |
+| Force commenting on Copilot comments | New issue #213 | Covered with per-thread reply requirement. |
+| Deployment to Kubernetes with Helm chart in local repo and ArgoCD config in separate repo | New issue #215 | Created focused split-repo GitOps deployment issue. |
+| Add smoke and E2E tests for web and CLIs | Existing #145 and #10 partially cover framework detection and agent validation; new issue #214 covers product web/CLI smoke and E2E guidance | Created focused test guidance issue. |
+| Need a command to setup development environment before an AI agent can run | New issue #211 | Same bootstrap command issue. |
+| Always create a new branch when modifying code | New issue #212 | Created focused branch-before-code policy issue. |
+| Create rules for creating plans and converting them to ADRs | Existing #154 | No new issue needed. |
+| Have plan/ADR rules included in generated rules when creating plans | Existing #154 | No new issue needed. |
+
+## Recommended Priority Order
+
+### P0: Restore trust in agent execution and repo safety
+
+- [x] #212: Require agents to create a new branch before modifying code — completed and merged via PR #216
+- [x] #211: Add a development-environment bootstrap command for AI agents — implemented and merged via PR #217
+- [x] #208: Define .ballast bootstrap behavior and Ballast skill support — implemented on branch `issue-208-ballast-bootstrap-skill`
+1. #144: Bug: ballast upgrade refresh skips installed skills instead of updating them
+
+These reduce the chance that agents start from a broken environment, edit the wrong branch, or operate with stale Ballast-managed guidance.
+
+### P1: Make local and CI verification reliable
+
+1. #210: Configure Husky pre-push hooks to run tests before pushing to GitHub
+2. #209: Add YAML and YML formatting checks to Husky hook guidance
+3. #214: Add smoke and E2E test guidance for web apps and CLIs
+4. #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps
+5. #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages
+
+This builds a coherent path from local hooks to smoke/E2E validation to canonical CI.
+
+### P2: Improve PR review and delivery workflow
+
+1. #213: Codify Copilot review polling and per-thread replies
+2. #154: Add plan-lifecycle rule: Plan -> ADR lifecycle for non-trivial features
+3. #159: Add TDD process discipline to testing agent rules
+4. #158: Reconcile tasks/todo.md format with global EXECUTION_TEMPLATES standard
+
+These make agent work easier to review, preserve implementation context, and keep planning artifacts consistent.
+
+### P3: Expand platform and deployment coverage
+
+1. #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config
+2. #188: Re-enable OpenCode as a first-class Ballast target
+3. #133: Create MCP server so AI agents can configure and use Ballast directly
+4. #10: Add agent validation tests: Dockerfiles + rule validation per AI platform
+
+This broadens Ballast from local rules into multi-agent and deployment orchestration.
+
+### P4: Backlog cleanup and ecosystem hardening
+
+1. #166: feat(doctor): detect drift and remove stale rules files
+2. #128: Detect project package manager during setup and align Node/package-manager defaults to LTS
+3. #94: Check required local tools for Ballast rules using PATH detection plus Homebrew install guidance
+4. #61: Support native Windows executable detection in TypeScript doctor
+5. #65: Improve ballast-go release installer portability by removing shell tool assumptions
+6. #160: Review Terraform linting and testing rules for best practices alignment
+7. #151: Review ansible rules: dependabot not supported, verify pre-commit linting setup
+8. #99: Add Next.js-specific TypeScript rules based on current Next.js linting and app best practices
+9. #175: Consider TTY detection for non-interactive mode in support file confirmation
+10. #153: feat: daily repo health check GitHub Action with structured report
+11. #149: feat: add interactive setup prompts to github-health-check skill for unconfigured sections
+12. #147: Add GitHub repo setup workflow and best practices skill
+13. #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
+14. #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
+15. #90: Add GitHub Actions Slack notifications for successful and failed builds
+16. #81: Deploy ballast-python to the everydaydevopio organization on PyPI
+17. #11: First-run interview: collect project preferences
+
+## Near-Term Execution Plan
+
+- [x] Implement #212 first because branch safety should be in place before more agent automation is added. Completed via PR #216.
+- [x] Implement #211 as the first bootstrap step. Completed via PR #217 with `ballast setup-dev`, package-manager detection, Corepack enablement for `pnpm`/`yarn`, safety allowlisting, docs, generated rule updates, and tests.
+- [x] Implement #208 next so `.ballast/` missing-state detection and Ballast skill support can build on the new `setup-dev` command. Implemented on branch `issue-208-ballast-bootstrap-skill`.
+1. Implement #209 and #210 as one git-hook workstream, with generated outputs regenerated in the same PR.
+2. Implement #214 with #145 in mind so generated testing guidance uses detected framework signals instead of generic defaults.
+3. Implement #213 before scaling PR automation or MCP workflows.
+4. Implement #154 after the task format issue #158 is resolved, or explicitly design #154 to tolerate the current `tasks/TODO.md` format until #158 lands.
+
+## Notes
+
+- New issues created during this review: #208, #209, #210, #211, #212, #213, #214, and #215.
+- Existing modified file `.github/workflows/publish.yml` was present before this work and was not touched.
+- If implementation changes root `agents/`, `skills/`, sync/build scripts, or root target config, regenerate and commit local Ballast-managed `.claude/` and `.codex/` outputs in the same PR.

--- a/skills/common/ballast-project-maintenance/SKILL.md
+++ b/skills/common/ballast-project-maintenance/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ballast-project-maintenance
+description: >
+  Inspect, bootstrap, and repair Ballast-managed repository state. Use this
+  skill when a user asks whether a repo is Ballast-managed, why .ballast/ is
+  missing, how to repair local Ballast CLIs, or how to refresh Ballast rules
+  and skills from saved config.
+---
+
+# Ballast Project Maintenance Skill
+
+Use this skill to inspect and repair Ballast-managed repository state without guessing.
+
+## State Model
+
+- `.rulesrc.json` is the saved Ballast configuration and should be committed when the repository is Ballast-managed.
+- `.ballast/` is generated local tool state for project-local backend CLIs.
+- `.ballast/` should be ignored by git and is safe to recreate.
+- Target directories such as `.codex/`, `.claude/`, `.cursor/`, `.gemini/`, and `.opencode/` contain Ballast-managed rules and skills plus any tool-specific user files.
+
+## Inspect State
+
+From the repository root, run:
+
+```bash
+ballast doctor
+```
+
+Check:
+
+- Whether `.rulesrc.json` exists and lists expected targets, agents, skills, languages, paths, and task system.
+- Whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` are present.
+- Whether backend CLIs are found and match the expected Ballast version.
+- Whether the doctor output recommends `ballast doctor --fix` or config refresh.
+
+## Repair Missing Or Incomplete `.ballast/`
+
+If `.ballast/` is missing or incomplete, recreate it with one of:
+
+```bash
+ballast doctor --fix
+ballast install-cli
+```
+
+Use `ballast doctor --fix` when saved config should also be refreshed. Use `ballast install-cli` when only local backend CLIs need to be installed or upgraded.
+
+For a specific backend:
+
+```bash
+ballast install-cli --language typescript
+ballast install-cli --language python
+ballast install-cli --language go
+```
+
+## Refresh Managed Rules And Skills
+
+If `.rulesrc.json` exists and generated rules or skills are stale, run:
+
+```bash
+ballast install --refresh-config
+```
+
+For patch-based refresh that preserves supported user-managed sections:
+
+```bash
+ballast install --refresh-config --patch
+```
+
+For wrapper upgrades:
+
+```bash
+ballast upgrade
+ballast upgrade --patch
+```
+
+## Agent Workflow
+
+1. Read `.rulesrc.json` before changing Ballast-managed outputs.
+2. Run `ballast doctor` and use its remediation text as the source of truth.
+3. Prefer `ballast doctor --fix` for repair when saved config exists.
+4. Prefer `ballast install-cli` when only `.ballast/` local tools are missing.
+5. Do not commit `.ballast/`; it is generated local state.
+6. When source `agents/`, `skills/`, sync/build scripts, or target config change, regenerate checked-in local `.claude/` and `.codex/` outputs in the same PR.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,14 @@
 # Tasks
 
+- [x] Confirm issue #208 scope, operating mode, and governing PRD gap.
+- [x] Add PRD requirements for generated `.ballast/` state and Ballast repair skill support.
+- [x] Add failing coverage for missing `.ballast/` doctor/install-cli behavior and the new skill registry entry.
+- [x] Implement wrapper state reporting/remediation and the Ballast maintenance skill.
+- [x] Update docs, agent guidance, package mirrors, and generated local target outputs.
+- [x] Run targeted verification and capture evidence.
+
+## Previous Tasks
+
 - [x] Confirm issue #211 scope and governing operating mode.
 - [x] Add PRD requirements and acceptance criteria for `ballast setup-dev`.
 - [x] Add failing wrapper tests for Corepack/package-manager setup behavior.
@@ -7,8 +16,6 @@
 - [x] Update local-dev agent guidance and regenerated Ballast-managed outputs.
 - [x] Run targeted and full verification commands.
 - [x] Push branch, open PR, and request Copilot review.
-
-## Previous Tasks
 
 - [x] Confirm issue #144 root cause and affected backends.
 - [x] Add PRD acceptance criteria for managed skill refresh.


### PR DESCRIPTION
## Summary
- define .ballast/ as generated local tool state in the PRD and docs
- report missing/incomplete .ballast state in ballast doctor with repair guidance
- add the ballast-project-maintenance skill across registries, docs, and package mirrors
- refresh local-dev generated guidance for Claude and Codex

Closes #208.

## Tests
- go test ./... (cli/ballast)
- go test ./... (packages/ballast-go/cmd/ballast-go)
- pnpm --dir packages/ballast-typescript test -- agents.test.ts build.test.ts repo-generated-artifacts.test.ts
- uv run python -m unittest tests.test_cli
- pre-commit hooks on commit
- pre-push unit tests for cli and language packages