### PR TITLE
Fix TypeScript package prettier check blockers

### DIFF
--- a/packages/ballast-typescript/.prettierignore
+++ b/packages/ballast-typescript/.prettierignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+coverage
+.pytest_cache
+.claude
+agents
+skills
+*.log
+.DS_Store

--- a/packages/ballast-typescript/.prettierignore
+++ b/packages/ballast-typescript/.prettierignore
@@ -1,7 +1,6 @@
 node_modules
 dist
 coverage
-.pytest_cache
 .claude
 agents
 skills


### PR DESCRIPTION
## Summary
- Adds a package-local Prettier ignore file for the TypeScript package.
- Excludes generated payload mirrors and build/cache output from the package-level Prettier check.
- Allows the repo-level pnpm prettier --check command to complete successfully.

## Verification
- pnpm prettier --check
- git push pre-push hook passed