### PR TITLE
Add integration framework detection guidance

### DIFF
--- a/.claude/rules/common/typescript-testing.md
+++ b/.claude/rules/common/typescript-testing.md
@@ -17,6 +17,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -40,7 +42,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -56,6 +59,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/.claude/rules/go/go-testing.md
+++ b/.claude/rules/go/go-testing.md
@@ -11,11 +11,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -23,6 +24,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -33,3 +40,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
+- Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/.claude/rules/python/python-testing.md
+++ b/.claude/rules/python/python-testing.md
@@ -10,11 +10,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -22,6 +23,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -32,3 +39,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the framework already used by the repo.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
+- Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/.claude/rules/typescript-testing.md
+++ b/.claude/rules/typescript-testing.md
@@ -16,6 +16,8 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -38,6 +40,8 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 - Reuse the real app `Dockerfile` and `docker-compose.yaml` when the repo has them.
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - Keep E2E narrow and stable. One critical path is enough unless the user asks for more.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Publish clear pass/fail output for smoke checks.
 
 ## Implementation Order
@@ -52,6 +56,7 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed
@@ -200,7 +205,8 @@ When the project ships a runnable app or service, add a smoke-test path in addit
 
 4. **Add an end-to-end path when the app has a user-facing flow**
    - For web apps, add E2E coverage for at least one critical path such as app boot, login, health page, or a core workflow.
-   - Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+   - Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+   - Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
    - Keep E2E scope narrow and stable; one critical user workflow is enough unless the user asks for more.
    - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 

--- a/.claude/rules/typescript/typescript-testing.md
+++ b/.claude/rules/typescript/typescript-testing.md
@@ -17,6 +17,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -40,7 +42,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -56,6 +59,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/.codex/rules/common/typescript-testing.md
+++ b/.codex/rules/common/typescript-testing.md
@@ -19,6 +19,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -42,7 +44,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -58,6 +61,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/.codex/rules/go/go-testing.md
+++ b/.codex/rules/go/go-testing.md
@@ -11,11 +11,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -23,6 +24,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -33,3 +40,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
+- Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/.codex/rules/python/python-testing.md
+++ b/.codex/rules/python/python-testing.md
@@ -10,11 +10,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -22,6 +23,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -32,3 +39,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the framework already used by the repo.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
+- Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/.codex/rules/typescript-testing.md
+++ b/.codex/rules/typescript-testing.md
@@ -18,6 +18,8 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -41,7 +43,8 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -57,6 +60,7 @@ You are a testing specialist for TypeScript and JavaScript projects. Your role i
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/.codex/rules/typescript/typescript-testing.md
+++ b/.codex/rules/typescript/typescript-testing.md
@@ -19,6 +19,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -42,7 +44,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -58,6 +61,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Suggested facts to record:
 Update this section when those facts change. If live runtime state is required, discover it separately instead of treating it as a durable repo fact.
 
 - Root `.rulesrc.json` targets are repo policy. Keep them aligned with every checked-in Ballast-managed target surface.
+- Do not edit checked-in `.claude/` or `.codex/` generated rule outputs directly. Change the source templates/content under repo-root `agents/` and `skills/`, then regenerate the local Ballast-managed outputs.
 - When repo-root `agents/`, `skills/`, Ballast sync/build scripts, or root target config change, regenerate and commit the corresponding local Ballast-managed `.claude/` and `.codex/` outputs in the same PR.
 
 ## Installed agent rules
@@ -72,4 +73,3 @@ Read and use these skill files in `.codex/rules/` when they are relevant:
 - `.codex/rules/aws-live-health-review.md` — run a read-only AWS live health review for current EC2, RDS, ALB, CloudWatch alarms, and logs
 - `.codex/rules/aws-weekly-security-review.md` — run a weekly read-only AWS security baseline review and generate a prioritized findings report
 - `.codex/rules/ballast-audit.md` — audit AI rule and skill files for context density, duplication, and bloat
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ Suggested facts to record:
 
 Update this section when those facts change. If live runtime state is required, discover it separately instead of treating it as a durable repo fact.
 
+- Root `.rulesrc.json` targets are repo policy. Keep them aligned with every checked-in Ballast-managed target surface.
+- Do not edit checked-in `.claude/` or `.codex/` generated rule outputs directly. Change the source templates/content under repo-root `agents/` and `skills/`, then regenerate the local Ballast-managed outputs.
+- When repo-root `agents/`, `skills/`, Ballast sync/build scripts, or root target config change, regenerate and commit the corresponding local Ballast-managed `.claude/` and `.codex/` outputs in the same PR.
+
 ## Installed agent rules
 
 Created by Ballast. Do not edit this section.
@@ -69,4 +73,3 @@ Read and use these skill files in `.claude/skills/` when they are relevant:
 - `.claude/skills/aws-live-health-review.skill` — run a read-only AWS live health review for current EC2, RDS, ALB, CloudWatch alarms, and logs
 - `.claude/skills/aws-weekly-security-review.skill` — run a weekly read-only AWS security baseline review and generate a prioritized findings report
 - `.claude/skills/ballast-audit.skill` — audit AI rule and skill files for context density, duplication, and bloat
-

--- a/PRD.md
+++ b/PRD.md
@@ -297,6 +297,32 @@ Ballast testing and publishing rules mention smoke tests, but they do not consis
 5. `docs/agents/testing.md` and `docs/agents/publishing.md` include the same operator-facing guidance.
 6. Tests or snapshots fail if the generated guidance drops the required smoke/E2E or CLI packaged-command expectations.
 
+## Integration Framework Detection Guidance
+
+### Problem
+
+Ballast testing rules now define smoke and E2E expectations, but agents still need explicit framework-detection discipline before adding or changing integration tests. Without language-aware detection markers, agents can replace established E2E stacks, add Playwright to library-only repositories, or miss browser app surfaces that should use Playwright when no browser E2E framework exists.
+
+### Requirements
+
+1. Generated TypeScript testing guidance must tell agents to detect existing unit, integration, and browser E2E frameworks before introducing new test tooling.
+2. Generated Python and Go testing guidance must tell agents to detect existing unit, integration, API, service, and browser E2E frameworks before introducing new test tooling.
+3. Browser E2E guidance must preserve an existing browser E2E framework such as Cypress, WebdriverIO, Selenium, Puppeteer, Robot Framework, pytest-playwright, Playwright Test, or Go browser harnesses when one is already present.
+4. Browser E2E guidance must prefer Playwright only when Playwright markers already exist or when the repository has a real browser application surface and no existing browser E2E framework.
+5. Generated guidance must warn agents not to add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
+6. Documentation must describe the same framework-detection and Playwright-selection expectations.
+7. Automated generated-content tests must cover the framework markers, existing-framework preservation, Playwright preference, and non-browser guardrail.
+
+### Acceptance Criteria
+
+1. TypeScript generated testing rules mention package/config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library.
+2. Python generated testing rules mention markers for pytest, unittest, tox/nox, Robot Framework, Selenium, Playwright or pytest-playwright, and API/service test clients.
+3. Go generated testing rules mention `go test`, integration build tags or naming, API/service tests, Selenium/chromedp/rod/agouti, and Playwright-driven browser harnesses.
+4. Generated testing rules for TypeScript, Python, and Go preserve existing browser E2E frameworks before adding Playwright.
+5. Generated testing rules for TypeScript, Python, and Go prefer Playwright only for existing Playwright repos or browser apps with no existing browser E2E framework.
+6. `docs/agents/testing.md` includes operator-facing framework-detection guidance aligned with generated rules.
+7. Tests fail if generated guidance loses required detection markers, existing-framework preservation, Playwright preference, or non-browser guardrails.
+
 ## Deployment Model Configuration
 
 ### Problem

--- a/agents/go/testing/content.md
+++ b/agents/go/testing/content.md
@@ -6,11 +6,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -18,6 +19,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -29,5 +36,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/agents/python/testing/content.md
+++ b/agents/python/testing/content.md
@@ -5,11 +5,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -17,6 +18,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -28,5 +35,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the repo's existing browser E2E framework when one is already present.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/agents/typescript/testing/content.md
+++ b/agents/typescript/testing/content.md
@@ -12,6 +12,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -35,7 +37,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -51,6 +54,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -35,7 +35,16 @@ The **testing** agent sets up and maintains test workflows for TypeScript, Pytho
 - Web smoke tests that use the repo Dockerfile and `docker-compose.yaml` for runnable apps and verify a live route or health endpoint
 - Explicit smoke-test pass/fail output
 - A smoke-test GitHub Action and matching README badge
-- Narrow end-to-end coverage for one critical workflow when the app has a real user flow, keeping an existing browser E2E framework when present and preferring Playwright only when Playwright markers already exist or browser automation is needed without an existing browser E2E framework
+- Narrow end-to-end coverage for one critical workflow when the app has a real user flow, keeping an existing browser E2E framework when present and preferring Playwright only when Playwright markers already exist or the repo has a real browser application surface with no existing browser E2E framework
+
+## Framework Detection
+
+- TypeScript/JavaScript: check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library before adding or replacing test tooling.
+- Python: check markers for pytest, unittest, tox, nox, Robot Framework, Selenium, Playwright or pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and existing API/service test clients.
+- Go: check markers for `go test`, integration build tags, `_integration_test.go`, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 
 ## Smoke and E2E Placement
 

--- a/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/go/testing/content.md
@@ -6,11 +6,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -18,6 +19,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -29,5 +36,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/python/testing/content.md
@@ -5,11 +5,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -17,6 +18,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -28,5 +35,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the repo's existing browser E2E framework when one is already present.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-go/cmd/ballast-go/agents/typescript/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/typescript/testing/content.md
@@ -12,6 +12,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -35,7 +37,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -51,6 +54,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/go/testing/content.md
@@ -6,11 +6,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -18,6 +19,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -29,5 +36,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/python/testing/content.md
@@ -5,11 +5,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -17,6 +18,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -28,5 +35,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the repo's existing browser E2E framework when one is already present.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-go/cmd/ballast/agents/typescript/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/typescript/testing/content.md
@@ -12,6 +12,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -35,7 +37,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -51,6 +54,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/packages/ballast-python/ballast/agents/go/testing/content.md
+++ b/packages/ballast-python/ballast/agents/go/testing/content.md
@@ -6,11 +6,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 2. Add table-driven tests for core logic.
 3. Make coverage part of the default test workflow, not an optional follow-up check.
 4. Include coverage checks in CI and fail when coverage requirements are not met.
-5. Keep tests deterministic and isolated.
-6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-7. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
-8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-9. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
+5. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+6. Keep tests deterministic and isolated.
+7. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+8. Make smoke tests emit explicit pass/fail output and exit non-zero on failure.
+9. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+10. Add narrow end-to-end coverage for one critical workflow when the app exposes a real end-user path.
 
 ## Commands
 
@@ -18,6 +19,12 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - `go test ./... -cover`
 - Coverage gate (example): `go test ./... -covermode=atomic -coverprofile=coverage.out` plus a threshold check in CI
 - a smoke-test command or script that validates the built container and prints explicit success/failure output
+
+## Framework Detection
+
+- Check markers for `go test`, integration build tags, `_integration_test.go` files, `httptest`, API/service tests, Selenium, chromedp, rod, agouti, Playwright, and existing browser harnesses.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -29,5 +36,6 @@ You are a Go testing specialist. Your role is to set up effective and maintainab
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds with Docker Compose, runs the smoke command, and fails the workflow on errors.
 - Add a README badge for the smoke workflow.
 - For apps with real user-facing or API workflows, add one stable E2E path that validates a critical flow without making the suite flaky.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-python/ballast/agents/python/testing/content.md
+++ b/packages/ballast-python/ballast/agents/python/testing/content.md
@@ -5,11 +5,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 1. Configure pytest with clear test discovery.
 2. Add coverage reporting via pytest-cov and make coverage part of the default test workflow.
 3. Provide fast local test commands and CI test steps, including a coverage step that fails when coverage requirements are not met.
-4. Encourage deterministic unit tests and minimal flaky integration tests.
-5. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
-6. Make smoke tests emit explicit pass/fail output and fail the command on errors.
-7. Add a GitHub Actions smoke-test workflow and a README badge for its status.
-8. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
+4. Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.
+5. Encourage deterministic unit tests and minimal flaky integration tests.
+6. When the project ships a runnable app or service, add smoke tests that build with the repo Dockerfile and run via `docker-compose.yaml`.
+7. Make smoke tests emit explicit pass/fail output and fail the command on errors.
+8. Add a GitHub Actions smoke-test workflow and a README badge for its status.
+9. Add narrow end-to-end coverage for one critical user flow when the app exposes a real workflow.
 
 ## Commands
 
@@ -17,6 +18,12 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - `pytest --cov=. --cov-report=term-missing`
 - Coverage gate (example): `pytest --cov=. --cov-report=term-missing --cov-fail-under=<minimum-coverage>`
 - `pytest -m smoke` or an equivalent smoke-test command when the app is runnable
+
+## Framework Detection
+
+- Check markers for `pytest`, `unittest`, `tox`, `nox`, Robot Framework, Selenium, Playwright, pytest-playwright, FastAPI TestClient, Django test client, Flask test client, and other existing API/service test clients.
+- Extend the repo's established integration-test pattern before introducing a new framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
 
 ## Smoke and End-to-End Testing
 
@@ -28,5 +35,6 @@ You are a Python testing specialist. Your role is to set up reliable automated t
 - Add a dedicated GitHub Actions workflow such as `.github/workflows/smoke.yml` that builds the image, starts the compose stack, runs the smoke command, and fails on any error.
 - Add a README badge for the smoke workflow.
 - For apps with user-facing flows, add one stable E2E path using the repo's existing browser E2E framework when one is already present.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.

--- a/packages/ballast-python/ballast/agents/typescript/testing/content.md
+++ b/packages/ballast-python/ballast/agents/typescript/testing/content.md
@@ -12,6 +12,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 ## Runner Selection
 
+- Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.
+- Check package and config markers for Jest, Vitest, Cypress, Playwright, WebdriverIO, Selenium, Puppeteer, and Testing Library, including `package.json` scripts and dependencies, `jest.config.*`, `vitest.config.*`, `cypress.config.*`, `playwright.config.*`, and `wdio.conf.*`.
 - Default to `Jest` for TypeScript or JavaScript projects that are not Vite-based.
 - Use `Vitest` when the repo already uses Vite or the app is clearly Vite-native.
 - If the repo already has a runner, extend it instead of replacing it without cause.
@@ -35,7 +37,8 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 - Add `test:smoke` only when the project exposes a runnable service, app, or CLI flow worth validating.
 - For a web app, make the web smoke test start the real app and verify a live route or health endpoint.
 - Keep E2E narrow and stable; one critical user workflow is enough unless the user asks for more.
-- Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.
+- Preserve an existing browser E2E framework unless the user explicitly asks to migrate.
+- Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.
 - Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.
 - Publish clear pass/fail output for smoke checks.
 
@@ -51,6 +54,7 @@ Keep this rule limited to runner choice, coverage policy, CI integration, and sm
 
 - Do not add a separate fake smoke app just for testing.
 - Do not introduce E2E tooling into a library-only repo.
+- Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.
 - Do not leave the build passing while test scripts are missing or stale.
 
 ## When Completed

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -244,7 +244,7 @@ describe('build', () => {
       expect(content).toContain('web smoke test');
       expect(content).toContain('live route or health endpoint');
       expect(content).toContain(
-        'Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.'
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
       );
       expect(content).toContain(
         'Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.'
@@ -252,15 +252,73 @@ describe('build', () => {
       expect(content).toContain('one critical user workflow');
     });
 
+    test('returns TypeScript testing content with integration framework detection guidance', () => {
+      const content = getContent('testing', undefined, 'typescript');
+      expect(content).toContain(
+        'Detect existing unit, integration, and browser E2E frameworks before adding or replacing test tooling.'
+      );
+      for (const marker of [
+        'Jest',
+        'Vitest',
+        'Cypress',
+        'Playwright',
+        'WebdriverIO',
+        'Selenium',
+        'Puppeteer',
+        'Testing Library'
+      ]) {
+        expect(content).toContain(marker);
+      }
+      expect(content).toContain(
+        'Preserve an existing browser E2E framework unless the user explicitly asks to migrate.'
+      );
+      expect(content).toContain(
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
+      );
+      expect(content).toContain(
+        'Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.'
+      );
+    });
+
     test('returns Python testing content with web smoke and E2E placement guidance', () => {
       const content = getContent('testing', undefined, 'python');
       expect(content).toContain('web smoke test');
       expect(content).toContain('live route or health endpoint');
       expect(content).toContain(
-        'Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.'
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
       );
       expect(content).toContain(
         'Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.'
+      );
+    });
+
+    test('returns Python testing content with integration framework detection guidance', () => {
+      const content = getContent('testing', undefined, 'python');
+      expect(content).toContain(
+        'Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.'
+      );
+      for (const marker of [
+        'pytest',
+        'unittest',
+        'tox',
+        'nox',
+        'Robot Framework',
+        'Selenium',
+        'pytest-playwright',
+        'Playwright',
+        'FastAPI TestClient',
+        'Django test client'
+      ]) {
+        expect(content).toContain(marker);
+      }
+      expect(content).toContain(
+        'Preserve an existing browser E2E framework unless the user explicitly asks to migrate.'
+      );
+      expect(content).toContain(
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
+      );
+      expect(content).toContain(
+        'Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.'
       );
     });
 
@@ -341,6 +399,35 @@ describe('build', () => {
       const content = getContent('testing', undefined, 'go');
       expect(content).toContain('Go testing specialist');
       expect(content).toContain('go test ./...');
+    });
+
+    test('returns Go testing content with integration framework detection guidance', () => {
+      const content = getContent('testing', undefined, 'go');
+      expect(content).toContain(
+        'Detect existing unit, integration, API/service, and browser E2E frameworks before adding or replacing test tooling.'
+      );
+      for (const marker of [
+        'go test',
+        'integration build tags',
+        '_integration_test.go',
+        'httptest',
+        'Selenium',
+        'chromedp',
+        'rod',
+        'agouti',
+        'Playwright'
+      ]) {
+        expect(content).toContain(marker);
+      }
+      expect(content).toContain(
+        'Preserve an existing browser E2E framework unless the user explicitly asks to migrate.'
+      );
+      expect(content).toContain(
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
+      );
+      expect(content).toContain(
+        'Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.'
+      );
     });
   });
 
@@ -525,7 +612,7 @@ describe('build', () => {
       const testing = buildCodexFormat('testing');
       expect(testing).toContain('web smoke test');
       expect(testing).toContain(
-        'Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.'
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
       );
       expect(testing).toContain(
         'Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.'
@@ -534,7 +621,7 @@ describe('build', () => {
       const pythonTesting = buildCodexFormat('testing', undefined, 'python');
       expect(pythonTesting).toContain('web smoke test');
       expect(pythonTesting).toContain(
-        'Prefer Playwright for browser E2E when Playwright markers already exist, or when browser automation is clearly needed and the repo does not already have a browser E2E framework.'
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
       );
       expect(pythonTesting).toContain(
         'Run fast unit tests and targeted smoke checks during local work, put deterministic build/typecheck plus smoke checks in pre-push, and run full smoke/E2E gates in CI.'
@@ -547,6 +634,32 @@ describe('build', () => {
       expect(publishingCli).toContain('representative command');
       expect(publishingCli).toContain(
         'Keep local packaged-command smoke checks fast, run them in pre-push when the packaged artifact can be built deterministically, and require them in CI before publish jobs.'
+      );
+    });
+
+    test('includes framework detection guidance in generated Codex testing rules', () => {
+      const testing = buildCodexFormat('testing');
+      expect(testing).toContain('Cypress');
+      expect(testing).toContain('WebdriverIO');
+      expect(testing).toContain(
+        'Preserve an existing browser E2E framework unless the user explicitly asks to migrate.'
+      );
+      expect(testing).toContain(
+        'Prefer Playwright only when Playwright markers already exist, or when the repo has a real browser application surface and no existing browser E2E framework.'
+      );
+
+      const pythonTesting = buildCodexFormat('testing', undefined, 'python');
+      expect(pythonTesting).toContain('Robot Framework');
+      expect(pythonTesting).toContain('pytest-playwright');
+      expect(pythonTesting).toContain(
+        'Do not add browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories without a user-facing browser surface.'
+      );
+
+      const goTesting = buildCodexFormat('testing', undefined, 'go');
+      expect(goTesting).toContain('chromedp');
+      expect(goTesting).toContain('integration build tags');
+      expect(goTesting).toContain(
+        'Preserve an existing browser E2E framework unless the user explicitly asks to migrate.'
       );
     });
   });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,15 @@
 # Tasks
 
+- [x] Confirm issue #145 scope, operating mode, and governing PRD gap.
+- [x] Add PRD requirements for integration-framework detection and Playwright preference across supported languages.
+- [x] Add failing generated-content coverage for framework detection markers and browser E2E framework selection.
+- [x] Update canonical testing guidance sources and docs.
+- [x] Sync package mirrors; leave checked-in `.codex`/`.claude` rule outputs unchanged per maintainer direction to change templates instead of generated rules.
+- [x] Run focused tests.
+- [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
+
+## Previous Tasks
+
 - [x] Confirm issue #160 scope, operating mode, and Terraform/OpenTofu tooling sources.
 - [x] Add PRD requirements for Terraform linting, testing, CI, security scanner, and OpenTofu guidance.
 - [x] Add failing generated-content coverage for Terraform best-practice guidance.
@@ -7,8 +17,6 @@
 - [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
 - [x] Run focused tests and required sync/generation checks.
 - [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
-
-## Previous Tasks
 
 - [x] Confirm issue #215 broader deployment-model scope, operating mode, and PRD requirements.
 - [x] Add PRD requirements for deployment model prompts, flags, persistence, doctor output, and publishing guidance.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,7 +4,7 @@
 - [x] Add PRD requirements for integration-framework detection and Playwright preference across supported languages.
 - [x] Add failing generated-content coverage for framework detection markers and browser E2E framework selection.
 - [x] Update canonical testing guidance sources and docs.
-- [x] Sync package mirrors; leave checked-in `.codex`/`.claude` rule outputs unchanged per maintainer direction to change templates instead of generated rules.
+- [x] Sync package mirrors and corresponding `.codex`/`.claude` testing outputs from the updated source templates.
 - [x] Run focused tests.
 - [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
 


### PR DESCRIPTION
## Summary
- add PRD requirements for issue #145 integration framework detection
- update TypeScript, Python, and Go testing source guidance to detect existing integration/browser E2E frameworks before adding tooling
- preserve existing browser E2E stacks and prefer Playwright only for existing Playwright repos or browser apps without an E2E framework
- document that generated .claude/.codex rule outputs should not be edited directly; source templates/content should be changed instead

## Verification
- pnpm --dir packages/ballast-typescript test -- build.test.ts
- pre-push unit tests for cli and language packages passed during git push

Closes #145