### PR TITLE
Align Terraform rules with current best practices

### DIFF
--- a/.claude/rules/terraform/terraform-git-hooks.md
+++ b/.claude/rules/terraform/terraform-git-hooks.md
@@ -22,7 +22,7 @@ You are a Git hook specialist. Your role is to establish local Git hook orchestr
 - Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.
 - Install hooks with `pre-commit install`.
 - Install the pre-push hook with `pre-commit install --hook-type pre-push`.
-- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `tfsec` from the hook configuration.
+- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
 - Keep `.terraform/`, state files, and plan files out of Git.
 - Keep the configuration current with `pre-commit autoupdate`.
 

--- a/.claude/rules/terraform/terraform-git-hooks.md
+++ b/.claude/rules/terraform/terraform-git-hooks.md
@@ -22,7 +22,7 @@ You are a Git hook specialist. Your role is to establish local Git hook orchestr
 - Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.
 - Install hooks with `pre-commit install`.
 - Install the pre-push hook with `pre-commit install --hook-type pre-push`.
-- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
+- Run `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
 - Keep `.terraform/`, state files, and plan files out of Git.
 - Keep the configuration current with `pre-commit autoupdate`.
 

--- a/.claude/rules/terraform/terraform-linting.md
+++ b/.claude/rules/terraform/terraform-linting.md
@@ -7,13 +7,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -21,15 +22,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -60,12 +62,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/.claude/rules/terraform/terraform-testing.md
+++ b/.claude/rules/terraform/terraform-testing.md
@@ -8,11 +8,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -23,7 +25,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -33,7 +39,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -41,7 +62,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/.codex/rules/terraform/terraform-git-hooks.md
+++ b/.codex/rules/terraform/terraform-git-hooks.md
@@ -22,7 +22,7 @@ You are a Git hook specialist. Your role is to establish local Git hook orchestr
 - Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.
 - Install hooks with `pre-commit install`.
 - Install the pre-push hook with `pre-commit install --hook-type pre-push`.
-- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `tfsec` from the hook configuration.
+- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
 - Keep `.terraform/`, state files, and plan files out of Git.
 - Keep the configuration current with `pre-commit autoupdate`.
 

--- a/.codex/rules/terraform/terraform-git-hooks.md
+++ b/.codex/rules/terraform/terraform-git-hooks.md
@@ -22,7 +22,7 @@ You are a Git hook specialist. Your role is to establish local Git hook orchestr
 - Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.
 - Install hooks with `pre-commit install`.
 - Install the pre-push hook with `pre-commit install --hook-type pre-push`.
-- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
+- Run `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.
 - Keep `.terraform/`, state files, and plan files out of Git.
 - Keep the configuration current with `pre-commit autoupdate`.
 

--- a/.codex/rules/terraform/terraform-linting.md
+++ b/.codex/rules/terraform/terraform-linting.md
@@ -7,13 +7,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -21,15 +22,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -60,12 +62,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/.codex/rules/terraform/terraform-testing.md
+++ b/.codex/rules/terraform/terraform-testing.md
@@ -8,11 +8,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -23,7 +25,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -33,7 +39,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -41,7 +62,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,31 @@
 # Product Requirements
 
+## Terraform Rule Best-Practices Alignment
+
+### Problem
+
+Ballast's Terraform linting and testing rules still describe an older validation baseline centered on `tfsec` and Terratest as optional add-ons. Terraform 1.6+ ships native tests, TFLint uses explicit provider/plugin configuration, tfsec has moved under Trivy, and many teams now need OpenTofu-compatible command guidance. Agents need generated Terraform rules that reflect those current practices without losing the conservative validation path for infrastructure changes.
+
+### Requirements
+
+1. Terraform linting guidance must keep `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, and recursive `tflint` as the baseline local and CI validation path.
+2. Terraform version guidance must keep `.terraform-version`/`tfenv` as the default Ballast path while allowing teams already standardized on `asdf` or `mise` to use those managers consistently.
+3. TFLint guidance must require `.tflint.hcl` plugin blocks for the active providers and `tflint --init` before recursive linting.
+4. Security scanning guidance must prefer `trivy config` for new work and describe `tfsec` as legacy-compatible because tfsec is now part of Trivy.
+5. Terraform testing guidance must document native `terraform test` for Terraform 1.6+ module assertions and Terratest for Go-backed or live integration tests.
+6. CI guidance for Terraform validation must include GitHub Actions `concurrency`, PR-time validation, plan/apply separation, and optional orchestration through Atlantis, Terraform Cloud, HCP Terraform, or OpenTofu-compatible platforms.
+7. OpenTofu guidance must acknowledge `tofu` as a compatible alternative when the repository standardizes on it, including `tofu fmt`, `tofu init -backend=false`, `tofu validate`, and `tofu test` equivalents.
+8. Terraform repo-layout guidance must prefer readable root files and independently testable modules without forcing a one-size-fits-all file split.
+
+### Acceptance Criteria
+
+1. Generated Terraform linting rules mention `trivy config` as the preferred new security scanner and `tfsec` as legacy-compatible.
+2. Generated Terraform linting rules require `.tflint.hcl` plugin blocks and `tflint --init` before recursive linting.
+3. Generated Terraform testing rules document native `terraform test` for Terraform 1.6+ and Terratest for Go-backed/live integration coverage.
+4. Generated Terraform testing rules include a GitHub Actions `concurrency` block and state that PR validation is separate from merge-gated apply workflows.
+5. Generated Terraform rules acknowledge OpenTofu command equivalents where relevant.
+6. Backend git-hook guidance no longer presents `tfsec` as the only Terraform security scanner.
+
 ## Ballast Local State Bootstrap And Repair
 
 ### Problem

--- a/agents/terraform/linting/content.md
+++ b/agents/terraform/linting/content.md
@@ -2,13 +2,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -16,15 +17,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -55,12 +57,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/agents/terraform/testing/content.md
+++ b/agents/terraform/testing/content.md
@@ -3,11 +3,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -18,7 +20,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -28,7 +34,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -36,7 +57,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/docs/agents/linting.md
+++ b/docs/agents/linting.md
@@ -20,9 +20,11 @@ The **linting** agent provides language-appropriate linting, formatting, and CI 
   - Guidance for inventories, role layout, and idempotent task design
 - **Terraform**
   - `terraform fmt -check -recursive` for formatting
-  - `terraform validate` and `tflint` for static validation
-  - `tfsec` or `trivy config` security checks
-  - `tfenv` guidance with `.terraform-version`
+  - `terraform init -backend=false`, `terraform validate`, and recursive `tflint` for static validation
+  - `.tflint.hcl` plugin blocks plus `tflint --init` for provider rules
+  - `trivy config` security checks, with `tfsec` only for legacy-compatible pipelines
+  - `tfenv` guidance with `.terraform-version`, or the repo's established `asdf`/`mise` standard
+  - OpenTofu equivalents such as `tofu fmt`, `tofu init -backend=false`, and `tofu validate` when the repo standardizes on `tofu`
 
 ## What It Provides
 
@@ -40,7 +42,7 @@ Recommended command set:
 - Python: `ruff check .` and `ruff format .`
 - Go: `gofmt -w .` and `golangci-lint run`
 - Ansible: `ansible-lint`, `yamllint .`, and `ansible-playbook --syntax-check site.yml`
-- Terraform: `tfenv install && tfenv use`, `terraform fmt -check -recursive`, `terraform validate`, `tflint --recursive`, and `tfsec .`
+- Terraform: `tfenv install && tfenv use`, `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .`
 
 ## Prompts to Improve Your App
 

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -22,8 +22,10 @@ The **testing** agent sets up and maintains test workflows for TypeScript, Pytho
   - Molecule or localhost playbook smoke tests for roles and inventories
 - **Terraform**
   - `terraform fmt -check -recursive` and `terraform validate`
-  - `tflint` and `tfsec`/`trivy config` for lint and security coverage
+  - `tflint` and `trivy config` for lint and security coverage, with `tfsec` only for legacy-compatible pipelines
   - `terraform init -backend=false` smoke setup plus plan-review guidance
+  - Native `terraform test` for Terraform 1.6+ module assertions and Terratest for Go-backed/live integration coverage
+  - OpenTofu equivalents such as `tofu test` when the repo standardizes on `tofu`
 
 ## What It Provides
 
@@ -51,7 +53,7 @@ Recommended baseline commands:
 - Python: `pytest`
 - Go: `go test ./...`
 - Ansible: `ansible-playbook --syntax-check site.yml` and `ansible-playbook --check --diff site.yml`
-- Terraform: `tfenv install && tfenv use`, `terraform init -backend=false`, `terraform validate`, `tflint --recursive`, and `tfsec .`
+- Terraform: `tfenv install && tfenv use`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, `trivy config .`, and `terraform test`
 
 ## Prompts to Improve Your App
 
@@ -63,4 +65,4 @@ Recommended baseline commands:
 - **"Add a smoke-test badge to the README"** — Status visibility
 - **"Add one stable end-to-end test for the login flow"** — Critical-path E2E
 - **"Add Ansible syntax-check and check-mode validation to CI"** — Infrastructure safety
-- **"Add Terraform validate, tflint, and tfsec to CI with tfenv version pinning"** — Terraform safety
+- **"Add Terraform validate, tflint, Trivy config scanning, and terraform test to CI with tfenv version pinning"** — Terraform safety

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -53,7 +53,7 @@ Recommended baseline commands:
 - Python: `pytest`
 - Go: `go test ./...`
 - Ansible: `ansible-playbook --syntax-check site.yml` and `ansible-playbook --check --diff site.yml`
-- Terraform: `tfenv install && tfenv use`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, `trivy config .`, and `terraform test`
+- Terraform: `tfenv install && tfenv use`, `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, `trivy config .`, and `terraform test`
 
 ## Prompts to Improve Your App
 

--- a/packages/ballast-go/cmd/ballast-go/agents/terraform/linting/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/terraform/linting/content.md
@@ -2,13 +2,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -16,15 +17,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -55,12 +57,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/packages/ballast-go/cmd/ballast-go/agents/terraform/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/terraform/testing/content.md
@@ -3,11 +3,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -18,7 +20,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -28,7 +34,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -36,7 +57,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -2124,7 +2124,7 @@ func renderGitHooksGuidance(language, hookMode string) string {
 			"- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.",
 			"- Install hooks with `pre-commit install`.",
 			"- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-			"- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
+			"- Run `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
 			"- Keep `.terraform/`, state files, and plan files out of Git.",
 			"- Keep the configuration current with `pre-commit autoupdate`.",
 		}, "\n")

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -2124,7 +2124,7 @@ func renderGitHooksGuidance(language, hookMode string) string {
 			"- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.",
 			"- Install hooks with `pre-commit install`.",
 			"- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-			"- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `tfsec` from the hook configuration.",
+			"- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
 			"- Keep `.terraform/`, state files, and plan files out of Git.",
 			"- Keep the configuration current with `pre-commit autoupdate`.",
 		}, "\n")

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -489,8 +489,51 @@ func TestInstallSupportsTerraformLanguageProfile(t *testing.T) {
 	if !strings.Contains(text, "Terraform linting specialist") {
 		t.Fatalf("expected terraform linting content, got %q", text)
 	}
-	if !strings.Contains(text, ".terraform-version") || !strings.Contains(text, "tfenv install") || !strings.Contains(text, "tfsec") {
+	if !strings.Contains(text, ".terraform-version") ||
+		!strings.Contains(text, "tfenv install") ||
+		!strings.Contains(text, "trivy config") ||
+		!strings.Contains(text, "tfsec") ||
+		!strings.Contains(text, "plugin blocks") ||
+		!strings.Contains(text, "tflint --init") ||
+		!strings.Contains(text, "OpenTofu") ||
+		!strings.Contains(text, "tofu fmt") {
 		t.Fatalf("expected terraform hook and tooling guidance, got %q", text)
+	}
+}
+
+func TestInstallSupportsTerraformTestingBestPractices(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"codex"},
+		agents:      []string{"testing"},
+		language:    "terraform",
+	})
+	if len(result.errors) > 0 {
+		t.Fatalf("unexpected install errors: %+v", result.errors)
+	}
+	if !slices.Contains(result.installed, "testing") {
+		t.Fatalf("expected terraform testing install, got %+v", result.installed)
+	}
+
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".codex", "rules", "terraform-testing.md"))
+	if err != nil {
+		t.Fatalf("expected terraform-testing.md to exist: %v", err)
+	}
+	text := string(content)
+	for _, want := range []string{
+		"terraform test",
+		"Terraform 1.6",
+		"Terratest",
+		"concurrency:",
+		"PR validation",
+		"OpenTofu",
+		"tofu test",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected terraform testing content to mention %q, got %q", want, text)
+		}
 	}
 }
 
@@ -505,7 +548,9 @@ func TestRenderGitHooksContentSupportsTerraform(t *testing.T) {
 	if !strings.Contains(got, "tfenv install") {
 		t.Fatalf("expected terraform git-hooks content to mention tfenv install, got %q", got)
 	}
-	if !strings.Contains(got, "terraform fmt -check -recursive") || !strings.Contains(got, "tfsec") {
+	if !strings.Contains(got, "terraform fmt -check -recursive") ||
+		!strings.Contains(got, "trivy config") ||
+		!strings.Contains(got, "tfsec") {
 		t.Fatalf("expected terraform git-hooks content to mention terraform checks, got %q", got)
 	}
 }

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -549,7 +549,11 @@ func TestRenderGitHooksContentSupportsTerraform(t *testing.T) {
 		t.Fatalf("expected terraform git-hooks content to mention tfenv install, got %q", got)
 	}
 	if !strings.Contains(got, "terraform fmt -check -recursive") ||
-		!strings.Contains(got, "trivy config") ||
+		!strings.Contains(got, "terraform init -backend=false") ||
+		!strings.Contains(got, "terraform validate") ||
+		!strings.Contains(got, "tflint --init") ||
+		!strings.Contains(got, "tflint --recursive") ||
+		!strings.Contains(got, "trivy config .") ||
 		!strings.Contains(got, "tfsec") {
 		t.Fatalf("expected terraform git-hooks content to mention terraform checks, got %q", got)
 	}

--- a/packages/ballast-go/cmd/ballast/agents/terraform/linting/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/terraform/linting/content.md
@@ -2,13 +2,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -16,15 +17,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -55,12 +57,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/packages/ballast-go/cmd/ballast/agents/terraform/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/terraform/testing/content.md
@@ -3,11 +3,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -18,7 +20,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -28,7 +34,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -36,7 +57,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/packages/ballast-python/ballast/agents/terraform/linting/content.md
+++ b/packages/ballast-python/ballast/agents/terraform/linting/content.md
@@ -2,13 +2,14 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 
 ## Your Responsibilities
 
-1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version.
+1. Pin the Terraform CLI version with `tfenv` and commit `.terraform-version` so local, CI, and review workflows use the same version. If the repo already standardizes on `asdf` or `mise`, keep that manager consistent instead of adding a second version manager.
 2. Add `terraform fmt -check -recursive` as the baseline formatting gate and keep HCL style consistent.
-3. Add `terraform validate` and `tflint` for syntax, provider, and static-analysis checks.
-4. Add security checks with `tfsec` or `trivy config` and make them part of the standard validation path.
-5. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
-6. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
-7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+3. Run `terraform init -backend=false` before `terraform validate` so validation can install providers without touching remote state.
+4. Add `tflint` with `.tflint.hcl` plugin blocks for the active cloud providers or module rules, then run `tflint --init` before recursive linting.
+5. Prefer `trivy config` for new security-scanning work. Keep `tfsec` only when an existing repo or CI pipeline still depends on it, because tfsec is now part of Trivy.
+6. Keep Terraform code modular, typed, and explicit: variables with types, outputs with descriptions where useful, and provider/version constraints in `versions.tf`.
+7. Prefer remote state, locked provider versions, least-privilege IAM, and secret-free code checked into Git.
+8. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
 
 ## Baseline Tooling
 
@@ -16,15 +17,16 @@ You are a Terraform linting specialist. Your role is to establish a clean, repea
 - `terraform fmt`
 - `terraform validate`
 - `tflint`
-- `tfsec` or `trivy config`
+- `trivy config`
+- `tfsec` for legacy-compatible pipelines
 
 ## Implementation Order
 
-1. Detect the repo shape and standardize it around `main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `versions.tf`, and `.terraform-version`.
+1. Detect the repo shape and keep it readable with root files such as `versions.tf`, `providers.tf`, `main.tf`, `variables.tf`, and `outputs.tf` where that split helps review. Do not force the split when an existing module layout is already clear.
 2. Add or update `.terraform-version` and document `tfenv install` plus `tfenv use`.
-3. Add or update `.tflint.hcl` when provider or module rules need tuning.
-4. Add CI lint and security commands.
-5. Run format, validate, lint, and security checks.
+3. Add or update `.tflint.hcl` with provider-specific plugin blocks, for example `plugin "aws"`, `plugin "azurerm"`, or `plugin "google"` with pinned versions and sources.
+4. Add CI lint and security commands with workflow `concurrency` so redundant validation runs for the same ref are cancelled.
+5. Run format, backend-free init, validate, lint, and security checks.
 
 ## Example Layout
 
@@ -55,12 +57,21 @@ That layout keeps the project easy to review:
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+
+For OpenTofu repositories, use the equivalent commands and keep the repo standardized on one CLI:
+
+- `tofu fmt -check -recursive`
+- `tofu init -backend=false`
+- `tofu validate`
+- `tofu test` when native tests exist
 
 ## Important Notes
 
 - Commit `.terraform-version` and keep it aligned with `required_version` in `versions.tf`.
 - Run `terraform fmt` before asking CI to validate formatting drift.
+- Run `tflint --init` after changing `.tflint.hcl` plugin blocks or plugin versions.
 - Keep provider constraints explicit and avoid unbounded major-version upgrades.
 - Use typed variables and validation blocks for inputs that have strict formats.
 - Prefer modules over copy-pasted resources when a pattern repeats.

--- a/packages/ballast-python/ballast/agents/terraform/testing/content.md
+++ b/packages/ballast-python/ballast/agents/terraform/testing/content.md
@@ -3,11 +3,13 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 ## Your Responsibilities
 
 1. Add `terraform fmt -check -recursive` and `terraform validate` as the minimum validation path.
-2. Add `tflint` and a security scanner such as `tfsec` or `trivy config` to CI and local checks.
+2. Add `tflint` and a security scanner, preferring `trivy config` for new work and keeping `tfsec` only for legacy-compatible pipelines.
 3. Ensure `tfenv` is part of the documented setup so validation runs against the intended Terraform version.
 4. Add a smoke path that runs `terraform init -backend=false` before validation.
-5. Make plan generation a review step for live environments and keep apply workflows separate from validation.
-6. Fail CI on formatting, validation, lint, or security regressions.
+5. Add native `terraform test` coverage for Terraform 1.6+ modules that can assert plan or apply behavior with `.tftest.hcl` files.
+6. Use Terratest when the repo already has Go-based infrastructure tests or needs live integration coverage outside native test assertions.
+7. Make plan generation a review step for live environments and keep apply workflows separate from validation.
+8. Fail CI on formatting, validation, lint, test, or security regressions.
 
 ## Baseline Commands
 
@@ -18,7 +20,11 @@ You are a Terraform testing specialist. Your role is to set up reliable validati
 - `terraform validate`
 - `tflint --init`
 - `tflint --recursive`
-- `tfsec .`
+- `trivy config .`
+- `tfsec .` when preserving a legacy pipeline
+- `terraform test`
+
+For OpenTofu repositories, use equivalent commands such as `tofu fmt -check -recursive`, `tofu init -backend=false`, `tofu validate`, and `tofu test`.
 
 ## Example Coverage
 
@@ -28,7 +34,22 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - validate root modules and representative child modules
 - lint recursively with `tflint`
 - run a security scan over the full tree
+- run native `terraform test` for modules with `.tftest.hcl` or `.tftest.json` tests
 - generate a plan in non-production environments before any apply workflow
+
+## CI Placement
+
+PR validation should be read-only and include formatting, backend-free initialization, validation, TFLint, security scanning, and native tests where present.
+
+```yaml
+concurrency:
+  group: terraform-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Keep apply workflows merge-gated, environment-protected, and separate from PR validation. Use a saved plan only within the same trusted workflow context, never as a committed artifact.
+
+Atlantis, Terraform Cloud, HCP Terraform, and OpenTofu-compatible orchestration platforms are acceptable when the repository already uses them; keep Ballast guidance aligned with that orchestrator's plan/apply separation and approval model.
 
 ## Important Notes
 
@@ -36,7 +57,8 @@ Use a root Terraform project with pinned versions and a lightweight module struc
 - Keep plan files out of Git and treat them as transient artifacts.
 - Prefer environment-specific `tfvars` files or workspace wiring over hand-edited resource blocks.
 - Security scanners are noisy when providers are misconfigured; fix the provider and version baseline before suppressing findings.
-- For shared modules, consider Terratest or example-module smoke tests when the repo already has Go-based test infrastructure.
+- Prefer native `terraform test` for module contract tests in Terraform 1.6+ and use `command = plan` when a test should avoid creating real infrastructure.
+- For shared modules, use Terratest or example-module smoke tests when the repo already has Go-based test infrastructure or needs live integration coverage.
 
 ## When Completed
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -708,7 +708,7 @@ def render_git_hooks_guidance(language: str, hook_mode: str) -> str:
                 "- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.",
                 "- Install hooks with `pre-commit install`.",
                 "- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-                "- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
+                "- Run `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
                 "- Keep `.terraform/`, state files, and plan files out of Git.",
                 "- Keep the configuration current with `pre-commit autoupdate`.",
             ]

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -708,7 +708,7 @@ def render_git_hooks_guidance(language: str, hook_mode: str) -> str:
                 "- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.",
                 "- Install hooks with `pre-commit install`.",
                 "- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-                "- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `tfsec` from the hook configuration.",
+                "- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.",
                 "- Keep `.terraform/`, state files, and plan files out of Git.",
                 "- Keep the configuration current with `pre-commit autoupdate`.",
             ]

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -1004,6 +1004,18 @@ Keep team-specific usage notes.
             self.assertIn("pre-commit install --hook-type pre-push", content)
             self.assertIn("ansible-playbook --syntax-check", content)
 
+    def test_render_terraform_git_hooks_guidance_uses_initialized_commands(
+        self,
+    ) -> None:
+        content = cli.render_git_hooks_guidance("terraform", "pre-commit")
+        self.assertIn("terraform fmt -check -recursive", content)
+        self.assertIn("terraform init -backend=false", content)
+        self.assertIn("terraform validate", content)
+        self.assertIn("tflint --init", content)
+        self.assertIn("tflint --recursive", content)
+        self.assertIn("trivy config .", content)
+        self.assertIn("tfsec", content)
+
     def test_patch_preserves_existing_sections(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -375,6 +375,39 @@ class PatchInstallTests(unittest.TestCase):
             self.assertIn("Terraform linting specialist", content)
             self.assertIn(".terraform-version", content)
             self.assertIn("tfenv install", content)
+            self.assertIn("trivy config", content)
+            self.assertIn("tfsec", content)
+            self.assertIn("plugin blocks", content)
+            self.assertIn("tflint --init", content)
+            self.assertIn("OpenTofu", content)
+            self.assertIn("tofu fmt", content)
+
+    def test_install_supports_terraform_testing_best_practices(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            result = cli.install(
+                root,
+                "codex",
+                ["testing"],
+                [],
+                "terraform",
+                False,
+                False,
+                False,
+            )
+
+            self.assertIn("testing", result.installed)
+            rule = root / ".codex" / "rules" / "terraform-testing.md"
+            self.assertTrue(rule.exists())
+            content = rule.read_text(encoding="utf-8")
+            self.assertIn("terraform test", content)
+            self.assertIn("Terraform 1.6", content)
+            self.assertIn("Terratest", content)
+            self.assertIn("concurrency:", content)
+            self.assertIn("PR validation", content)
+            self.assertIn("OpenTofu", content)
+            self.assertIn("tofu test", content)
 
     def test_install_creates_skill_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -311,6 +311,17 @@ describe('build', () => {
       expect(content).toContain('pre-commit autoupdate');
     });
 
+    test('returns initialized terraform git-hooks command guidance', () => {
+      const content = getContent('git-hooks', undefined, 'terraform');
+      expect(content).toContain('terraform fmt -check -recursive');
+      expect(content).toContain('terraform init -backend=false');
+      expect(content).toContain('terraform validate');
+      expect(content).toContain('tflint --init');
+      expect(content).toContain('tflint --recursive');
+      expect(content).toContain('trivy config .');
+      expect(content).toContain('tfsec');
+    });
+
     test('returns husky git-hooks content for typescript', () => {
       const content = getContent('git-hooks', undefined, 'typescript', {
         hookMode: 'husky'

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -186,7 +186,7 @@ function renderGitHooksGuidance(
       '- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.',
       '- Install hooks with `pre-commit install`.',
       '- Install the pre-push hook with `pre-commit install --hook-type pre-push`.',
-      '- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.',
+      '- Run `terraform fmt -check -recursive`, `terraform init -backend=false`, `terraform validate`, `tflint --init`, `tflint --recursive`, and `trivy config .` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.',
       '- Keep `.terraform/`, state files, and plan files out of Git.',
       '- Keep the configuration current with `pre-commit autoupdate`.'
     ].join('\n');

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -186,7 +186,7 @@ function renderGitHooksGuidance(
       '- Commit `.terraform-version` and use `tfenv install` plus `tfenv use` before running Terraform commands.',
       '- Install hooks with `pre-commit install`.',
       '- Install the pre-push hook with `pre-commit install --hook-type pre-push`.',
-      '- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `tfsec` from the hook configuration.',
+      '- Run `terraform fmt -check -recursive`, `terraform validate`, `tflint`, and `trivy config` from the hook configuration; keep `tfsec` only for legacy-compatible pipelines.',
       '- Keep `.terraform/`, state files, and plan files out of Git.',
       '- Keep the configuration current with `pre-commit autoupdate`.'
     ].join('\n');

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -948,7 +948,41 @@ This section should be gone after force.
       expect(content).toContain('.terraform-version');
       expect(content).toContain('tfenv install');
       expect(content).toContain('terraform fmt -check -recursive');
+      expect(content).toContain('trivy config');
       expect(content).toContain('tfsec');
+      expect(content).toContain('plugin blocks');
+      expect(content).toContain('tflint --init');
+      expect(content).toContain('OpenTofu');
+      expect(content).toContain('tofu fmt');
+    });
+
+    test('writes terraform testing rules with native tests and CI guidance', () => {
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'codex',
+        agents: ['testing'],
+        language: 'terraform',
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installed).toContain('testing');
+      const ruleFile = path.join(
+        tmpDir,
+        '.codex',
+        'rules',
+        'terraform-testing.md'
+      );
+      expect(fs.existsSync(ruleFile)).toBe(true);
+      const content = fs.readFileSync(ruleFile, 'utf8');
+      expect(content).toContain('terraform test');
+      expect(content).toContain('Terraform 1.6');
+      expect(content).toContain('Terratest');
+      expect(content).toContain('concurrency:');
+      expect(content).toContain('PR validation');
+      expect(content).toContain('apply');
+      expect(content).toContain('OpenTofu');
+      expect(content).toContain('tofu test');
     });
 
     test('uses husky guidance for typescript-only installs', () => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,15 @@
 # Tasks
 
+- [x] Confirm issue #160 scope, operating mode, and Terraform/OpenTofu tooling sources.
+- [x] Add PRD requirements for Terraform linting, testing, CI, security scanner, and OpenTofu guidance.
+- [x] Add failing generated-content coverage for Terraform best-practice guidance.
+- [x] Update canonical Terraform rule content, docs, and backend git-hook snippets.
+- [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
+- [x] Run focused tests and required sync/generation checks.
+- [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
+
+## Previous Tasks
+
 - [x] Confirm issue #215 broader deployment-model scope, operating mode, and PRD requirements.
 - [x] Add PRD requirements for deployment model prompts, flags, persistence, doctor output, and publishing guidance.
 - [x] Add failing tests for deployment model config parsing, CLI flags, install prompting, wrapper forwarding, and doctor output.
@@ -8,8 +18,6 @@
 - [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
 - [x] Run focused tests and required sync/generation checks.
 - [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
-
-## Previous Tasks
 
 - [x] Confirm issue #214 scope, approval, and coordination boundary with #145.
 - [x] Add PRD requirements for web smoke/E2E and CLI packaged-command smoke guidance.


### PR DESCRIPTION
## Summary
- Updates Terraform linting/testing guidance for Trivy-first security scanning, TFLint plugin initialization, native terraform test, OpenTofu equivalents, and CI plan/apply separation.
- Syncs Terraform rule content into package mirrors and checked-in Claude/Codex generated outputs.
- Adds TypeScript, Python, and Go coverage for the updated Terraform guidance.

Closes #160.

## Verification
- pnpm --filter @everydaydevopsio/ballast test -- install.test.ts --runInBand
- uv run python -m unittest tests.test_cli
- go test . (packages/ballast-go/cmd/ballast-go)
- pnpm --filter @everydaydevopsio/ballast test -- repo-generated-artifacts.test.ts --runInBand
- pnpm --filter @everydaydevopsio/ballast run build
- git push pre-push hook passed

## Note
- pnpm prettier --check remains blocked on main by existing repo-wide formatter/template issues; follow-up branch will address that separately.