### PR TITLE
Fix required option prompts and support file patching

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -147,7 +147,7 @@ Ballast does not apply the same overwrite decision matrix to installed skill fil
 4. `--force` must prompt before replacing an existing support file (`AGENTS.md`, `CLAUDE.md`, or `GEMINI.md`) that would lose user customizations.
 5. In non-interactive mode (`--yes` or CI environment variables), an attempted `--force` overwrite of an existing support file must fail with a clear error telling the operator to rerun interactively without `--yes`.
 6. Creating a missing support file with `--force` must continue without prompting.
-7. Support-file patch behavior and existing agent-rule overwrite semantics must remain unchanged.
+7. Existing support files must be patched by default when `--force` is not set, updating only Ballast-managed installed-rule and installed-skill sections while preserving user-managed sections.
 8. README and installation documentation must describe the updated `--patch` and `--force` behavior.
 9. If an existing Claude `.skill` archive is unreadable during `--patch`, install must recover by overwriting it with canonical packaged skill content instead of failing the run.
 
@@ -161,8 +161,29 @@ Ballast does not apply the same overwrite decision matrix to installed skill fil
 6. Given an existing support file and interactive `--force`, answering yes overwrites the support file with canonical content.
 7. Given an existing support file and non-interactive `--force`, install exits with an error and does not overwrite the file.
 8. Automated tests cover the skill-file decision matrix and support-file confirmation behavior in the TypeScript, Python, and Go backends.
-9. README and `docs/installation.md` describe when to use `--patch` versus `--force`, including the support-file confirmation behavior.
+9. README and `docs/installation.md` describe when support files are patched by default and when to use `--patch` versus `--force`, including the support-file confirmation behavior.
 10. Given an existing unreadable Claude `.skill` archive and `force=false, patch=true`, install replaces it with canonical content and completes without an install error.
+
+## Required Agent Option Resolution
+
+### Problem
+
+Some agents require repo-level option values before rule content is generated. Wrapper-driven installs resolved publishing deployment model differently from the tasks task system, so first-run installs with `--all` could prompt for publishing while silently defaulting tasks when no `.rulesrc.json` existed.
+
+### Requirements
+
+1. Wrapper-driven installs must resolve required options through one shared code path.
+2. When `tasks` is selected and `.rulesrc.json` has no `taskSystem`, interactive installs must prompt for the task system and non-interactive installs must use the default.
+3. When `publishing` is selected and `.rulesrc.json` has no `deploymentModel`, interactive installs must prompt for the deployment model and non-interactive installs must use the default.
+4. Explicit CLI flags must override saved config and prompted/default values.
+5. Resolved values must be saved to `.rulesrc.json` and forwarded to backend invocations.
+
+### Acceptance Criteria
+
+1. Given a first-run multi-language install with `--all`, Ballast prompts for both task system and deployment model.
+2. Given saved values in `.rulesrc.json`, Ballast does not prompt and reuses the saved values.
+3. Given `--yes` or CI, Ballast uses defaults for missing selected-agent options.
+4. Tests cover first-run prompt resolution and backend argument forwarding.
 
 ## Ballast Upgrade Skill Refresh
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Recommended order for one repository that uses all five language profiles:
 4. If the repo also contains Ansible, run `ballast-go install --language ansible --target cursor --all`.
 5. If the repo also contains Terraform, run `ballast-go install --language terraform --target cursor --all`.
 
-Ballast only installs shipped agents and skills and follows the single overwrite policy: existing rule and skill files are preserved unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set, updating only Ballast-managed installed-rule and installed-skill sections.
+Ballast only installs shipped agents and skills and follows the single overwrite policy: existing rule and skill files are preserved unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set, updating only installed-rule and installed-skill sections that include the Ballast-managed notice. Older or customized support-file sections without that notice are preserved unless you use `--patch` or confirm the interactive patch prompt.
 
 Use `--patch` when you want to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
 
@@ -330,7 +330,7 @@ Use `--force` when you want to reset a managed rule or skill file to canonical B
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
-When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` uses defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` and CI mode use defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
 
 ## Wrapper Commands
 

--- a/README.md
+++ b/README.md
@@ -325,12 +325,12 @@ Use `--force` when you want to reset a managed rule or skill file to canonical B
 - `--all`: install all agents for the selected language
 - `--all-skills`: install all available skills for the selected language
 - `--task-system`: task system for the tasks agent: `github`, `jira`, or `linear`
-- `--deployment-model`: deployment model for the publishing agent: `none`, `kubernetes`, `serverless`, `server`, or `hosted`
+- `--deployment-model`: app/service deployment model for publishing: `none`, `kubernetes`, `serverless`, `server`, or `hosted`; use `none` for CLI, library, or SDK-only projects
 - `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
-When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and `deploymentModel`; `--yes` uses defaults.
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` uses defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
 
 ## Wrapper Commands
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Recommended order for one repository that uses all five language profiles:
 4. If the repo also contains Ansible, run `ballast-go install --language ansible --target cursor --all`.
 5. If the repo also contains Terraform, run `ballast-go install --language terraform --target cursor --all`.
 
-Ballast only installs shipped agents and skills and follows the single overwrite policy: existing rule and skill files are preserved unless you explicitly choose `--patch` or `--force`.
+Ballast only installs shipped agents and skills and follows the single overwrite policy: existing rule and skill files are preserved unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set, updating only Ballast-managed installed-rule and installed-skill sections.
 
 Use `--patch` when you want to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
 
@@ -324,9 +324,13 @@ Use `--force` when you want to reset a managed rule or skill file to canonical B
 - `--skill, -s`: comma-separated skill list
 - `--all`: install all agents for the selected language
 - `--all-skills`: install all available skills for the selected language
+- `--task-system`: task system for the tasks agent: `github`, `jira`, or `linear`
+- `--deployment-model`: deployment model for the publishing agent: `none`, `kubernetes`, `serverless`, `server`, or `hosted`
 - `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
+
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and `deploymentModel`; `--yes` uses defaults.
 
 ## Wrapper Commands
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -2152,11 +2152,26 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		return nil, nil
 	}
 
-	requestedTaskSystem, err := parseTaskSystemFlag(args)
+	taskSystemOption := requiredInstallOption{
+		FieldName:    "taskSystem",
+		FlagName:     "--task-system",
+		PromptLabel:  "Task system for tasks",
+		Allowed:      supportedTaskSystems,
+		DefaultValue: "github",
+	}
+	deploymentModelOption := requiredInstallOption{
+		FieldName:    "deploymentModel",
+		FlagName:     "--deployment-model",
+		PromptLabel:  "Deployment model for publishing apps",
+		Allowed:      supportedDeploymentModels,
+		DefaultValue: "none",
+	}
+
+	requestedTaskSystem, err := parseRequiredInstallOptionFlag(args, taskSystemOption)
 	if err != nil {
 		return nil, err
 	}
-	requestedDeploymentModel, err := parseDeploymentModelFlag(args)
+	requestedDeploymentModel, err := parseRequiredInstallOptionFlag(args, deploymentModelOption)
 	if err != nil {
 		return nil, err
 	}
@@ -2278,19 +2293,25 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		return nil, err
 	}
 
-	var savedTaskSystem string
-	if config != nil {
-		savedTaskSystem = config.TaskSystem
+	savedTaskSystem, err := resolveRequiredInstallOption(requiredInstallOptionResolution{
+		Option:         taskSystemOption,
+		Requested:      requestedTaskSystem,
+		Saved:          configValue(config, taskSystemOption.FieldName),
+		Selected:       slices.Contains(persistAgents, "tasks"),
+		NonInteractive: !isInteractiveInstall(args),
+	})
+	if err != nil {
+		return nil, err
 	}
-	if requestedTaskSystem != "" {
-		savedTaskSystem = requestedTaskSystem
-	}
-	var savedDeploymentModel string
-	if config != nil {
-		savedDeploymentModel = config.DeploymentModel
-	}
-	if requestedDeploymentModel != "" {
-		savedDeploymentModel = requestedDeploymentModel
+	savedDeploymentModel, err := resolveRequiredInstallOption(requiredInstallOptionResolution{
+		Option:         deploymentModelOption,
+		Requested:      requestedDeploymentModel,
+		Saved:          configValue(config, deploymentModelOption.FieldName),
+		Selected:       slices.Contains(persistAgents, "publishing"),
+		NonInteractive: !isInteractiveInstall(args),
+	})
+	if err != nil {
+		return nil, err
 	}
 	configToSave := monorepoConfig{
 		Targets:         savedTargets,
@@ -2326,11 +2347,11 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	baseArgs := withTargetSelection(stripMonorepoFlags(args), requestedTargets)
 	plan := make([]backendInvocation, 0, len(profiles)+1)
 	commonArgs := withSkillSelection(withAgentSelection(baseArgs, commonSelection), selectedSkills)
-	if requestedTaskSystem != "" && slices.Contains(configToSave.Agents, "tasks") {
-		commonArgs = append(commonArgs, "--task-system", requestedTaskSystem)
+	if savedTaskSystem != "" && slices.Contains(configToSave.Agents, "tasks") {
+		commonArgs = append(commonArgs, "--task-system", savedTaskSystem)
 	}
-	if requestedDeploymentModel != "" && slices.Contains(configToSave.Agents, "publishing") {
-		commonArgs = append(commonArgs, "--deployment-model", requestedDeploymentModel)
+	if savedDeploymentModel != "" && slices.Contains(configToSave.Agents, "publishing") {
+		commonArgs = append(commonArgs, "--deployment-model", savedDeploymentModel)
 	}
 	if len(commonSelection) > 0 || len(selectedSkills) > 0 {
 		commonLanguage := profiles[0].Language
@@ -2339,7 +2360,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		}
 		tool := toolsByLanguage[commonLanguage]
 		env := monorepoInvocationEnv("common")
-		if requestedTaskSystem != "" && slices.Contains(commonSelection, "tasks") {
+		if savedTaskSystem != "" && slices.Contains(commonSelection, "tasks") && savedTaskSystem != configValue(config, taskSystemOption.FieldName) {
 			env["BALLAST_REFRESH_TASK_RULES"] = "1"
 		}
 		plan = append(plan, backendInvocation{
@@ -2662,58 +2683,59 @@ func splitAgentValues(raw string) []string {
 	return agents
 }
 
+type requiredInstallOption struct {
+	FieldName    string
+	FlagName     string
+	PromptLabel  string
+	Allowed      []string
+	DefaultValue string
+}
+
+type requiredInstallOptionResolution struct {
+	Option         requiredInstallOption
+	Requested      string
+	Saved          string
+	Selected       bool
+	NonInteractive bool
+}
+
 func parseTaskSystemFlag(args []string) (string, error) {
-	raw := ""
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if strings.HasPrefix(arg, "--task-system=") {
-			raw = strings.TrimSpace(strings.TrimPrefix(arg, "--task-system="))
-			continue
-		}
-		if arg != "--task-system" {
-			continue
-		}
-		if i+1 >= len(args) {
-			return "", errors.New("missing value for --task-system")
-		}
-		candidate := strings.TrimSpace(args[i+1])
-		if candidate == "" || strings.HasPrefix(candidate, "-") {
-			return "", errors.New("missing value for --task-system")
-		}
-		raw = candidate
-		i++
-	}
-	if raw == "" {
-		return "", nil
-	}
-	normalized := strings.ToLower(raw)
-	if slices.Contains(supportedTaskSystems, normalized) {
-		return normalized, nil
-	}
-	return "", fmt.Errorf(
-		"invalid --task-system: %s (valid: %s)",
-		raw,
-		strings.Join(supportedTaskSystems, ", "),
-	)
+	return parseRequiredInstallOptionFlag(args, requiredInstallOption{
+		FieldName:    "taskSystem",
+		FlagName:     "--task-system",
+		PromptLabel:  "Task system for tasks",
+		Allowed:      supportedTaskSystems,
+		DefaultValue: "github",
+	})
 }
 
 func parseDeploymentModelFlag(args []string) (string, error) {
+	return parseRequiredInstallOptionFlag(args, requiredInstallOption{
+		FieldName:    "deploymentModel",
+		FlagName:     "--deployment-model",
+		PromptLabel:  "Deployment model for publishing apps",
+		Allowed:      supportedDeploymentModels,
+		DefaultValue: "none",
+	})
+}
+
+func parseRequiredInstallOptionFlag(args []string, option requiredInstallOption) (string, error) {
 	raw := ""
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if strings.HasPrefix(arg, "--deployment-model=") {
-			raw = strings.TrimSpace(strings.TrimPrefix(arg, "--deployment-model="))
+		if strings.HasPrefix(arg, option.FlagName+"=") {
+			raw = strings.TrimSpace(strings.TrimPrefix(arg, option.FlagName+"="))
 			continue
 		}
-		if arg != "--deployment-model" {
+		if arg != option.FlagName {
 			continue
 		}
 		if i+1 >= len(args) {
-			return "", errors.New("missing value for --deployment-model")
+			return "", fmt.Errorf("missing value for %s", option.FlagName)
 		}
 		candidate := strings.TrimSpace(args[i+1])
 		if candidate == "" || strings.HasPrefix(candidate, "-") {
-			return "", errors.New("missing value for --deployment-model")
+			return "", fmt.Errorf("missing value for %s", option.FlagName)
 		}
 		raw = candidate
 		i++
@@ -2722,14 +2744,76 @@ func parseDeploymentModelFlag(args []string) (string, error) {
 		return "", nil
 	}
 	normalized := strings.ToLower(raw)
-	if slices.Contains(supportedDeploymentModels, normalized) {
+	if slices.Contains(option.Allowed, normalized) {
 		return normalized, nil
 	}
 	return "", fmt.Errorf(
-		"invalid --deployment-model: %s (valid: %s)",
+		"invalid %s: %s (valid: %s)",
+		option.FlagName,
 		raw,
-		strings.Join(supportedDeploymentModels, ", "),
+		strings.Join(option.Allowed, ", "),
 	)
+}
+
+func resolveRequiredInstallOption(resolution requiredInstallOptionResolution) (string, error) {
+	if resolution.Requested != "" {
+		return resolution.Requested, nil
+	}
+	saved := strings.ToLower(strings.TrimSpace(resolution.Saved))
+	if saved != "" {
+		if slices.Contains(resolution.Option.Allowed, saved) {
+			return saved, nil
+		}
+		return "", fmt.Errorf(
+			"invalid %s %q; use one of: %s",
+			resolution.Option.FieldName,
+			resolution.Saved,
+			strings.Join(resolution.Option.Allowed, ", "),
+		)
+	}
+	if !resolution.Selected {
+		return "", nil
+	}
+	if resolution.NonInteractive {
+		return resolution.Option.DefaultValue, nil
+	}
+	return promptRequiredInstallOption(resolution.Option)
+}
+
+func promptRequiredInstallOption(option requiredInstallOption) (string, error) {
+	allowed := strings.Join(option.Allowed, ", ")
+	for {
+		fmt.Printf("%s [%s] (default: %s): ", option.PromptLabel, allowed, option.DefaultValue)
+		var response string
+		if _, err := fmt.Scanln(&response); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || strings.Contains(err.Error(), "unexpected newline") || strings.Contains(err.Error(), "expected newline") {
+				return option.DefaultValue, nil
+			}
+			return "", err
+		}
+		value := strings.ToLower(strings.TrimSpace(response))
+		if value == "" {
+			return option.DefaultValue, nil
+		}
+		if slices.Contains(option.Allowed, value) {
+			return value, nil
+		}
+		fmt.Printf("Invalid %s. Choose one of: %s\n", option.FieldName, allowed)
+	}
+}
+
+func configValue(config *monorepoConfig, field string) string {
+	if config == nil {
+		return ""
+	}
+	switch field {
+	case "taskSystem":
+		return config.TaskSystem
+	case "deploymentModel":
+		return config.DeploymentModel
+	default:
+		return ""
+	}
 }
 
 func findFlagValue(args []string, longFlag string, shortFlag string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -2175,6 +2176,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	if err != nil {
 		return nil, err
 	}
+	promptReader := bufio.NewReader(os.Stdin)
 
 	config, err := loadMonorepoConfig(root)
 	if err != nil {
@@ -2299,6 +2301,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		Saved:          configValue(config, taskSystemOption.FieldName),
 		Selected:       slices.Contains(persistAgents, "tasks"),
 		NonInteractive: !isInteractiveInstall(args),
+		Reader:         promptReader,
 	})
 	if err != nil {
 		return nil, err
@@ -2309,6 +2312,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 		Saved:          configValue(config, deploymentModelOption.FieldName),
 		Selected:       slices.Contains(persistAgents, "publishing"),
 		NonInteractive: !isInteractiveInstall(args),
+		Reader:         promptReader,
 	})
 	if err != nil {
 		return nil, err
@@ -2697,6 +2701,7 @@ type requiredInstallOptionResolution struct {
 	Saved          string
 	Selected       bool
 	NonInteractive bool
+	Reader         *bufio.Reader
 }
 
 func parseTaskSystemFlag(args []string) (string, error) {
@@ -2777,16 +2782,27 @@ func resolveRequiredInstallOption(resolution requiredInstallOptionResolution) (s
 	if resolution.NonInteractive {
 		return resolution.Option.DefaultValue, nil
 	}
-	return promptRequiredInstallOption(resolution.Option)
+	return promptRequiredInstallOption(resolution.Option, resolution.Reader)
 }
 
-func promptRequiredInstallOption(option requiredInstallOption) (string, error) {
+func promptRequiredInstallOption(option requiredInstallOption, reader *bufio.Reader) (string, error) {
+	if reader == nil {
+		reader = bufio.NewReader(os.Stdin)
+	}
 	allowed := strings.Join(option.Allowed, ", ")
 	for {
 		fmt.Printf("%s [%s] (default: %s): ", option.PromptLabel, allowed, option.DefaultValue)
-		var response string
-		if _, err := fmt.Scanln(&response); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || strings.Contains(err.Error(), "unexpected newline") || strings.Contains(err.Error(), "expected newline") {
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				if strings.TrimSpace(response) != "" {
+					value := strings.ToLower(strings.TrimSpace(response))
+					if slices.Contains(option.Allowed, value) {
+						return value, nil
+					}
+					fmt.Printf("Invalid %s. Choose one of: %s\n", option.FieldName, allowed)
+					continue
+				}
 				return option.DefaultValue, nil
 			}
 			return "", err
@@ -3462,12 +3478,16 @@ func isInteractiveInstall(args []string) bool {
 
 func promptSupportFilePatch(path string) (bool, error) {
 	fmt.Printf("Existing %s found. Patch the Installed agent rules section? [y/N]: ", filepath.Base(path))
-	var response string
-	if _, err := fmt.Scanln(&response); err != nil {
-		if errors.Is(err, os.ErrClosed) || strings.Contains(err.Error(), "unexpected newline") || strings.Contains(err.Error(), "expected newline") {
-			return false, nil
+	reader := bufio.NewReader(os.Stdin)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+			if strings.TrimSpace(response) == "" {
+				return false, nil
+			}
+		} else {
+			return false, err
 		}
-		return false, err
 	}
 	value := strings.ToLower(strings.TrimSpace(response))
 	return value == "y" || value == "yes", nil

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -2704,26 +2704,6 @@ type requiredInstallOptionResolution struct {
 	Reader         *bufio.Reader
 }
 
-func parseTaskSystemFlag(args []string) (string, error) {
-	return parseRequiredInstallOptionFlag(args, requiredInstallOption{
-		FieldName:    "taskSystem",
-		FlagName:     "--task-system",
-		PromptLabel:  "Task system for tasks",
-		Allowed:      supportedTaskSystems,
-		DefaultValue: "github",
-	})
-}
-
-func parseDeploymentModelFlag(args []string) (string, error) {
-	return parseRequiredInstallOptionFlag(args, requiredInstallOption{
-		FieldName:    "deploymentModel",
-		FlagName:     "--deployment-model",
-		PromptLabel:  "App deployment model for publishing (use none for CLI/library/SDK-only projects)",
-		Allowed:      supportedDeploymentModels,
-		DefaultValue: "none",
-	})
-}
-
 func parseRequiredInstallOptionFlag(args []string, option requiredInstallOption) (string, error) {
 	raw := ""
 	for i := 0; i < len(args); i++ {
@@ -3155,8 +3135,9 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 		return nil
 	}
 	trackedPaths := ballastManagedPathsFromSupportFile(root, target)
+	configBackedStaleRulePaths := configBackedStaleRulePathSet(root, target, previous)
 	for _, file := range stringDifference(allManagedRulePaths(root, target), managedRulePaths(root, target, next)) {
-		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !allowConfigBackedStaleRuleRemoval(root, target, file, previous) {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !configBackedStaleRulePaths[file] {
 			continue
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -3176,20 +3157,19 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 	return nil
 }
 
-func allowConfigBackedStaleRuleRemoval(root string, target string, path string, previous *monorepoConfig) bool {
+func configBackedStaleRulePathSet(root string, target string, previous *monorepoConfig) map[string]bool {
+	paths := map[string]bool{}
 	if previous == nil {
-		return false
+		return paths
 	}
 	previousLanguageRules := &monorepoConfig{
 		Agents:    filterAgents(previous.Agents, languageAgentIDs()),
 		Languages: previous.Languages,
 	}
 	for _, previousPath := range managedRulePaths(root, target, previousLanguageRules) {
-		if previousPath == path {
-			return true
-		}
+		paths[previousPath] = true
 	}
-	return false
+	return paths
 }
 
 func allowConfigBackedStaleSkillRemoval(root string, target string, path string, previous *monorepoConfig) bool {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -456,7 +456,7 @@ func printUsage() {
 	fmt.Println("When --language is omitted, ballast detects the repository layout.")
 	fmt.Println("Install target behavior: `--target` adds to the saved targets in `.rulesrc.json`; use `--remove-target` to stop managing a target and clean up Ballast-managed files for it.")
 	fmt.Println("Install language behavior: `--remove-language` removes languages from `.rulesrc.json`, removes their `paths`, and prunes stale Ballast-managed rule files.")
-	fmt.Println("Publishing deployment model behavior: `--deployment-model` stores app deployment guidance as one of none, kubernetes, serverless, server, or hosted.")
+	fmt.Println("Publishing deployment model behavior: `--deployment-model` stores app/service deployment guidance as one of none, kubernetes, serverless, server, or hosted. Use `none` for CLI, library, or SDK-only projects.")
 	fmt.Println("Single-language repos are forwarded to the matching backend CLI.")
 	fmt.Println("Mixed TypeScript/Python/Go/Ansible/Terraform repos install all rules at the repo root under per-language directories (for example `.claude/rules/typescript/`, `.gemini/rules/python/`, and `.codex/rules/terraform/`).")
 }
@@ -2163,7 +2163,7 @@ func resolveMonorepoPlan(root string, args []string) (*monorepoPlan, error) {
 	deploymentModelOption := requiredInstallOption{
 		FieldName:    "deploymentModel",
 		FlagName:     "--deployment-model",
-		PromptLabel:  "Deployment model for publishing apps",
+		PromptLabel:  "App deployment model for publishing (use none for CLI/library/SDK-only projects)",
 		Allowed:      supportedDeploymentModels,
 		DefaultValue: "none",
 	}
@@ -2718,7 +2718,7 @@ func parseDeploymentModelFlag(args []string) (string, error) {
 	return parseRequiredInstallOptionFlag(args, requiredInstallOption{
 		FieldName:    "deploymentModel",
 		FlagName:     "--deployment-model",
-		PromptLabel:  "Deployment model for publishing apps",
+		PromptLabel:  "App deployment model for publishing (use none for CLI/library/SDK-only projects)",
 		Allowed:      supportedDeploymentModels,
 		DefaultValue: "none",
 	})

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -3140,7 +3140,7 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 	}
 	trackedPaths := ballastManagedPathsFromSupportFile(root, target)
 	for _, file := range stringDifference(allManagedRulePaths(root, target), managedRulePaths(root, target, next)) {
-		if !ballastOwnsManagedFile(file) && !trackedPaths[file] {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !allowConfigBackedStaleRuleRemoval(root, target, file, previous) {
 			continue
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -3158,6 +3158,22 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 		pruneEmptyParents(filepath.Dir(file), targetRootDir(root, target))
 	}
 	return nil
+}
+
+func allowConfigBackedStaleRuleRemoval(root string, target string, path string, previous *monorepoConfig) bool {
+	if previous == nil {
+		return false
+	}
+	previousLanguageRules := &monorepoConfig{
+		Agents:    filterAgents(previous.Agents, languageAgentIDs()),
+		Languages: previous.Languages,
+	}
+	for _, previousPath := range managedRulePaths(root, target, previousLanguageRules) {
+		if previousPath == path {
+			return true
+		}
+	}
+	return false
 }
 
 func allowConfigBackedStaleSkillRemoval(root string, target string, path string, previous *monorepoConfig) bool {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -3453,7 +3453,16 @@ func isInteractiveInstall(args []string) bool {
 			return false
 		}
 	}
-	return true
+	return !isCIMode()
+}
+
+func isCIMode() bool {
+	for _, name := range []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI", "TF_BUILD", "BUILDKITE", "CIRCLECI"} {
+		if strings.TrimSpace(os.Getenv(name)) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func promptSupportFilePatch(path string) (bool, error) {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -3569,6 +3569,29 @@ func TestUpdateMonorepoSupportFilesPreservesUnmanagedSectionsWithoutPatch(t *tes
 	}
 }
 
+func TestUpdateMonorepoSupportFilesDoesNotPromptInCI(t *testing.T) {
+	t.Setenv("CI", "true")
+	root := resolvedTempDir(t)
+	plan := &monorepoPlan{
+		Targets:  []string{"claude"},
+		Common:   []string{"local-dev"},
+		Language: []string{"linting"},
+		Config: monorepoConfig{
+			Languages: []string{"typescript"},
+		},
+	}
+	mustWriteFile(t, filepath.Join(root, "CLAUDE.md"), "# CLAUDE.md\n\n## Installed agent rules\n\nCustom unmanaged rules section.\n")
+
+	output := captureStdout(t, func() {
+		if err := updateMonorepoSupportFiles(root, plan, []string{"install", "--target", "claude", "--all"}); err != nil {
+			t.Fatalf("updateMonorepoSupportFiles returned error: %v", err)
+		}
+	})
+	if strings.Contains(output, "Patch the Installed agent rules section") {
+		t.Fatalf("expected CI mode to avoid support-file prompt, got %q", output)
+	}
+}
+
 func TestRemoveStaleManagedFilesSkipsUnmanagedCanonicalFiles(t *testing.T) {
 	root := resolvedTempDir(t)
 	rulePath := filepath.Join(root, ".codex", "rules", "common", "docs.md")
@@ -4113,6 +4136,7 @@ func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
 }
 
 func TestResolveMonorepoPlanPromptsForRequiredFirstRunOptions(t *testing.T) {
+	clearCIEnv(t)
 	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
 	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
@@ -4153,6 +4177,27 @@ func TestResolveMonorepoPlanPromptsForRequiredFirstRunOptions(t *testing.T) {
 	}
 	if !strings.Contains(got, "--deployment-model serverless") {
 		t.Fatalf("expected prompted deployment-model forwarded to backend, got %q", got)
+	}
+}
+
+func TestResolveMonorepoPlanDefaultsRequiredOptionsInCI(t *testing.T) {
+	t.Setenv("CI", "true")
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+
+	plan, err := resolveMonorepoPlan(root, []string{"install", "--target", "codex", "--all"})
+	if err != nil {
+		t.Fatalf("resolveMonorepoPlan returned error: %v", err)
+	}
+	if plan == nil || len(plan.Invocations) == 0 {
+		t.Fatalf("expected monorepo plan, got %#v", plan)
+	}
+	if plan.Config.TaskSystem != "github" {
+		t.Fatalf("expected default taskSystem in CI, got %#v", plan.Config)
+	}
+	if plan.Config.DeploymentModel != "none" {
+		t.Fatalf("expected default deploymentModel in CI, got %#v", plan.Config)
 	}
 }
 
@@ -4365,6 +4410,13 @@ func withWorkingDir(t *testing.T, dir string, fn func()) {
 		}
 	})
 	fn()
+}
+
+func clearCIEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"CI", "GITHUB_ACTIONS", "GITLAB_CI", "TF_BUILD", "BUILDKITE", "CIRCLECI"} {
+		t.Setenv(name, "")
+	}
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -4070,6 +4070,50 @@ func TestResolveMonorepoPlanNormalizesTaskSystemFlagForBackend(t *testing.T) {
 	}
 }
 
+func TestResolveMonorepoPlanPromptsForRequiredFirstRunOptions(t *testing.T) {
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+
+	originalStdin := os.Stdin
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = reader.Close()
+	})
+	if _, err := writer.WriteString("linear\nserverless\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := resolveMonorepoPlan(root, []string{"install", "--target", "codex", "--all"})
+	if err != nil {
+		t.Fatalf("resolveMonorepoPlan returned error: %v", err)
+	}
+	if plan == nil || len(plan.Invocations) == 0 {
+		t.Fatalf("expected monorepo plan, got %#v", plan)
+	}
+	if plan.Config.TaskSystem != "linear" {
+		t.Fatalf("expected prompted taskSystem in saved config, got %#v", plan.Config)
+	}
+	if plan.Config.DeploymentModel != "serverless" {
+		t.Fatalf("expected prompted deploymentModel in saved config, got %#v", plan.Config)
+	}
+	got := strings.Join(plan.Invocations[0].Args, " ")
+	if !strings.Contains(got, "--task-system linear") {
+		t.Fatalf("expected prompted task-system forwarded to backend, got %q", got)
+	}
+	if !strings.Contains(got, "--deployment-model serverless") {
+		t.Fatalf("expected prompted deployment-model forwarded to backend, got %q", got)
+	}
+}
+
 func TestResolveMonorepoPlanNormalizesDeploymentModelFlagForBackend(t *testing.T) {
 	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -3842,6 +3842,48 @@ func TestRunMonorepoRemoveLanguageCleansManagedRulesAndConfig(t *testing.T) {
 	}
 }
 
+func TestRunMonorepoRemoveLanguageCleansConfigBackedRuleWithoutMarker(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["codex"],
+  "agents": ["linting"],
+  "languages": ["typescript", "python"],
+  "paths": {
+    "typescript": ["apps/frontend"],
+    "python": ["services/api"]
+  }
+}`)
+	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname = \"api\"\n")
+	mustWriteFile(
+		t,
+		filepath.Join(root, ".codex", "rules", "typescript", "typescript-linting.md"),
+		"# TypeScript Linting Rules\n\nlegacy generated content without marker\n",
+	)
+
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--remove-language", "typescript", "--yes"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Join(root, ".codex", "rules", "typescript", "typescript-linting.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected config-backed markerless typescript rule to be removed, got err=%v", err)
+	}
+}
+
 // TestRunMonorepoInstallPreservesTaskSystemWrittenByBackend asserts that a
 // taskSystem value written to .rulesrc.json by a backend invocation (simulating
 // what ballast-typescript does after prompting the user) is not clobbered by

--- a/docs/agents/publishing.md
+++ b/docs/agents/publishing.md
@@ -31,7 +31,7 @@ When the publishing agent is installed, Ballast records `deploymentModel` in `.r
 - `server` — self-managed VM, VPS, or bare-metal deployment with a repeatable artifact transfer, service restart, health check, and rollback path.
 - `hosted` — app platforms such as Vercel, Netlify, Render, Railway, or Fly.io.
 
-Use `ballast install --agent publishing --deployment-model kubernetes` for non-interactive setup. Interactive installs prompt for the deployment model only when the publishing agent is selected.
+Use `ballast install --agent publishing --deployment-model kubernetes` for non-interactive app/service setup. Interactive installs prompt for the app deployment model only when the publishing agent is selected; choose `none` for CLI, library, or SDK-only projects.
 
 ## CLI Smoke Placement
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -178,7 +178,7 @@ Example root config:
 
 Manual path overrides are supported by editing the root `.rulesrc.json` before the next `ballast install`.
 
-If `CLAUDE.md`, `GEMINI.md`, or `AGENTS.md` already exists, Ballast creates the file when missing. New `CLAUDE.md` and `AGENTS.md` support files include a user-managed `Repository Facts` section for durable repo metadata such as `OWNER/REPO`, default branch, canonical config paths, workflow filenames, preferred commands, coverage thresholds, and generated paths agents should not edit directly. Gemini installs generate `GEMINI.md` and ensure `AGENTS.md` exists so the shared repository facts remain available through the `@./AGENTS.md` include. `--patch` updates only the Ballast-managed `Installed agent rules` and `Installed skills` sections for these files; the `Repository Facts` section remains user-managed.
+If `CLAUDE.md`, `GEMINI.md`, or `AGENTS.md` already exists and `--force` is not set, Ballast patches only the Ballast-managed `Installed agent rules` and `Installed skills` sections and preserves user-managed sections. Ballast creates the file when missing. New `CLAUDE.md` and `AGENTS.md` support files include a user-managed `Repository Facts` section for durable repo metadata such as `OWNER/REPO`, default branch, canonical config paths, workflow filenames, preferred commands, coverage thresholds, and generated paths agents should not edit directly. Gemini installs generate `GEMINI.md` and ensure `AGENTS.md` exists so the shared repository facts remain available through the `@./AGENTS.md` include. The `Repository Facts` section remains user-managed.
 
 ### Per-language fallback
 
@@ -189,7 +189,7 @@ uvx --from "https://github.com/everydaydevopsio/ballast/releases/download/v${VER
 ballast-go install --target cursor --all
 ```
 
-Ballast preserves existing rule and skill files unless you explicitly choose `--patch` or `--force`.
+Ballast preserves existing rule and skill files unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set.
 
 Use `--patch` to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
 
@@ -206,10 +206,13 @@ For single-language TypeScript installs, the `git-hooks` rules should use Husky 
 - `--skill, -s`: comma-separated list
 - `--all`: install all available agents
 - `--all-skills`: install all available skills
+- `--task-system`: task system for the tasks agent: `github`, `jira`, or `linear`
 - `--deployment-model`: deployment model for the publishing agent: `none`, `kubernetes`, `serverless`, `server`, or `hosted`
 - `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
+
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and `deploymentModel`; `--yes` uses defaults.
 
 ## Wrapper Commands
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,12 +207,12 @@ For single-language TypeScript installs, the `git-hooks` rules should use Husky 
 - `--all`: install all available agents
 - `--all-skills`: install all available skills
 - `--task-system`: task system for the tasks agent: `github`, `jira`, or `linear`
-- `--deployment-model`: deployment model for the publishing agent: `none`, `kubernetes`, `serverless`, `server`, or `hosted`
+- `--deployment-model`: app/service deployment model for publishing: `none`, `kubernetes`, `serverless`, `server`, or `hosted`; use `none` for CLI, library, or SDK-only projects
 - `--force, -f`: overwrite existing rule and skill files; prompts before replacing existing support files
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
-When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and `deploymentModel`; `--yes` uses defaults.
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` uses defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
 
 ## Wrapper Commands
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -178,7 +178,7 @@ Example root config:
 
 Manual path overrides are supported by editing the root `.rulesrc.json` before the next `ballast install`.
 
-If `CLAUDE.md`, `GEMINI.md`, or `AGENTS.md` already exists and `--force` is not set, Ballast patches only the Ballast-managed `Installed agent rules` and `Installed skills` sections and preserves user-managed sections. Ballast creates the file when missing. New `CLAUDE.md` and `AGENTS.md` support files include a user-managed `Repository Facts` section for durable repo metadata such as `OWNER/REPO`, default branch, canonical config paths, workflow filenames, preferred commands, coverage thresholds, and generated paths agents should not edit directly. Gemini installs generate `GEMINI.md` and ensure `AGENTS.md` exists so the shared repository facts remain available through the `@./AGENTS.md` include. The `Repository Facts` section remains user-managed.
+If `CLAUDE.md`, `GEMINI.md`, or `AGENTS.md` already exists and `--force` is not set, Ballast patches installed-rule and installed-skill sections that include the Ballast-managed notice and preserves user-managed sections. Older or customized support-file sections without that notice are preserved unless you use `--patch` or confirm the interactive patch prompt. Ballast creates the file when missing. New `CLAUDE.md` and `AGENTS.md` support files include a user-managed `Repository Facts` section for durable repo metadata such as `OWNER/REPO`, default branch, canonical config paths, workflow filenames, preferred commands, coverage thresholds, and generated paths agents should not edit directly. Gemini installs generate `GEMINI.md` and ensure `AGENTS.md` exists so the shared repository facts remain available through the `@./AGENTS.md` include. The `Repository Facts` section remains user-managed.
 
 ### Per-language fallback
 
@@ -189,7 +189,7 @@ uvx --from "https://github.com/everydaydevopsio/ballast/releases/download/v${VER
 ballast-go install --target cursor --all
 ```
 
-Ballast preserves existing rule and skill files unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set.
+Ballast preserves existing rule and skill files unless you explicitly choose `--patch` or `--force`. Existing support files (`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`) are patched by default when `--force` is not set, but only for installed-rule and installed-skill sections that include the Ballast-managed notice. Older or customized support-file sections without that notice are preserved unless you use `--patch` or confirm the interactive patch prompt.
 
 Use `--patch` to merge upstream Ballast updates into an existing rule or skill file while preserving user-edited sections.
 
@@ -212,7 +212,7 @@ For single-language TypeScript installs, the `git-hooks` rules should use Husky 
 - `--patch, -p`: merge upstream rule and skill updates into existing files while preserving user-edited sections (`--force` wins if both are set)
 - `--yes, -y`: non-interactive mode
 
-When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` uses defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
+When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value, interactive installs prompt for `taskSystem` and app `deploymentModel`; `--yes` and CI mode use defaults. For CLI, library, or SDK-only projects, choose `none` for `deploymentModel`.
 
 ## Wrapper Commands
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -44,6 +44,8 @@ var topLevelYAMLKeyRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+):(.*)$`)
 var gitHooksGuidanceToken = "{{BALLAST_GIT_HOOKS_GUIDANCE}}"
 var gitHooksPreCommitGlobToken = "{{BALLAST_GIT_HOOKS_PRE_COMMIT_GLOB}}"
 var deploymentModelGuidanceToken = "{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}"
+var taskSystemToken = "{{taskSystem}}"
+var taskSystems = []string{"github", "jira", "linear"}
 var deploymentModels = []string{"none", "kubernetes", "serverless", "server", "hosted"}
 
 func withImplicitAgents(agents []string) []string {
@@ -126,6 +128,7 @@ type resolveOptions struct {
 	allSkills       bool
 	yes             bool
 	language        string
+	taskSystem      string
 	deploymentModel string
 }
 
@@ -141,6 +144,7 @@ type installOptions struct {
 	patchGemini     bool
 	skipSupport     map[string]struct{}
 	saveConfig      bool
+	taskSystem      string
 	deploymentModel string
 }
 
@@ -211,6 +215,7 @@ func runInstall(args []string) int {
 	force := fs.Bool("force", false, "overwrite existing rule and skill files; prompts before replacing support files")
 	patch := fs.Bool("patch", false, "merge upstream rule and skill updates into existing files")
 	fs.BoolVar(patch, "p", false, "merge upstream rule and skill updates into existing files")
+	taskSystemFlag := fs.String("task-system", "", "task system for tasks: github|jira|linear")
 	deploymentModelFlag := fs.String("deployment-model", "", "deployment model for publishing apps: none|kubernetes|serverless|server|hosted")
 	yes := fs.Bool("yes", false, "non-interactive mode")
 	fs.BoolVar(yes, "y", false, "non-interactive mode")
@@ -235,6 +240,11 @@ func runInstall(args []string) int {
 		fmt.Printf("Invalid --language. Use: %s\n", strings.Join(languages, ", "))
 		return 1
 	}
+	taskSystem := normalizeRequiredInstallOptionValue(*taskSystemFlag)
+	if taskSystem != "" && !contains(taskSystems, taskSystem) {
+		fmt.Printf("Invalid --task-system. Use: %s\n", strings.Join(taskSystems, ", "))
+		return 1
+	}
 	deploymentModel := normalizeDeploymentModel(*deploymentModelFlag)
 	if deploymentModel != "" && !contains(deploymentModels, deploymentModel) {
 		fmt.Printf("Invalid --deployment-model. Use: %s\n", strings.Join(deploymentModels, ", "))
@@ -256,6 +266,7 @@ func runInstall(args []string) int {
 		allSkills:       *allSkills,
 		yes:             *yes,
 		language:        lang,
+		taskSystem:      taskSystem,
 		deploymentModel: deploymentModel,
 	})
 	if err != nil {
@@ -268,46 +279,6 @@ func runInstall(args []string) int {
 		return 1
 	}
 
-	patchClaude := false
-	patchGemini := false
-	for _, target := range resolved.Targets {
-		if target == "claude" && exists(claudeMDPath(root)) && !*force {
-			if *patch {
-				patchClaude = true
-			} else if !*yes && !isCIMode() {
-				approved, promptErr := promptYesNo(
-					fmt.Sprintf(
-						"Existing CLAUDE.md found at %s. Patch the Installed agent rules section?",
-						claudeMDPath(root),
-					),
-					false,
-				)
-				if promptErr != nil {
-					fmt.Println(promptErr)
-					return 1
-				}
-				patchClaude = approved
-			}
-		}
-		if target == "gemini" && exists(geminiMDPath(root)) && !*force {
-			if *patch {
-				patchGemini = true
-			} else if !*yes && !isCIMode() {
-				approved, promptErr := promptYesNo(
-					fmt.Sprintf(
-						"Existing GEMINI.md found at %s. Patch the Installed agent rules section?",
-						geminiMDPath(root),
-					),
-					false,
-				)
-				if promptErr != nil {
-					fmt.Println(promptErr)
-					return 1
-				}
-				patchGemini = approved
-			}
-		}
-	}
 	skippedSupport := map[string]struct{}{}
 	for _, target := range resolved.Targets {
 		supportPath := supportFilePath(root, target)
@@ -345,10 +316,11 @@ func runInstall(args []string) int {
 		language:        lang,
 		force:           *force,
 		patch:           *patch,
-		patchClaude:     patchClaude,
-		patchGemini:     patchGemini,
+		patchClaude:     false,
+		patchGemini:     false,
 		skipSupport:     skippedSupport,
 		saveConfig:      true,
+		taskSystem:      resolved.TaskSystem,
 		deploymentModel: resolved.DeploymentModel,
 	})
 
@@ -389,12 +361,6 @@ func runInstall(args []string) int {
 	}
 	if len(result.skipped) > 0 {
 		fmt.Printf("Skipped (already present; use --force to overwrite): %s\n", strings.Join(result.skipped, ", "))
-	}
-	if len(result.skippedSupportFiles) > 0 {
-		fmt.Printf(
-			"Skipped support files (already present; use --force to overwrite): %s\n",
-			strings.Join(result.skippedSupportFiles, ", "),
-		)
 	}
 	if len(result.declinedSupportFiles) > 0 {
 		fmt.Printf(
@@ -437,6 +403,7 @@ Options:
   --skill, -s <skills>      Skill(s): owasp-security-scan, aws-health-review, aws-live-health-review, aws-weekly-security-review, github-health-check, ballast-audit, ballast-project-maintenance (comma-separated)
   --all                     Install all agents
   --all-skills              Install all skills
+  --task-system <system>    Task system for tasks: %s
   --deployment-model <mode> Deployment model for publishing apps: %s
   --force                   Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
@@ -456,7 +423,7 @@ Examples:
   ballast-go install --target claude --all --force
   ballast-go install --target cursor --agent linting --patch
   ballast-go install --yes --target cursor --target codex --all
-`, resolveVersion(), strings.Join(targets, ", "), strings.Join(languages, ", "), strings.Join(deploymentModels, ", "))
+`, resolveVersion(), strings.Join(targets, ", "), strings.Join(languages, ", "), strings.Join(taskSystems, ", "), strings.Join(deploymentModels, ", "))
 }
 
 func hasHelpFlag(args []string) bool {
@@ -739,11 +706,27 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 	if config != nil && len(opts.targets) == 0 && len(flagAgents) == 0 && len(flagSkills) == 0 {
 		next := *config
 		next.Agents = withImplicitAgents(config.Agents)
+		if contains(next.Agents, "tasks") {
+			taskSystem, err := resolveRequiredInstallOption(requiredInstallOptionResolution{
+				Option:         taskSystemRequiredOption(),
+				Requested:      opts.taskSystem,
+				Saved:          next.TaskSystem,
+				Selected:       true,
+				NonInteractive: ci,
+			})
+			if err != nil {
+				return nil, err
+			}
+			next.TaskSystem = taskSystem
+		}
 		if contains(next.Agents, "publishing") {
-			deploymentModel, err := resolveDeploymentModelForPublishing(
-				strings.TrimSpace(next.DeploymentModel),
-				ci,
-			)
+			deploymentModel, err := resolveRequiredInstallOption(requiredInstallOptionResolution{
+				Option:         deploymentModelRequiredOption(),
+				Requested:      opts.deploymentModel,
+				Saved:          next.DeploymentModel,
+				Selected:       true,
+				NonInteractive: ci,
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -772,20 +755,37 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 	} else if config != nil {
 		resolvedSkills = slices.Clone(config.Skills)
 	}
+	taskSystem := opts.taskSystem
 	deploymentModel := opts.deploymentModel
-	if deploymentModel == "" && config != nil {
-		deploymentModel = normalizeDeploymentModel(config.DeploymentModel)
-	}
 
 	if len(resolvedTargets) > 0 && (len(resolvedAgents) > 0 || len(resolvedSkills) > 0) {
-		if contains(resolvedAgents, "publishing") {
+		if contains(resolvedAgents, "tasks") {
 			var err error
-			deploymentModel, err = resolveDeploymentModelForPublishing(deploymentModel, ci)
+			taskSystem, err = resolveRequiredInstallOption(requiredInstallOptionResolution{
+				Option:         taskSystemRequiredOption(),
+				Requested:      opts.taskSystem,
+				Saved:          configValue(config, "taskSystem"),
+				Selected:       true,
+				NonInteractive: ci,
+			})
 			if err != nil {
 				return nil, err
 			}
 		}
-		return &rulesConfig{Targets: resolvedTargets, Agents: resolvedAgents, Skills: resolvedSkills, DeploymentModel: deploymentModel}, nil
+		if contains(resolvedAgents, "publishing") {
+			var err error
+			deploymentModel, err = resolveRequiredInstallOption(requiredInstallOptionResolution{
+				Option:         deploymentModelRequiredOption(),
+				Requested:      opts.deploymentModel,
+				Saved:          configValue(config, "deploymentModel"),
+				Selected:       true,
+				NonInteractive: ci,
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		return &rulesConfig{Targets: resolvedTargets, Agents: resolvedAgents, Skills: resolvedSkills, TaskSystem: taskSystem, DeploymentModel: deploymentModel}, nil
 	}
 
 	if ci {
@@ -813,15 +813,34 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 			return nil, err
 		}
 	}
+	if contains(resolvedAgents, "tasks") {
+		var err error
+		taskSystem, err = resolveRequiredInstallOption(requiredInstallOptionResolution{
+			Option:         taskSystemRequiredOption(),
+			Requested:      opts.taskSystem,
+			Saved:          configValue(config, "taskSystem"),
+			Selected:       true,
+			NonInteractive: ci,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
 	if contains(resolvedAgents, "publishing") {
 		var err error
-		deploymentModel, err = resolveDeploymentModelForPublishing(deploymentModel, ci)
+		deploymentModel, err = resolveRequiredInstallOption(requiredInstallOptionResolution{
+			Option:         deploymentModelRequiredOption(),
+			Requested:      opts.deploymentModel,
+			Saved:          configValue(config, "deploymentModel"),
+			Selected:       true,
+			NonInteractive: ci,
+		})
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return &rulesConfig{Targets: resolvedTargets, Agents: resolvedAgents, Skills: resolvedSkills, DeploymentModel: deploymentModel}, nil
+	return &rulesConfig{Targets: resolvedTargets, Agents: resolvedAgents, Skills: resolvedSkills, TaskSystem: taskSystem, DeploymentModel: deploymentModel}, nil
 }
 
 func install(opts installOptions) installResult {
@@ -846,6 +865,7 @@ func install(opts installOptions) installResult {
 			Agents:          opts.agents,
 			Skills:          opts.skills,
 			Languages:       []string{opts.language},
+			TaskSystem:      opts.taskSystem,
 			DeploymentModel: opts.deploymentModel,
 		}); err != nil {
 			result.errors = append(result.errors, agentError{agent: "config", err: err.Error()})
@@ -888,7 +908,7 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: agentID, err: err.Error()})
 					continue
 				}
-				content, err := buildContent(agentID, target, opts.language, suffix, hookMode, opts.deploymentModel)
+				content, err := buildContent(agentID, target, opts.language, suffix, hookMode, opts.taskSystem, opts.deploymentModel)
 				if err != nil {
 					result.errors = append(result.errors, agentError{agent: agentID, err: err.Error()})
 					continue
@@ -1020,17 +1040,13 @@ func install(opts installOptions) installResult {
 				if !contains(result.declinedSupportFiles, agentsPath) {
 					result.declinedSupportFiles = append(result.declinedSupportFiles, agentsPath)
 				}
-			} else if exists(agentsPath) && !opts.force && !opts.patch {
-				if !contains(result.skippedSupportFiles, agentsPath) {
-					result.skippedSupportFiles = append(result.skippedSupportFiles, agentsPath)
-				}
 			} else {
 				content, err := buildCodexAgentsMD(supportAgents, supportSkills, opts.language)
 				if err != nil {
 					result.errors = append(result.errors, agentError{agent: "codex", err: err.Error()})
 				} else {
 					nextContent := content
-					if exists(agentsPath) && !opts.force && opts.patch {
+					if exists(agentsPath) && !opts.force {
 						existing, readErr := os.ReadFile(agentsPath)
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "codex", err: readErr.Error()})
@@ -1049,14 +1065,10 @@ func install(opts installOptions) installResult {
 
 		if target == "claude" && !disableSupportFiles {
 			claudePath := claudeMDPath(opts.projectRoot)
-			shouldPatchClaude := opts.patch || opts.patchClaude
+			shouldPatchClaude := exists(claudePath) && !opts.force || opts.patch || opts.patchClaude
 			if _, skipped := opts.skipSupport[claudePath]; skipped {
 				if !contains(result.declinedSupportFiles, claudePath) {
 					result.declinedSupportFiles = append(result.declinedSupportFiles, claudePath)
-				}
-			} else if exists(claudePath) && !opts.force && !shouldPatchClaude {
-				if !contains(result.skippedSupportFiles, claudePath) {
-					result.skippedSupportFiles = append(result.skippedSupportFiles, claudePath)
 				}
 			} else {
 				content, err := buildClaudeMD(supportAgents, supportSkills, opts.language)
@@ -1083,14 +1095,10 @@ func install(opts installOptions) installResult {
 
 		if target == "gemini" && !disableSupportFiles {
 			geminiPath := geminiMDPath(opts.projectRoot)
-			shouldPatchGemini := opts.patch || opts.patchGemini
+			shouldPatchGemini := exists(geminiPath) && !opts.force || opts.patch || opts.patchGemini
 			if _, skipped := opts.skipSupport[geminiPath]; skipped {
 				if !contains(result.declinedSupportFiles, geminiPath) {
 					result.declinedSupportFiles = append(result.declinedSupportFiles, geminiPath)
-				}
-			} else if exists(geminiPath) && !opts.force && !shouldPatchGemini {
-				if !contains(result.skippedSupportFiles, geminiPath) {
-					result.skippedSupportFiles = append(result.skippedSupportFiles, geminiPath)
 				}
 			} else {
 				content, err := buildGeminiMD(supportAgents, supportSkills, opts.language)
@@ -1884,8 +1892,8 @@ func patchCodexAgentsMD(existing, canonical string) string {
 	return current
 }
 
-func buildContent(agentID, target, language, suffix, hookMode, deploymentModel string) (string, error) {
-	content, err := readContent(agentID, language, suffix, hookMode, deploymentModel)
+func buildContent(agentID, target, language, suffix, hookMode, taskSystem, deploymentModel string) (string, error) {
+	content, err := readContent(agentID, language, suffix, hookMode, taskSystem, deploymentModel)
 	if err != nil {
 		return "", err
 	}
@@ -1896,12 +1904,14 @@ func buildContent(agentID, target, language, suffix, hookMode, deploymentModel s
 			return "", err
 		}
 		front = applyHookTemplateVariables(front, agentID, language, hookMode)
+		front = applyTaskSystemVariables(front, agentID, taskSystem)
 		return front + "\n" + content, nil
 	case "claude":
 		header, err := readTemplate(agentID, language, "claude-header.md", suffix)
 		if err != nil {
 			return "", err
 		}
+		header = applyTaskSystemVariables(header, agentID, taskSystem)
 		return header + content, nil
 	case "gemini":
 		header, err := readTemplate(agentID, language, "gemini-header.md", suffix)
@@ -1914,12 +1924,14 @@ func buildContent(agentID, target, language, suffix, hookMode, deploymentModel s
 				}
 			}
 		}
+		header = applyTaskSystemVariables(header, agentID, taskSystem)
 		return header + "\n---\n\n" + renderGeminiMandates() + content, nil
 	case "opencode":
 		front, err := readTemplate(agentID, language, "opencode-frontmatter.yaml", suffix)
 		if err != nil {
 			return "", err
 		}
+		front = applyTaskSystemVariables(front, agentID, taskSystem)
 		return front + "\n" + content, nil
 	case "codex":
 		header, err := readTemplate(agentID, language, "codex-header.md", suffix)
@@ -1929,6 +1941,7 @@ func buildContent(agentID, target, language, suffix, hookMode, deploymentModel s
 				return "", err
 			}
 		}
+		header = applyTaskSystemVariables(header, agentID, taskSystem)
 		return header + content, nil
 	default:
 		return "", fmt.Errorf("unknown target: %s", target)
@@ -1946,6 +1959,10 @@ func renderGitHooksPreCommitGlob(agentID, language, hookMode string) string {
 }
 
 func normalizeDeploymentModel(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeRequiredInstallOptionValue(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
@@ -1992,6 +2009,13 @@ func applyDeploymentModelGuidance(content, agentID, deploymentModel string) stri
 	return strings.ReplaceAll(content, deploymentModelGuidanceToken, renderDeploymentModelGuidance(deploymentModel))
 }
 
+func applyTaskSystemVariables(content, agentID, taskSystem string) string {
+	if agentID != "tasks" || !strings.Contains(content, taskSystemToken) {
+		return content
+	}
+	return strings.ReplaceAll(content, taskSystemToken, normalizeRequiredInstallOptionValue(taskSystem))
+}
+
 func applyHookTemplateVariables(content, agentID, language, hookMode string) string {
 	if !strings.Contains(content, gitHooksPreCommitGlobToken) {
 		return content
@@ -2026,7 +2050,7 @@ func listRuleSuffixes(agentID, language string) ([]string, error) {
 	return suffixes, nil
 }
 
-func readContent(agentID, language, suffix, hookMode, deploymentModel string) (string, error) {
+func readContent(agentID, language, suffix, hookMode, taskSystem, deploymentModel string) (string, error) {
 	name := "content.md"
 	if suffix != "" {
 		name = "content-" + suffix + ".md"
@@ -2036,6 +2060,7 @@ func readContent(agentID, language, suffix, hookMode, deploymentModel string) (s
 		return "", fmt.Errorf("agent %q has no %s", agentID, name)
 	}
 	content := applyDeploymentModelGuidance(string(bytes), agentID, deploymentModel)
+	content = applyTaskSystemVariables(content, agentID, taskSystem)
 	if agentID == "git-hooks" && strings.Contains(content, gitHooksGuidanceToken) {
 		content = strings.ReplaceAll(content, gitHooksGuidanceToken, renderGitHooksGuidance(language, hookMode))
 	}
@@ -2246,7 +2271,7 @@ func loadConfig(projectRoot, language string) *rulesConfig {
 		BallastVersion:  raw.BallastVersion,
 		Languages:       raw.Languages,
 		Paths:           raw.Paths,
-		TaskSystem:      raw.TaskSystem,
+		TaskSystem:      normalizeRequiredInstallOptionValue(raw.TaskSystem),
 		DeploymentModel: normalizeDeploymentModel(raw.DeploymentModel),
 	}
 }
@@ -2275,6 +2300,10 @@ func saveConfig(projectRoot, language string, cfg rulesConfig) error {
 		cfg.Paths = mergeLanguagePaths(nil, cfg.Languages)
 	}
 	cfg.DeploymentModel = normalizeDeploymentModel(cfg.DeploymentModel)
+	cfg.TaskSystem = normalizeRequiredInstallOptionValue(cfg.TaskSystem)
+	if cfg.TaskSystem != "" && !contains(taskSystems, cfg.TaskSystem) {
+		return fmt.Errorf("invalid taskSystem %q; use one of: %s", cfg.TaskSystem, strings.Join(taskSystems, ", "))
+	}
 	if cfg.DeploymentModel != "" && !contains(deploymentModels, cfg.DeploymentModel) {
 		return fmt.Errorf("invalid deploymentModel %q; use one of: %s", cfg.DeploymentModel, strings.Join(deploymentModels, ", "))
 	}
@@ -2388,7 +2417,7 @@ func promptTarget() (string, error) {
 	for {
 		fmt.Printf("AI platform (%s): ", strings.Join(targets, ", "))
 		line, err := reader.ReadString('\n')
-		if err != nil && !errors.Is(err, os.ErrClosed) {
+		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
 			if len(strings.TrimSpace(line)) == 0 {
 				return "", err
 			}
@@ -2473,39 +2502,92 @@ func promptSkills(language string) ([]string, error) {
 	}
 }
 
-func resolveDeploymentModelForPublishing(current string, nonInteractive bool) (string, error) {
-	model := normalizeDeploymentModel(current)
-	if model != "" {
-		if !contains(deploymentModels, model) {
-			return "", fmt.Errorf("invalid deploymentModel %q; use one of: %s", model, strings.Join(deploymentModels, ", "))
-		}
-		return model, nil
-	}
-	if nonInteractive {
-		return "none", nil
-	}
-	return promptDeploymentModel()
+type requiredInstallOption struct {
+	FieldName    string
+	PromptLabel  string
+	Allowed      []string
+	DefaultValue string
 }
 
-func promptDeploymentModel() (string, error) {
-	allowed := strings.Join(deploymentModels, ", ")
-	reader := bufio.NewReader(os.Stdin)
+type requiredInstallOptionResolution struct {
+	Option         requiredInstallOption
+	Requested      string
+	Saved          string
+	Selected       bool
+	NonInteractive bool
+}
+
+func taskSystemRequiredOption() requiredInstallOption {
+	return requiredInstallOption{
+		FieldName:    "taskSystem",
+		PromptLabel:  "Task system for tasks",
+		Allowed:      taskSystems,
+		DefaultValue: "github",
+	}
+}
+
+func deploymentModelRequiredOption() requiredInstallOption {
+	return requiredInstallOption{
+		FieldName:    "deploymentModel",
+		PromptLabel:  "Deployment model for publishing apps",
+		Allowed:      deploymentModels,
+		DefaultValue: "none",
+	}
+}
+
+func resolveRequiredInstallOption(resolution requiredInstallOptionResolution) (string, error) {
+	if resolution.Requested != "" {
+		return resolution.Requested, nil
+	}
+	saved := normalizeRequiredInstallOptionValue(resolution.Saved)
+	if saved != "" {
+		if contains(resolution.Option.Allowed, saved) {
+			return saved, nil
+		}
+		return "", fmt.Errorf("invalid %s %q; use one of: %s", resolution.Option.FieldName, resolution.Saved, strings.Join(resolution.Option.Allowed, ", "))
+	}
+	if !resolution.Selected {
+		return "", nil
+	}
+	if resolution.NonInteractive {
+		return resolution.Option.DefaultValue, nil
+	}
+	return promptRequiredInstallOption(resolution.Option)
+}
+
+func promptRequiredInstallOption(option requiredInstallOption) (string, error) {
+	allowed := strings.Join(option.Allowed, ", ")
 	for {
-		fmt.Printf("Deployment model for publishing apps [%s] (default: none): ", allowed)
-		line, err := reader.ReadString('\n')
-		if err != nil && !errors.Is(err, os.ErrClosed) {
-			if len(strings.TrimSpace(line)) == 0 {
-				return "", err
+		fmt.Printf("%s [%s] (default: %s): ", option.PromptLabel, allowed, option.DefaultValue)
+		var response string
+		if _, err := fmt.Scanln(&response); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || strings.Contains(err.Error(), "unexpected newline") || strings.Contains(err.Error(), "expected newline") {
+				return option.DefaultValue, nil
 			}
+			return "", err
 		}
-		value := normalizeDeploymentModel(line)
+		value := normalizeRequiredInstallOptionValue(response)
 		if value == "" {
-			return "none", nil
+			return option.DefaultValue, nil
 		}
-		if contains(deploymentModels, value) {
+		if contains(option.Allowed, value) {
 			return value, nil
 		}
-		fmt.Printf("Invalid deployment model. Choose one of: %s\n", allowed)
+		fmt.Printf("Invalid %s. Choose one of: %s\n", option.FieldName, allowed)
+	}
+}
+
+func configValue(config *rulesConfig, field string) string {
+	if config == nil {
+		return ""
+	}
+	switch field {
+	case "taskSystem":
+		return config.TaskSystem
+	case "deploymentModel":
+		return config.DeploymentModel
+	default:
+		return ""
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -1053,18 +1053,22 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: "codex", err: err.Error()})
 				} else {
 					nextContent := content
+					shouldWrite := true
 					if exists(agentsPath) && !opts.force {
 						existing, readErr := os.ReadFile(agentsPath)
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "codex", err: readErr.Error()})
+							shouldWrite = false
 						} else {
 							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch)
 						}
 					}
-					if err := os.WriteFile(agentsPath, []byte(nextContent), 0o644); err != nil {
-						result.errors = append(result.errors, agentError{agent: "codex", err: err.Error()})
-					} else if !contains(result.installedSupport, agentsPath) {
-						result.installedSupport = append(result.installedSupport, agentsPath)
+					if shouldWrite {
+						if err := os.WriteFile(agentsPath, []byte(nextContent), 0o644); err != nil {
+							result.errors = append(result.errors, agentError{agent: "codex", err: err.Error()})
+						} else if !contains(result.installedSupport, agentsPath) {
+							result.installedSupport = append(result.installedSupport, agentsPath)
+						}
 					}
 				}
 			}
@@ -1083,18 +1087,22 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: "claude", err: err.Error()})
 				} else {
 					nextContent := content
+					shouldWrite := true
 					if exists(claudePath) && !opts.force && shouldPatchClaude {
 						existing, readErr := os.ReadFile(claudePath)
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "claude", err: readErr.Error()})
+							shouldWrite = false
 						} else {
 							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch || opts.patchClaude)
 						}
 					}
-					if err := os.WriteFile(claudePath, []byte(nextContent), 0o644); err != nil {
-						result.errors = append(result.errors, agentError{agent: "claude", err: err.Error()})
-					} else if !contains(result.installedSupport, claudePath) {
-						result.installedSupport = append(result.installedSupport, claudePath)
+					if shouldWrite {
+						if err := os.WriteFile(claudePath, []byte(nextContent), 0o644); err != nil {
+							result.errors = append(result.errors, agentError{agent: "claude", err: err.Error()})
+						} else if !contains(result.installedSupport, claudePath) {
+							result.installedSupport = append(result.installedSupport, claudePath)
+						}
 					}
 				}
 			}
@@ -1113,18 +1121,22 @@ func install(opts installOptions) installResult {
 					result.errors = append(result.errors, agentError{agent: "gemini", err: err.Error()})
 				} else {
 					nextContent := content
+					shouldWrite := true
 					if exists(geminiPath) && !opts.force && shouldPatchGemini {
 						existing, readErr := os.ReadFile(geminiPath)
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "gemini", err: readErr.Error()})
+							shouldWrite = false
 						} else {
 							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch || opts.patchGemini)
 						}
 					}
-					if err := os.WriteFile(geminiPath, []byte(nextContent), 0o644); err != nil {
-						result.errors = append(result.errors, agentError{agent: "gemini", err: err.Error()})
-					} else if !contains(result.installedSupport, geminiPath) {
-						result.installedSupport = append(result.installedSupport, geminiPath)
+					if shouldWrite {
+						if err := os.WriteFile(geminiPath, []byte(nextContent), 0o644); err != nil {
+							result.errors = append(result.errors, agentError{agent: "gemini", err: err.Error()})
+						} else if !contains(result.installedSupport, geminiPath) {
+							result.installedSupport = append(result.installedSupport, geminiPath)
+						}
 					}
 				}
 			}

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -1072,7 +1072,7 @@ func install(opts installOptions) installResult {
 
 		if target == "claude" && !disableSupportFiles {
 			claudePath := claudeMDPath(opts.projectRoot)
-			shouldPatchClaude := exists(claudePath) && !opts.force || opts.patch || opts.patchClaude
+			shouldPatchClaude := (exists(claudePath) && !opts.force) || opts.patch || opts.patchClaude
 			if _, skipped := opts.skipSupport[claudePath]; skipped {
 				if !contains(result.declinedSupportFiles, claudePath) {
 					result.declinedSupportFiles = append(result.declinedSupportFiles, claudePath)
@@ -1102,7 +1102,7 @@ func install(opts installOptions) installResult {
 
 		if target == "gemini" && !disableSupportFiles {
 			geminiPath := geminiMDPath(opts.projectRoot)
-			shouldPatchGemini := exists(geminiPath) && !opts.force || opts.patch || opts.patchGemini
+			shouldPatchGemini := (exists(geminiPath) && !opts.force) || opts.patch || opts.patchGemini
 			if _, skipped := opts.skipSupport[geminiPath]; skipped {
 				if !contains(result.declinedSupportFiles, geminiPath) {
 					result.declinedSupportFiles = append(result.declinedSupportFiles, geminiPath)

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -693,6 +693,7 @@ func runDoctor() int {
 func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 	config := loadConfig(opts.projectRoot, opts.language)
 	ci := isCIMode() || opts.yes
+	promptReader := bufio.NewReader(os.Stdin)
 
 	flagAgents := opts.agents
 	if opts.all {
@@ -713,6 +714,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 				Saved:          next.TaskSystem,
 				Selected:       true,
 				NonInteractive: ci,
+				Reader:         promptReader,
 			})
 			if err != nil {
 				return nil, err
@@ -726,6 +728,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 				Saved:          next.DeploymentModel,
 				Selected:       true,
 				NonInteractive: ci,
+				Reader:         promptReader,
 			})
 			if err != nil {
 				return nil, err
@@ -767,6 +770,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 				Saved:          configValue(config, "taskSystem"),
 				Selected:       true,
 				NonInteractive: ci,
+				Reader:         promptReader,
 			})
 			if err != nil {
 				return nil, err
@@ -780,6 +784,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 				Saved:          configValue(config, "deploymentModel"),
 				Selected:       true,
 				NonInteractive: ci,
+				Reader:         promptReader,
 			})
 			if err != nil {
 				return nil, err
@@ -821,6 +826,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 			Saved:          configValue(config, "taskSystem"),
 			Selected:       true,
 			NonInteractive: ci,
+			Reader:         promptReader,
 		})
 		if err != nil {
 			return nil, err
@@ -834,6 +840,7 @@ func resolveTargetAndAgents(opts resolveOptions) (*rulesConfig, error) {
 			Saved:          configValue(config, "deploymentModel"),
 			Selected:       true,
 			NonInteractive: ci,
+			Reader:         promptReader,
 		})
 		if err != nil {
 			return nil, err
@@ -2515,6 +2522,7 @@ type requiredInstallOptionResolution struct {
 	Saved          string
 	Selected       bool
 	NonInteractive bool
+	Reader         *bufio.Reader
 }
 
 func taskSystemRequiredOption() requiredInstallOption {
@@ -2552,16 +2560,27 @@ func resolveRequiredInstallOption(resolution requiredInstallOptionResolution) (s
 	if resolution.NonInteractive {
 		return resolution.Option.DefaultValue, nil
 	}
-	return promptRequiredInstallOption(resolution.Option)
+	return promptRequiredInstallOption(resolution.Option, resolution.Reader)
 }
 
-func promptRequiredInstallOption(option requiredInstallOption) (string, error) {
+func promptRequiredInstallOption(option requiredInstallOption, reader *bufio.Reader) (string, error) {
+	if reader == nil {
+		reader = bufio.NewReader(os.Stdin)
+	}
 	allowed := strings.Join(option.Allowed, ", ")
 	for {
 		fmt.Printf("%s [%s] (default: %s): ", option.PromptLabel, allowed, option.DefaultValue)
-		var response string
-		if _, err := fmt.Scanln(&response); err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) || strings.Contains(err.Error(), "unexpected newline") || strings.Contains(err.Error(), "expected newline") {
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				if strings.TrimSpace(response) != "" {
+					value := normalizeRequiredInstallOptionValue(response)
+					if contains(option.Allowed, value) {
+						return value, nil
+					}
+					fmt.Printf("Invalid %s. Choose one of: %s\n", option.FieldName, allowed)
+					continue
+				}
 				return option.DefaultValue, nil
 			}
 			return "", err

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -1058,7 +1058,7 @@ func install(opts installOptions) installResult {
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "codex", err: readErr.Error()})
 						} else {
-							nextContent = patchCodexAgentsMD(string(existing), content)
+							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch)
 						}
 					}
 					if err := os.WriteFile(agentsPath, []byte(nextContent), 0o644); err != nil {
@@ -1088,7 +1088,7 @@ func install(opts installOptions) installResult {
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "claude", err: readErr.Error()})
 						} else {
-							nextContent = patchCodexAgentsMD(string(existing), content)
+							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch || opts.patchClaude)
 						}
 					}
 					if err := os.WriteFile(claudePath, []byte(nextContent), 0o644); err != nil {
@@ -1118,7 +1118,7 @@ func install(opts installOptions) installResult {
 						if readErr != nil {
 							result.errors = append(result.errors, agentError{agent: "gemini", err: readErr.Error()})
 						} else {
-							nextContent = patchCodexAgentsMD(string(existing), content)
+							nextContent = patchCodexAgentsMDWithOptions(string(existing), content, opts.patch || opts.patchGemini)
 						}
 					}
 					if err := os.WriteFile(geminiPath, []byte(nextContent), 0o644); err != nil {
@@ -1843,36 +1843,65 @@ func patchRuleContent(existing, canonical, target string) string {
 }
 
 func findSectionRange(content, heading string) (int, int, bool) {
+	ranges := findSectionRanges(content, heading)
+	if len(ranges) == 0 {
+		return 0, 0, false
+	}
+	return ranges[0].start, ranges[0].end, true
+}
+
+type sectionRange struct {
+	start int
+	end   int
+}
+
+func findSectionRanges(content, heading string) []sectionRange {
 	normalized := normalizeLineEndings(content)
 	lines := strings.SplitAfter(normalized, "\n")
 	position := 0
-	start := -1
-	end := len(normalized)
 	marker := "## " + heading
 	inCodeFence := false
+	type headingPosition struct {
+		line  string
+		start int
+	}
+	headings := []headingPosition{}
 
-	for index, line := range lines {
+	for _, line := range lines {
 		trimmed := strings.TrimSuffix(line, "\n")
 		if strings.HasPrefix(strings.TrimSpace(trimmed), "```") {
 			inCodeFence = !inCodeFence
 		}
-		if !inCodeFence && start < 0 {
-			if trimmed == marker {
-				start = position
-			}
-		} else if !inCodeFence && strings.HasPrefix(trimmed, "## ") {
-			end = position
-			return start, end, true
+		if !inCodeFence && strings.HasPrefix(trimmed, "## ") {
+			headings = append(headings, headingPosition{line: trimmed, start: position})
 		}
 		position += len(line)
-		if index == len(lines)-1 && start >= 0 {
-			return start, end, true
-		}
 	}
-	return 0, 0, false
+
+	ranges := []sectionRange{}
+	for index, headingPosition := range headings {
+		if headingPosition.line != marker {
+			continue
+		}
+		end := len(normalized)
+		if index+1 < len(headings) {
+			end = headings[index+1].start
+		}
+		ranges = append(ranges, sectionRange{start: headingPosition.start, end: end})
+	}
+	return ranges
 }
 
 func patchCodexAgentsMD(existing, canonical string) string {
+	return patchCodexAgentsMDWithOptions(existing, canonical, true)
+}
+
+func hasBallastManagedNotice(section string) bool {
+	return strings.Contains(section, "Created by [Ballast]") &&
+		strings.Contains(section, "Do not edit this section.")
+}
+
+func patchCodexAgentsMDWithOptions(existing, canonical string, replaceUnmanagedSections bool) string {
 	if strings.TrimSpace(existing) == "" {
 		return normalizeLineEndings(canonical)
 	}
@@ -1885,16 +1914,24 @@ func patchCodexAgentsMD(existing, canonical string) string {
 			continue
 		}
 		canonicalSection := strings.TrimRight(canonical[canonicalStart:canonicalEnd], "\n")
-		existingStart, existingEnd, ok := findSectionRange(current, heading)
-		if !ok {
+		var existingRange sectionRange
+		found := false
+		for _, candidate := range findSectionRanges(current, heading) {
+			if replaceUnmanagedSections || hasBallastManagedNotice(current[candidate.start:candidate.end]) {
+				existingRange = candidate
+				found = true
+				break
+			}
+		}
+		if !found {
 			current = strings.TrimRight(current, "\n") + "\n\n" + canonicalSection + "\n"
 			continue
 		}
-		current = strings.TrimRight(current[:existingStart], "\n") +
+		current = strings.TrimRight(current[:existingRange.start], "\n") +
 			"\n\n" +
 			canonicalSection +
 			"\n\n" +
-			strings.TrimLeft(current[existingEnd:], "\n") + "\n"
+			strings.TrimLeft(current[existingRange.end:], "\n") + "\n"
 	}
 	return current
 }

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -216,7 +216,7 @@ func runInstall(args []string) int {
 	patch := fs.Bool("patch", false, "merge upstream rule and skill updates into existing files")
 	fs.BoolVar(patch, "p", false, "merge upstream rule and skill updates into existing files")
 	taskSystemFlag := fs.String("task-system", "", "task system for tasks: github|jira|linear")
-	deploymentModelFlag := fs.String("deployment-model", "", "deployment model for publishing apps: none|kubernetes|serverless|server|hosted")
+	deploymentModelFlag := fs.String("deployment-model", "", "app/service deployment model for publishing; use none for CLI/library/SDK-only projects: none|kubernetes|serverless|server|hosted")
 	yes := fs.Bool("yes", false, "non-interactive mode")
 	fs.BoolVar(yes, "y", false, "non-interactive mode")
 	repositoryFactsFile := fs.String("repository-facts-file", "", "optional path to wrapper-generated repository facts JSON")
@@ -404,7 +404,7 @@ Options:
   --all                     Install all agents
   --all-skills              Install all skills
   --task-system <system>    Task system for tasks: %s
-  --deployment-model <mode> Deployment model for publishing apps: %s
+  --deployment-model <mode> App/service deployment model for publishing; use none for CLI/library/SDK-only projects: %s
   --force                   Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json
@@ -2537,7 +2537,7 @@ func taskSystemRequiredOption() requiredInstallOption {
 func deploymentModelRequiredOption() requiredInstallOption {
 	return requiredInstallOption{
 		FieldName:    "deploymentModel",
-		PromptLabel:  "Deployment model for publishing apps",
+		PromptLabel:  "App deployment model for publishing (use none for CLI/library/SDK-only projects)",
 		Allowed:      deploymentModels,
 		DefaultValue: "none",
 	}

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -1019,7 +1019,7 @@ func TestRunInstallPromptsToPatchExistingGeminiMD(t *testing.T) {
 		t.Fatal(err)
 	}
 	geminiPath := filepath.Join(tmpDir, "GEMINI.md")
-	if err := os.WriteFile(geminiPath, []byte("# GEMINI.md\n\n## Team Notes\n\nKeep this section.\n\n## Installed agent rules\n\n- `.gemini/rules/old.md` - Old rule\n"), 0o644); err != nil {
+	if err := os.WriteFile(geminiPath, []byte("# GEMINI.md\n\n## Team Notes\n\nKeep this section.\n\n## Installed agent rules\n\nCreated by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.\n\n- `.gemini/rules/old.md` - Old rule\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2016,7 +2016,7 @@ Keep my custom rule text.
 		t.Fatal(err)
 	}
 	agentsMD := filepath.Join(tmpDir, "AGENTS.md")
-	if err := os.WriteFile(agentsMD, []byte("# AGENTS.md\n\n## Team Notes\n\nKeep this section.\n\n## Installed agent rules\n\nRead and follow these rule files in `.codex/rules/` when they apply:\n\n- `.codex/rules/old.md` - Old rule\n"), 0o644); err != nil {
+	if err := os.WriteFile(agentsMD, []byte("# AGENTS.md\n\n## Team Notes\n\nKeep this section.\n\n## Installed agent rules\n\nCreated by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.\n\nRead and follow these rule files in `.codex/rules/` when they apply:\n\n- `.codex/rules/old.md` - Old rule\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2052,6 +2052,39 @@ Keep my custom rule text.
 	}
 	if strings.Contains(text, "`.codex/rules/old.md`") {
 		t.Fatalf("expected old installed-rules entry to be replaced: %s", text)
+	}
+}
+
+func TestInstallDefaultPatchPreservesUnmanagedCodexSupportSection(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentsMD := filepath.Join(tmpDir, "AGENTS.md")
+	if err := os.WriteFile(agentsMD, []byte("# AGENTS.md\n\n## Installed agent rules\n\n- `.codex/rules/old.md` - Team managed rule\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := install(installOptions{
+		projectRoot: tmpDir,
+		targets:     []string{"codex"},
+		agents:      []string{"linting"},
+		language:    "go",
+		force:       false,
+		patch:       false,
+		saveConfig:  false,
+	})
+	if len(result.errors) > 0 {
+		t.Fatalf("unexpected install errors: %+v", result.errors)
+	}
+
+	content, err := os.ReadFile(agentsMD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(content)
+	if !strings.Contains(text, "`.codex/rules/old.md`") {
+		t.Fatalf("expected unmanaged section to be preserved: %s", text)
+	}
+	if !strings.Contains(text, "`.codex/rules/go-linting.md`") {
+		t.Fatalf("expected linting rule to be installed: %s", text)
 	}
 }
 
@@ -2168,5 +2201,18 @@ func TestPatchCodexAgentsMDIgnoresHeadingInsideCodeFence(t *testing.T) {
 	}
 	if !strings.Contains(merged, "```md\n## Installed agent rules\n```") {
 		t.Fatalf("expected fenced code block to be preserved without matching: %s", merged)
+	}
+}
+
+func TestPatchCodexAgentsMDPreservesUnmanagedSectionsInManagedOnlyMode(t *testing.T) {
+	existing := "# AGENTS.md\n\n## Installed agent rules\n\n- `.codex/rules/old.md` - Team managed rule\n"
+	canonical := "# AGENTS.md\n\n## Installed agent rules\n\nCreated by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.\n\n- `.codex/rules/go-linting.md` - New rule\n"
+
+	merged := patchCodexAgentsMDWithOptions(existing, canonical, false)
+	if !strings.Contains(merged, "`.codex/rules/old.md`") {
+		t.Fatalf("expected unmanaged section to be preserved: %s", merged)
+	}
+	if !strings.Contains(merged, "`.codex/rules/go-linting.md`") {
+		t.Fatalf("expected managed section to be appended: %s", merged)
 	}
 }

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -2085,6 +2086,67 @@ func TestInstallDefaultPatchPreservesUnmanagedCodexSupportSection(t *testing.T) 
 	}
 	if !strings.Contains(text, "`.codex/rules/go-linting.md`") {
 		t.Fatalf("expected linting rule to be installed: %s", text)
+	}
+}
+
+func TestInstallSkipsSupportFileWriteWhenExistingFileCannotBeRead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("write-only chmod semantics differ on Windows")
+	}
+
+	tests := []struct {
+		name        string
+		target      string
+		path        string
+		expectedErr string
+	}{
+		{name: "codex", target: "codex", path: "AGENTS.md", expectedErr: "codex"},
+		{name: "claude", target: "claude", path: "CLAUDE.md", expectedErr: "claude"},
+		{name: "gemini", target: "gemini", path: "GEMINI.md", expectedErr: "gemini"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			supportPath := filepath.Join(tmpDir, test.path)
+			original := "# " + test.path + "\n\n## Installed agent rules\n\nDo not replace this.\n"
+			if err := os.WriteFile(supportPath, []byte(original), 0o200); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_ = os.Chmod(supportPath, 0o600)
+			})
+
+			result := install(installOptions{
+				projectRoot: tmpDir,
+				targets:     []string{test.target},
+				agents:      []string{"linting"},
+				language:    "go",
+				force:       false,
+				patch:       false,
+				saveConfig:  false,
+			})
+
+			if len(result.errors) == 0 {
+				t.Fatalf("expected read error for %s", test.path)
+			}
+			if !strings.Contains(result.errors[0].agent, test.expectedErr) {
+				t.Fatalf("expected %s read error, got %+v", test.expectedErr, result.errors)
+			}
+			if contains(result.installedSupport, supportPath) {
+				t.Fatalf("expected unreadable support file not to be reported as installed")
+			}
+			if err := os.Chmod(supportPath, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			content, err := os.ReadFile(supportPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(content) != original {
+				t.Fatalf("expected original support file to be preserved, got %q", string(content))
+			}
+		})
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -538,7 +538,7 @@ func TestInstallSupportsTerraformTestingBestPractices(t *testing.T) {
 }
 
 func TestRenderGitHooksContentSupportsTerraform(t *testing.T) {
-	got, err := readContent("git-hooks", "terraform", "", "standalone", "none")
+	got, err := readContent("git-hooks", "terraform", "", "standalone", "github", "none")
 	if err != nil {
 		t.Fatalf("read terraform git-hooks content: %v", err)
 	}
@@ -846,7 +846,7 @@ func TestBuildGeminiMDIncludesRepositoryFactsAndSkills(t *testing.T) {
 }
 
 func TestBuildContentGeminiIncludesMandates(t *testing.T) {
-	content, err := buildContent("linting", "gemini", "go", "", "standalone", "none")
+	content, err := buildContent("linting", "gemini", "go", "", "standalone", "github", "none")
 	if err != nil {
 		t.Fatalf("buildContent(gemini): %v", err)
 	}
@@ -863,7 +863,7 @@ func TestBuildContentGeminiIncludesMandates(t *testing.T) {
 }
 
 func TestBuildContentRendersPublishingDeploymentModelToken(t *testing.T) {
-	content, err := buildContent("publishing", "codex", "go", "apps", "standalone", "kubernetes")
+	content, err := buildContent("publishing", "codex", "go", "apps", "standalone", "github", "kubernetes")
 	if err != nil {
 		t.Fatalf("buildContent(publishing): %v", err)
 	}
@@ -1601,6 +1601,100 @@ func TestRunInstallWritesDeploymentModelForPublishing(t *testing.T) {
 	}
 }
 
+func TestRunInstallPromptsForTaskSystemAndDeploymentModelOnFirstRun(t *testing.T) {
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+	t.Setenv("GITLAB_CI", "")
+	t.Setenv("TF_BUILD", "")
+	tmpDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalStdin := os.Stdin
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		_ = reader.Close()
+	})
+	if _, err := writer.WriteString("linear\nserverless\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode := runInstall([]string{"install", "--target", "codex", "--language", "go", "--all"})
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".rulesrc.json"))
+	if err != nil {
+		t.Fatalf("read .rulesrc.json: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, `"taskSystem": "linear"`) {
+		t.Fatalf("expected prompted taskSystem in config: %s", text)
+	}
+	if !strings.Contains(text, `"deploymentModel": "serverless"`) {
+		t.Fatalf("expected prompted deploymentModel in config: %s", text)
+	}
+	taskRule, err := os.ReadFile(filepath.Join(tmpDir, ".codex", "rules", "tasks-task-system.md"))
+	if err != nil {
+		t.Fatalf("read tasks-task-system.md: %v", err)
+	}
+	if !strings.Contains(string(taskRule), "linear") || strings.Contains(string(taskRule), "{{taskSystem}}") {
+		t.Fatalf("expected task rule to render prompted task system: %s", string(taskRule))
+	}
+}
+
+func TestRunInstallDefaultsRequiredOptionsInNonInteractiveMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	exitCode := runInstall([]string{"install", "--target", "codex", "--language", "go", "--all", "--yes"})
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".rulesrc.json"))
+	if err != nil {
+		t.Fatalf("read .rulesrc.json: %v", err)
+	}
+	text := string(content)
+	if !strings.Contains(text, `"taskSystem": "github"`) {
+		t.Fatalf("expected default taskSystem in config: %s", text)
+	}
+	if !strings.Contains(text, `"deploymentModel": "none"`) {
+		t.Fatalf("expected default deploymentModel in config: %s", text)
+	}
+}
+
 func TestRunInstallRejectsInvalidDeploymentModel(t *testing.T) {
 	output := captureStdout(t, func() {
 		exitCode := runInstall([]string{"install", "--target", "codex", "--agent", "publishing", "--deployment-model", "bogus", "--yes"})
@@ -1610,6 +1704,18 @@ func TestRunInstallRejectsInvalidDeploymentModel(t *testing.T) {
 	})
 	if !strings.Contains(output, "Invalid --deployment-model") {
 		t.Fatalf("expected invalid deployment model message, got %q", output)
+	}
+}
+
+func TestRunInstallRejectsInvalidTaskSystem(t *testing.T) {
+	output := captureStdout(t, func() {
+		exitCode := runInstall([]string{"install", "--target", "codex", "--agent", "tasks", "--task-system", "notion", "--yes"})
+		if exitCode != 1 {
+			t.Fatalf("expected exit code 1, got %d", exitCode)
+		}
+	})
+	if !strings.Contains(output, "Invalid --task-system") {
+		t.Fatalf("expected invalid task system message, got %q", output)
 	}
 }
 
@@ -1893,7 +1999,7 @@ func TestPatchFlagUpdatesClaudeMDSection(t *testing.T) {
 	}
 }
 
-func TestInstallPatchUpdatesCodexAgentsMDSectionOnly(t *testing.T) {
+func TestInstallUpdatesCodexAgentsMDSectionByDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 	rulePath := filepath.Join(tmpDir, ".codex", "rules", "go-linting.md")
 	if err := os.MkdirAll(filepath.Dir(rulePath), 0o755); err != nil {
@@ -1920,11 +2026,14 @@ Keep my custom rule text.
 		agents:      []string{"linting"},
 		language:    "go",
 		force:       false,
-		patch:       true,
+		patch:       false,
 		saveConfig:  false,
 	})
 	if len(result.errors) > 0 {
 		t.Fatalf("unexpected install errors: %+v", result.errors)
+	}
+	if contains(result.skippedSupportFiles, agentsMD) {
+		t.Fatalf("expected AGENTS.md to be patched by default, got skipped support files: %#v", result.skippedSupportFiles)
 	}
 
 	content, err := os.ReadFile(agentsMD)

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1633,7 +1633,7 @@ def prompt_skills(language: str) -> list[str]:
 
 def prompt_deployment_model() -> str:
     value = prompt(
-        "Deployment model for publishing apps "
+        "App deployment model for publishing (use none for CLI/library/SDK-only projects) "
         f"[{', '.join(DEPLOYMENT_MODELS)}] (default: none): "
     )
     normalized = normalize_deployment_model(value)
@@ -2146,7 +2146,7 @@ def parser() -> argparse.ArgumentParser:
     install_cmd.add_argument(
         "--deployment-model",
         choices=DEPLOYMENT_MODELS,
-        help="Deployment model for publishing apps",
+        help="App/service deployment model for publishing; use none for CLI/library/SDK-only projects",
     )
     install_cmd.add_argument(
         "--force",

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1493,30 +1493,41 @@ def patch_rule_content(existing: str, canonical: str, target: str) -> str:
 
 
 def find_markdown_section_range(content: str, heading: str) -> tuple[int, int] | None:
+    ranges = find_markdown_section_ranges(content, heading)
+    return ranges[0] if ranges else None
+
+
+def find_markdown_section_ranges(content: str, heading: str) -> list[tuple[int, int]]:
     normalized = normalize_line_endings(content)
     lines = normalized.split("\n")
     target = f"## {heading}"
     in_fence = False
     offset = 0
+    headings: list[tuple[str, int]] = []
 
-    for i, line in enumerate(lines):
+    for line in lines:
         if line.startswith("```"):
             in_fence = not in_fence
-        if not in_fence and line == target:
-            start = offset
-            offset += len(line) + 1
-            for next_line in lines[i + 1 :]:
-                if next_line.startswith("```"):
-                    in_fence = not in_fence
-                if not in_fence and next_line.startswith("## "):
-                    return start, offset - 1
-                offset += len(next_line) + 1
-            return start, len(normalized)
+        if not in_fence and line.startswith("## "):
+            headings.append((line, offset))
         offset += len(line) + 1
-    return None
+
+    ranges: list[tuple[int, int]] = []
+    for index, (line, start) in enumerate(headings):
+        if line != target:
+            continue
+        end = headings[index + 1][1] if index + 1 < len(headings) else len(normalized)
+        ranges.append((start, end))
+    return ranges
 
 
-def patch_codex_agents_md(existing: str, canonical: str) -> str:
+def has_ballast_managed_notice(section: str) -> bool:
+    return "Created by [Ballast]" in section and "Do not edit this section." in section
+
+
+def patch_codex_agents_md(
+    existing: str, canonical: str, replace_unmanaged_sections: bool = True
+) -> str:
     if not existing.strip():
         return canonical
 
@@ -1527,7 +1538,15 @@ def patch_codex_agents_md(existing: str, canonical: str) -> str:
             continue
         canonical_section = canonical[canonical_range[0] : canonical_range[1]].rstrip()
 
-        existing_range = find_markdown_section_range(next_content, heading)
+        existing_range = next(
+            (
+                range_
+                for range_ in find_markdown_section_ranges(next_content, heading)
+                if replace_unmanaged_sections
+                or has_ballast_managed_notice(next_content[range_[0] : range_[1]])
+            ),
+            None,
+        )
         if not existing_range:
             next_content = next_content.rstrip() + "\n\n" + canonical_section + "\n"
             continue
@@ -1882,7 +1901,9 @@ def install(
                 content = build_claude_md(support_agents, support_skills, language)
                 next_content = (
                     patch_codex_agents_md(
-                        claude_md.read_text(encoding="utf-8"), content
+                        claude_md.read_text(encoding="utf-8"),
+                        content,
+                        replace_unmanaged_sections=patch or patch_claude_md,
                     )
                     if claude_md.exists() and not force and should_patch_claude_md
                     else content
@@ -1904,7 +1925,9 @@ def install(
                 content = build_gemini_md(support_agents, support_skills, language)
                 next_content = (
                     patch_codex_agents_md(
-                        gemini_md.read_text(encoding="utf-8"), content
+                        gemini_md.read_text(encoding="utf-8"),
+                        content,
+                        replace_unmanaged_sections=patch or patch_gemini_md,
                     )
                     if gemini_md.exists() and not force and should_patch_gemini_md
                     else content
@@ -1925,7 +1948,9 @@ def install(
                 )
                 next_content = (
                     patch_codex_agents_md(
-                        agents_md.read_text(encoding="utf-8"), content
+                        agents_md.read_text(encoding="utf-8"),
+                        content,
+                        replace_unmanaged_sections=patch,
                     )
                     if agents_md.exists() and not force
                     else content

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1872,11 +1872,11 @@ def install(
 
     if target == "claude" and not disable_support_files:
         claude_md = root / "CLAUDE.md"
-        should_patch_claude_md = patch or patch_claude_md
+        should_patch_claude_md = (
+            (claude_md.exists() and not force) or patch or patch_claude_md
+        )
         if str(claude_md) in skipped_support_files:
             result.declined_support_files.append(str(claude_md))
-        elif claude_md.exists() and not force and not should_patch_claude_md:
-            result.skipped_support_files.append(str(claude_md))
         else:
             try:
                 content = build_claude_md(support_agents, support_skills, language)
@@ -1894,11 +1894,11 @@ def install(
 
     if target == "gemini" and not disable_support_files:
         gemini_md = root / "GEMINI.md"
-        should_patch_gemini_md = patch or patch_gemini_md
+        should_patch_gemini_md = (
+            (gemini_md.exists() and not force) or patch or patch_gemini_md
+        )
         if str(gemini_md) in skipped_support_files:
             result.declined_support_files.append(str(gemini_md))
-        elif gemini_md.exists() and not force and not should_patch_gemini_md:
-            result.skipped_support_files.append(str(gemini_md))
         else:
             try:
                 content = build_gemini_md(support_agents, support_skills, language)
@@ -1918,8 +1918,6 @@ def install(
         agents_md = root / "AGENTS.md"
         if str(agents_md) in skipped_support_files:
             result.declined_support_files.append(str(agents_md))
-        elif agents_md.exists() and not force and not patch:
-            result.skipped_support_files.append(str(agents_md))
         else:
             try:
                 content = build_codex_agents_md(
@@ -1929,7 +1927,7 @@ def install(
                     patch_codex_agents_md(
                         agents_md.read_text(encoding="utf-8"), content
                     )
-                    if agents_md.exists() and not force and patch
+                    if agents_md.exists() and not force
                     else content
                 )
                 agents_md.write_text(next_content, encoding="utf-8")
@@ -2010,11 +2008,6 @@ def print_install_result(
             "Skipped (already present; use --force to overwrite): "
             + ", ".join(result.skipped)
         )
-    if result.skipped_support_files:
-        print(
-            "Skipped support files (already present; use --force to overwrite): "
-            + ", ".join(result.skipped_support_files)
-        )
     if result.declined_support_files:
         print(
             "Skipped support files (overwrite declined): "
@@ -2054,24 +2047,6 @@ def run_install(args: argparse.Namespace) -> int:
         print(f"Invalid --target. Use: {', '.join(TARGETS)}")
         return 1
 
-    patch_claude_md = False
-    if "claude" in targets and (root / "CLAUDE.md").exists() and not bool(args.force):
-        if bool(args.patch):
-            patch_claude_md = True
-        elif not is_ci_mode() and not bool(args.yes):
-            patch_claude_md = prompt_yes_no(
-                f"Existing CLAUDE.md found at {root / 'CLAUDE.md'}. Patch the Installed agent rules section?"
-            )
-
-    patch_gemini_md = False
-    if "gemini" in targets and (root / "GEMINI.md").exists() and not bool(args.force):
-        if bool(args.patch):
-            patch_gemini_md = True
-        elif not is_ci_mode() and not bool(args.yes):
-            patch_gemini_md = prompt_yes_no(
-                f"Existing GEMINI.md found at {root / 'GEMINI.md'}. Patch the Installed agent rules section?"
-            )
-
     support_decisions: dict[str, str | None] = {}
     for target in targets:
         skipped_support_file, support_error = confirm_support_file_overwrite(
@@ -2109,8 +2084,8 @@ def run_install(args: argparse.Namespace) -> int:
                     bool(args.force),
                     bool(args.patch),
                     False,
-                    patch_claude_md,
-                    patch_gemini_md,
+                    False,
+                    False,
                     {skipped_support_file} if skipped_support_file else None,
                     deployment_model,
                 ),

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -1192,7 +1192,7 @@ Read and follow these rule files in `.claude/rules/` when they apply:
 
             self.assertFalse((root / "AGENTS.md").exists())
 
-    def test_install_skips_existing_gemini_md_without_patch(self) -> None:
+    def test_install_patches_existing_gemini_md_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             (root / "GEMINI.md").write_text(
@@ -1201,6 +1201,12 @@ Read and follow these rule files in `.claude/rules/` when they apply:
 ## Team Notes
 
 Keep this section.
+
+## Installed agent rules
+
+Read and follow these rule files in `.gemini/rules/` when they apply:
+
+- `.gemini/rules/old.md` - Old rule
 """,
                 encoding="utf-8",
             )
@@ -1209,9 +1215,12 @@ Keep this section.
                 root, "gemini", ["linting"], [], "python", False, False, False
             )
 
-            self.assertIn(str(root / "GEMINI.md"), result.skipped_support_files)
+            self.assertIn(str(root / "GEMINI.md"), result.installed_support_files)
+            self.assertNotIn(str(root / "GEMINI.md"), result.skipped_support_files)
             gemini_md = (root / "GEMINI.md").read_text(encoding="utf-8")
             self.assertIn("## Team Notes", gemini_md)
+            self.assertIn("`.gemini/rules/python-linting.md`", gemini_md)
+            self.assertNotIn("`.gemini/rules/old.md`", gemini_md)
             self.assertFalse((root / "AGENTS.md").exists())
 
     def test_patch_updates_gemini_md_section_only(self) -> None:

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -1204,6 +1204,8 @@ Keep this section.
 
 ## Installed agent rules
 
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
+
 Read and follow these rule files in `.gemini/rules/` when they apply:
 
 - `.gemini/rules/old.md` - Old rule
@@ -1417,6 +1419,25 @@ Read and follow these rule files in `.gemini/rules/` when they apply:
             self.assertIn("`.claude/rules/python-linting.md`", claude_md)
             self.assertNotIn("`.claude/rules/old.md`", claude_md)
 
+    def test_default_patch_preserves_unmanaged_codex_support_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "AGENTS.md").write_text(
+                """# AGENTS.md
+
+## Installed agent rules
+
+- `.codex/rules/old.md` - Team managed rule
+""",
+                encoding="utf-8",
+            )
+
+            cli.install(root, "codex", ["linting"], [], "python", False, False, False)
+
+            agents_md = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("`.codex/rules/old.md`", agents_md)
+            self.assertIn("`.codex/rules/python-linting.md`", agents_md)
+
     def test_patch_merges_frontmatter_keys(self) -> None:
         existing = """---
 description: Team customized linting rules
@@ -1477,6 +1498,31 @@ Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. D
         self.assertIn("```md\n## Installed agent rules\n```", merged)
         self.assertIn("`.codex/rules/python-linting.md`", merged)
         self.assertNotIn("`.codex/rules/old.md`", merged)
+
+    def test_patch_codex_agents_md_preserves_unmanaged_sections_in_managed_only_mode(
+        self,
+    ) -> None:
+        existing = """# AGENTS.md
+
+## Installed agent rules
+
+- `.codex/rules/old.md` - Team managed rule
+"""
+        canonical = """# AGENTS.md
+
+## Installed agent rules
+
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
+
+- `.codex/rules/python-linting.md` - New rule
+"""
+
+        merged = cli.patch_codex_agents_md(
+            existing, canonical, replace_unmanaged_sections=False
+        )
+
+        self.assertIn("`.codex/rules/old.md`", merged)
+        self.assertIn("`.codex/rules/python-linting.md`", merged)
 
 
 if __name__ == "__main__":

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -165,7 +165,7 @@ Options:
   --all                     Install all agents
   --all-skills              Install all skills
   --task-system <system>    Task system for the tasks agent: ${TASK_SYSTEMS.join(', ')} (default: github)
-  --deployment-model <model> Deployment model for the publishing agent: ${DEPLOYMENT_MODELS.join(', ')} (default: none)
+  --deployment-model <model> App/service deployment model for publishing; use none for CLI/library/SDK-only projects: ${DEPLOYMENT_MODELS.join(', ')} (default: none)
   --force, -f               Overwrite existing rule/skill files; prompts before replacing AGENTS.md, CLAUDE.md, or GEMINI.md
   --patch, -p               Merge upstream rule/skill updates into existing files; ignored when --force is set
   --yes, -y                 Non-interactive; require --target and --agent/--all if no .rulesrc.json

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -1688,7 +1688,7 @@ Keep my custom responsibilities.
         );
       });
 
-      test('claude skips existing CLAUDE.md unless patch is approved', () => {
+      test('claude patches existing CLAUDE.md by default', () => {
         fs.writeFileSync(
           path.join(tmpDir, 'CLAUDE.md'),
           `# CLAUDE.md
@@ -1696,6 +1696,12 @@ Keep my custom responsibilities.
 ## Team Notes
 
 Keep this section.
+
+## Installed agent rules
+
+Read and follow these rule files in \`.claude/rules/\` when they apply:
+
+- \`.claude/rules/old.md\` — Old rule
 `
         );
 
@@ -1707,12 +1713,19 @@ Keep this section.
           saveConfig: false
         });
 
-        expect(result.skippedSupportFiles).toContain(
+        expect(result.installedSupportFiles).toContain(
           path.join(tmpDir, 'CLAUDE.md')
         );
-        expect(
-          fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8')
-        ).toContain('## Team Notes');
+        expect(result.skippedSupportFiles).not.toContain(
+          path.join(tmpDir, 'CLAUDE.md')
+        );
+        const claudeMd = fs.readFileSync(
+          path.join(tmpDir, 'CLAUDE.md'),
+          'utf8'
+        );
+        expect(claudeMd).toContain('## Team Notes');
+        expect(claudeMd).toContain('`.claude/rules/typescript-linting.md`');
+        expect(claudeMd).not.toContain('`.claude/rules/old.md`');
       });
 
       test('claude patch updates installed rules section without removing user notes', () => {
@@ -1883,7 +1896,7 @@ Read and follow these rule files in \`.gemini/rules/\` when they apply:
         expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
       });
 
-      test('gemini skips existing GEMINI.md unless patch is approved', () => {
+      test('gemini patches existing GEMINI.md by default', () => {
         fs.writeFileSync(
           path.join(tmpDir, 'GEMINI.md'),
           `# GEMINI.md
@@ -1891,6 +1904,12 @@ Read and follow these rule files in \`.gemini/rules/\` when they apply:
 ## Team Notes
 
 Keep this section.
+
+## Installed agent rules
+
+Read and follow these rule files in \`.gemini/rules/\` when they apply:
+
+- \`.gemini/rules/old.md\` — Old rule
 `
         );
 
@@ -1902,12 +1921,19 @@ Keep this section.
           saveConfig: false
         });
 
-        expect(result.skippedSupportFiles).toContain(
+        expect(result.installedSupportFiles).toContain(
           path.join(tmpDir, 'GEMINI.md')
         );
-        expect(
-          fs.readFileSync(path.join(tmpDir, 'GEMINI.md'), 'utf8')
-        ).toContain('## Team Notes');
+        expect(result.skippedSupportFiles).not.toContain(
+          path.join(tmpDir, 'GEMINI.md')
+        );
+        const geminiMd = fs.readFileSync(
+          path.join(tmpDir, 'GEMINI.md'),
+          'utf8'
+        );
+        expect(geminiMd).toContain('## Team Notes');
+        expect(geminiMd).toContain('`.gemini/rules/typescript-linting.md`');
+        expect(geminiMd).not.toContain('`.gemini/rules/old.md`');
       });
 
       test('codex: writes to .codex/rules/<agent>.md and AGENTS.md', () => {

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -1699,6 +1699,8 @@ Keep this section.
 
 ## Installed agent rules
 
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
+
 Read and follow these rule files in \`.claude/rules/\` when they apply:
 
 - \`.claude/rules/old.md\` — Old rule
@@ -1850,6 +1852,8 @@ Keep this section.
 
 ## Installed agent rules
 
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
+
 Read and follow these rule files in \`.gemini/rules/\` when they apply:
 
 - \`.gemini/rules/old.md\` — Old rule
@@ -1906,6 +1910,8 @@ Read and follow these rule files in \`.gemini/rules/\` when they apply:
 Keep this section.
 
 ## Installed agent rules
+
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
 
 Read and follow these rule files in \`.gemini/rules/\` when they apply:
 
@@ -2011,6 +2017,33 @@ Read and follow these rule files in \`.codex/rules/\` when they apply:
         expect(agentsMd).toContain('Keep this section.');
         expect(agentsMd).toContain('`.codex/rules/typescript-linting.md`');
         expect(agentsMd).not.toContain('`.codex/rules/old.md`');
+      });
+
+      test('codex default patch preserves unmanaged installed rules section', () => {
+        fs.writeFileSync(
+          path.join(tmpDir, 'AGENTS.md'),
+          `# AGENTS.md
+
+## Installed agent rules
+
+- \`.codex/rules/old.md\` — Team managed rule
+`
+        );
+
+        install({
+          projectRoot: tmpDir,
+          target: 'codex',
+          agents: ['linting'],
+          force: false,
+          saveConfig: false
+        });
+
+        const agentsMd = fs.readFileSync(
+          path.join(tmpDir, 'AGENTS.md'),
+          'utf8'
+        );
+        expect(agentsMd).toContain('`.codex/rules/old.md`');
+        expect(agentsMd).toContain('`.codex/rules/typescript-linting.md`');
       });
 
       test('codex patch keeps rules in AGENTS.md for config-backed skill-only updates', () => {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -776,7 +776,13 @@ export function install(options: InstallOptions): InstallResult {
         );
         const nextContent =
           fs.existsSync(claudeMdPath) && !force && shouldPatchClaudeMd
-            ? patchCodexAgentsMd(fs.readFileSync(claudeMdPath, 'utf8'), content)
+            ? patchCodexAgentsMd(
+                fs.readFileSync(claudeMdPath, 'utf8'),
+                content,
+                {
+                  replaceUnmanagedSections: patch || patchClaudeMd
+                }
+              )
             : content;
         fs.writeFileSync(claudeMdPath, nextContent, 'utf8');
         installedSupportFiles.push(claudeMdPath);
@@ -804,7 +810,13 @@ export function install(options: InstallOptions): InstallResult {
         );
         const nextContent =
           fs.existsSync(geminiMdPath) && !force && shouldPatchGeminiMd
-            ? patchCodexAgentsMd(fs.readFileSync(geminiMdPath, 'utf8'), content)
+            ? patchCodexAgentsMd(
+                fs.readFileSync(geminiMdPath, 'utf8'),
+                content,
+                {
+                  replaceUnmanagedSections: patch || patchGeminiMd
+                }
+              )
             : content;
         fs.writeFileSync(geminiMdPath, nextContent, 'utf8');
         installedSupportFiles.push(geminiMdPath);
@@ -830,7 +842,13 @@ export function install(options: InstallOptions): InstallResult {
         );
         const nextContent =
           fs.existsSync(agentsMdPath) && !force
-            ? patchCodexAgentsMd(fs.readFileSync(agentsMdPath, 'utf8'), content)
+            ? patchCodexAgentsMd(
+                fs.readFileSync(agentsMdPath, 'utf8'),
+                content,
+                {
+                  replaceUnmanagedSections: patch
+                }
+              )
             : content;
         fs.writeFileSync(agentsMdPath, nextContent, 'utf8');
         installedSupportFiles.push(agentsMdPath);

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -763,11 +763,10 @@ export function install(options: InstallOptions): InstallResult {
 
   if (!disableSupportFiles && target === 'claude') {
     const claudeMdPath = getClaudeMdPath(projectRoot);
-    const shouldPatchClaudeMd = patch || patchClaudeMd;
+    const shouldPatchClaudeMd =
+      fs.existsSync(claudeMdPath) && !force ? true : patch || patchClaudeMd;
     if (skippedSupportSet.has(claudeMdPath)) {
       declinedSupportFiles.push(claudeMdPath);
-    } else if (fs.existsSync(claudeMdPath) && !force && !shouldPatchClaudeMd) {
-      skippedSupportFiles.push(claudeMdPath);
     } else {
       try {
         const content = buildClaudeMd(
@@ -792,11 +791,10 @@ export function install(options: InstallOptions): InstallResult {
 
   if (!disableSupportFiles && target === 'gemini') {
     const geminiMdPath = getGeminiMdPath(projectRoot);
-    const shouldPatchGeminiMd = patch || patchGeminiMd;
+    const shouldPatchGeminiMd =
+      fs.existsSync(geminiMdPath) && !force ? true : patch || patchGeminiMd;
     if (skippedSupportSet.has(geminiMdPath)) {
       declinedSupportFiles.push(geminiMdPath);
-    } else if (fs.existsSync(geminiMdPath) && !force && !shouldPatchGeminiMd) {
-      skippedSupportFiles.push(geminiMdPath);
     } else {
       try {
         const content = buildGeminiMd(
@@ -823,8 +821,6 @@ export function install(options: InstallOptions): InstallResult {
     const agentsMdPath = getCodexAgentsMdPath(projectRoot);
     if (skippedSupportSet.has(agentsMdPath)) {
       declinedSupportFiles.push(agentsMdPath);
-    } else if (fs.existsSync(agentsMdPath) && !force && !patch) {
-      skippedSupportFiles.push(agentsMdPath);
     } else {
       try {
         const content = buildCodexAgentsMd(
@@ -833,7 +829,7 @@ export function install(options: InstallOptions): InstallResult {
           language
         );
         const nextContent =
-          fs.existsSync(agentsMdPath) && !force && patch
+          fs.existsSync(agentsMdPath) && !force
             ? patchCodexAgentsMd(fs.readFileSync(agentsMdPath, 'utf8'), content)
             : content;
         fs.writeFileSync(agentsMdPath, nextContent, 'utf8');
@@ -1052,30 +1048,6 @@ export async function runInstall(
       );
     }
 
-    const claudeMdPath = getClaudeMdPath(projectRoot);
-    let patchClaudeMd = false;
-    if (target === 'claude' && fs.existsSync(claudeMdPath) && !options.force) {
-      if (options.patch) {
-        patchClaudeMd = true;
-      } else if (!isCiMode() && !options.yes) {
-        patchClaudeMd = await promptYesNo(
-          `Existing CLAUDE.md found at ${claudeMdPath}. Patch the Installed agent rules section?`
-        );
-      }
-    }
-
-    const geminiMdPath = getGeminiMdPath(projectRoot);
-    let patchGeminiMd = false;
-    if (target === 'gemini' && fs.existsSync(geminiMdPath) && !options.force) {
-      if (options.patch) {
-        patchGeminiMd = true;
-      } else if (!isCiMode() && !options.yes) {
-        patchGeminiMd = await promptYesNo(
-          `Existing GEMINI.md found at ${geminiMdPath}. Patch the Installed agent rules section?`
-        );
-      }
-    }
-
     const result = install({
       projectRoot,
       target,
@@ -1084,8 +1056,8 @@ export async function runInstall(
       language,
       force: options.force ?? false,
       patch: options.patch ?? false,
-      patchClaudeMd,
-      patchGeminiMd,
+      patchClaudeMd: false,
+      patchGeminiMd: false,
       skipSupportFiles: supportDecision.skipSupportFile
         ? [supportDecision.skipSupportFile]
         : [],
@@ -1135,13 +1107,6 @@ export async function runInstall(
     if (result.skipped.length > 0) {
       console.log(
         `Skipped (already present; use --force to overwrite): ${result.skipped.join(', ')}`
-      );
-    }
-    if (result.skippedSupportFiles.length > 0) {
-      console.log(
-        `Skipped support files (already present; use --force to overwrite): ${result.skippedSupportFiles.join(
-          ', '
-        )}`
       );
     }
     if (result.declinedSupportFiles.length > 0) {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -182,7 +182,7 @@ async function promptTaskSystem(): Promise<TaskSystem> {
 
 async function promptDeploymentModel(): Promise<DeploymentModel> {
   const line = await prompt(
-    `Deployment model (${DEPLOYMENT_MODELS.join(', ')}) [${DEFAULT_DEPLOYMENT_MODEL}]: `
+    `App deployment model for publishing (use none for CLI/library/SDK-only projects) (${DEPLOYMENT_MODELS.join(', ')}) [${DEFAULT_DEPLOYMENT_MODEL}]: `
   );
   if (!line) return DEFAULT_DEPLOYMENT_MODEL;
   const token = line.trim().toLowerCase();

--- a/packages/ballast-typescript/src/patch.test.ts
+++ b/packages/ballast-typescript/src/patch.test.ts
@@ -235,6 +235,41 @@ Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. D
       expect(merged).toContain('`.codex/rules/typescript-linting.md`');
     });
 
+    test('normalizes CRLF content before patching installed sections', () => {
+      const existing = [
+        '# AGENTS.md',
+        '',
+        '## Team Notes',
+        '',
+        'Keep this note.',
+        '',
+        '## Installed agent rules',
+        '',
+        'Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.',
+        '',
+        '- `.codex/rules/old.md` — Old rule',
+        ''
+      ].join('\r\n');
+      const canonical = [
+        '# AGENTS.md',
+        '',
+        '## Installed agent rules',
+        '',
+        'Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.',
+        '',
+        '- `.codex/rules/typescript-linting.md` — Linting rule',
+        ''
+      ].join('\r\n');
+
+      const merged = patchCodexAgentsMd(existing, canonical, {
+        replaceUnmanagedSections: false
+      });
+      expect(merged).toContain('## Team Notes\n\nKeep this note.');
+      expect(merged).toContain('`.codex/rules/typescript-linting.md`');
+      expect(merged).not.toContain('`.codex/rules/old.md`');
+      expect(merged).not.toContain('\r\n');
+    });
+
     test('ignores installed-rules headings inside fenced code blocks', () => {
       const existing = `# AGENTS.md
 

--- a/packages/ballast-typescript/src/patch.test.ts
+++ b/packages/ballast-typescript/src/patch.test.ts
@@ -211,6 +211,30 @@ Read and follow these rule files in \`.codex/rules/\` when they apply:
       expect(merged).not.toContain('`.codex/rules/old.md`');
     });
 
+    test('preserves unmanaged installed sections in managed-only mode', () => {
+      const existing = `# AGENTS.md
+
+## Installed agent rules
+
+- \`.codex/rules/old.md\` — Team managed rule
+`;
+
+      const canonical = `# AGENTS.md
+
+## Installed agent rules
+
+Created by [Ballast](https://github.com/everydaydevopsio/ballast) v9.9.9-test. Do not edit this section.
+
+- \`.codex/rules/typescript-linting.md\` — Linting rule
+`;
+
+      const merged = patchCodexAgentsMd(existing, canonical, {
+        replaceUnmanagedSections: false
+      });
+      expect(merged).toContain('`.codex/rules/old.md`');
+      expect(merged).toContain('`.codex/rules/typescript-linting.md`');
+    });
+
     test('ignores installed-rules headings inside fenced code blocks', () => {
       const existing = `# AGENTS.md
 

--- a/packages/ballast-typescript/src/patch.ts
+++ b/packages/ballast-typescript/src/patch.ts
@@ -11,6 +11,15 @@ interface MarkdownSection {
   text: string;
 }
 
+interface MarkdownSectionRange {
+  start: number;
+  end: number;
+}
+
+interface PatchCodexAgentsMdOptions {
+  replaceUnmanagedSections?: boolean;
+}
+
 interface ParsedMarkdownBody {
   intro: string;
   sections: MarkdownSection[];
@@ -186,48 +195,61 @@ export function patchRuleContent(
   }
 }
 
-function findMarkdownSectionRange(
+function findMarkdownSectionRanges(
   content: string,
   heading: string
-): { start: number; end: number } | null {
+): MarkdownSectionRange[] {
   const lines = content.split(/\r?\n/);
   const targetHeading = `## ${heading}`;
   let inFence = false;
   let offset = 0;
+  const headings: Array<{ line: string; start: number }> = [];
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  for (const line of lines) {
     if (line.startsWith('```')) {
       inFence = !inFence;
     }
-    if (!inFence && line === targetHeading) {
-      const start = offset;
-      offset += line.length + 1;
-      for (let j = i + 1; j < lines.length; j++) {
-        const nextLine = lines[j];
-        if (nextLine.startsWith('```')) {
-          inFence = !inFence;
-        }
-        if (!inFence && nextLine.startsWith('## ')) {
-          return { start, end: offset - 1 };
-        }
-        offset += nextLine.length + 1;
-      }
-      return { start, end: content.length };
+    if (!inFence && line.startsWith('## ')) {
+      headings.push({ line, start: offset });
     }
     offset += line.length + 1;
   }
-  return null;
+
+  return headings
+    .map((item, index) => ({
+      heading: item.line,
+      start: item.start,
+      end:
+        index + 1 < headings.length ? headings[index + 1].start : content.length
+    }))
+    .filter((range) => range.heading === targetHeading)
+    .map(({ start, end }) => ({ start, end }));
+}
+
+function findMarkdownSectionRange(
+  content: string,
+  heading: string
+): MarkdownSectionRange | null {
+  return findMarkdownSectionRanges(content, heading)[0] ?? null;
+}
+
+function hasBallastManagedNotice(section: string): boolean {
+  return (
+    section.includes('Created by [Ballast]') &&
+    section.includes('Do not edit this section.')
+  );
 }
 
 export function patchCodexAgentsMd(
   existing: string,
-  canonical: string
+  canonical: string,
+  options: PatchCodexAgentsMdOptions = {}
 ): string {
   if (!existing.trim()) {
     return canonical;
   }
 
+  const replaceUnmanagedSections = options.replaceUnmanagedSections ?? true;
   let next = existing;
   for (const heading of ['Installed agent rules', 'Installed skills']) {
     const canonicalRange = findMarkdownSectionRange(canonical, heading);
@@ -238,7 +260,13 @@ export function patchCodexAgentsMd(
     const canonicalSection = canonical
       .slice(canonicalRange.start, canonicalRange.end)
       .trimEnd();
-    const existingRange = findMarkdownSectionRange(next, heading);
+    const existingRange =
+      findMarkdownSectionRanges(next, heading).find((range) => {
+        if (replaceUnmanagedSections) {
+          return true;
+        }
+        return hasBallastManagedNotice(next.slice(range.start, range.end));
+      }) ?? null;
 
     if (!existingRange) {
       next = `${next.trimEnd()}\n\n${canonicalSection}\n`;

--- a/packages/ballast-typescript/src/patch.ts
+++ b/packages/ballast-typescript/src/patch.ts
@@ -27,6 +27,10 @@ interface ParsedMarkdownBody {
 
 const DANGEROUS_YAML_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n/g, '\n');
+}
+
 function splitFrontmatterDocument(content: string): ParsedFrontmatterDocument {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
   if (!match || match.index !== 0) {
@@ -246,9 +250,11 @@ export function patchCodexAgentsMd(
   options: PatchCodexAgentsMdOptions = {}
 ): string {
   if (!existing.trim()) {
-    return canonical;
+    return normalizeLineEndings(canonical);
   }
 
+  existing = normalizeLineEndings(existing);
+  canonical = normalizeLineEndings(canonical);
   const replaceUnmanagedSections = options.replaceUnmanagedSections ?? true;
   let next = existing;
   for (const heading of ['Installed agent rules', 'Installed skills']) {

--- a/scripts/e2e-go-first-run-required-options.sh
+++ b/scripts/e2e-go-first-run-required-options.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/go-first-run-required-options"
+mkdir -p "${PROJECT}"
+
+cat > "${PROJECT}/go.mod" <<'EOF'
+module example.com/ballast-go-required-options
+
+go 1.24
+EOF
+
+OUTPUT="$(
+  cd "${PROJECT}"
+  printf 'linear\nserverless\n' | ballast-go install --target codex --language go --all
+)"
+
+assert_contains '"taskSystem": "linear"' "${PROJECT}/.rulesrc.json"
+assert_contains '"deploymentModel": "serverless"' "${PROJECT}/.rulesrc.json"
+assert_file_exists "${PROJECT}/.codex/rules/tasks-task-system.md"
+assert_contains 'linear' "${PROJECT}/.codex/rules/tasks-task-system.md"
+assert_not_contains '{{taskSystem}}' "${PROJECT}/.codex/rules/tasks-task-system.md"
+assert_contains 'Serverless deployment model:' "${PROJECT}/.codex/rules/publishing-apps.md"
+assert_doctor_contains "${OUTPUT}" "Task system for tasks"
+assert_doctor_contains "${OUTPUT}" "Deployment model for publishing apps"
+
+echo "PASS: go-first-run-required-options-e2e"

--- a/scripts/e2e-go-first-run-required-options.sh
+++ b/scripts/e2e-go-first-run-required-options.sh
@@ -20,7 +20,9 @@ EOF
 
 OUTPUT="$(
   cd "${PROJECT}"
-  printf 'linear\nserverless\n' | ballast-go install --target codex --language go --all
+  printf 'linear\nserverless\n' |
+    env -u CI -u GITHUB_ACTIONS -u GITLAB_CI -u TF_BUILD -u BUILDKITE -u CIRCLECI \
+      ballast-go install --target codex --language go --all
 )"
 
 assert_contains '"taskSystem": "linear"' "${PROJECT}/.rulesrc.json"

--- a/scripts/e2e-go-first-run-required-options.sh
+++ b/scripts/e2e-go-first-run-required-options.sh
@@ -30,6 +30,6 @@ assert_contains 'linear' "${PROJECT}/.codex/rules/tasks-task-system.md"
 assert_not_contains '{{taskSystem}}' "${PROJECT}/.codex/rules/tasks-task-system.md"
 assert_contains 'Serverless deployment model:' "${PROJECT}/.codex/rules/publishing-apps.md"
 assert_doctor_contains "${OUTPUT}" "Task system for tasks"
-assert_doctor_contains "${OUTPUT}" "Deployment model for publishing apps"
+assert_doctor_contains "${OUTPUT}" "App deployment model for publishing (use none for CLI/library/SDK-only projects)"
 
 echo "PASS: go-first-run-required-options-e2e"

--- a/scripts/e2e-support-file-default-patch.sh
+++ b/scripts/e2e-support-file-default-patch.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+# shellcheck source=./e2e/helpers.sh
+source "${REPO_ROOT}/scripts/e2e/helpers.sh"
+setup_ballast_e2e
+
+PROJECT="${WORKDIR}/support-file-default-patch"
+mkdir -p "${PROJECT}"
+
+cat > "${PROJECT}/go.mod" <<'EOF'
+module example.com/ballast-support-file-default-patch
+
+go 1.24
+EOF
+
+cat > "${PROJECT}/AGENTS.md" <<'EOF'
+# AGENTS.md
+
+## Team Notes
+
+Keep this section.
+
+## Installed agent rules
+
+Created by Ballast. Do not edit this section.
+
+Read and follow these rule files in `.codex/rules/` when they apply:
+
+- `.codex/rules/old.md` — Old rule
+EOF
+
+OUTPUT="$(
+  cd "${PROJECT}"
+  ballast-go install --target codex --language go --agent docs --yes
+)"
+
+assert_contains '## Team Notes' "${PROJECT}/AGENTS.md"
+assert_contains 'Keep this section.' "${PROJECT}/AGENTS.md"
+assert_contains '`.codex/rules/docs.md`' "${PROJECT}/AGENTS.md"
+assert_not_contains '`.codex/rules/old.md`' "${PROJECT}/AGENTS.md"
+assert_not_contains 'Skipped support files' <(printf '%s' "${OUTPUT}")
+
+echo "PASS: support-file-default-patch-e2e"

--- a/scripts/release-cross-language-check.sh
+++ b/scripts/release-cross-language-check.sh
@@ -45,6 +45,8 @@ main() {
   run_language_smoke "terraform-sample" "terraform" "ballast-go" "terraform-linting.mdc"
 
   "${REPO_ROOT}/scripts/smoke-wrapper-monorepo.sh"
+  "${REPO_ROOT}/scripts/e2e-go-first-run-required-options.sh"
+  "${REPO_ROOT}/scripts/e2e-support-file-default-patch.sh"
 
   echo "Cross-language release validation passed."
 }


### PR DESCRIPTION
## Summary
- patch existing AGENTS.md/CLAUDE.md/GEMINI.md support files by default instead of skipping them
- resolve required taskSystem/deploymentModel options through shared code paths in wrapper and ballast-go
- add e2e coverage for first-run Go prompts and default support-file patching

## Tests
- go test ./... (cli/ballast)
- go test ./cmd/ballast-go (packages/ballast-go)
- pnpm --dir packages/ballast-typescript test -- install.test.ts
- uv run --directory packages/ballast-python --with pytest python -m pytest tests/test_cli.py
- ./scripts/e2e-go-first-run-required-options.sh
- ./scripts/e2e-support-file-default-patch.sh
- ./scripts/release-cross-language-check.sh with repo-local CI-style binaries