### PR TITLE
Update issue priority plan after issue 93

### DIFF
--- a/plans/issue-priority-plan.md
+++ b/plans/issue-priority-plan.md
@@ -1,6 +1,6 @@
 # Plan: Open Issue Review and Next Priorities
 
-**Status:** Updated after #209, #210, #213, and #214 completion
+**Status:** Updated after #93 / PR #231, #145 / PR #230, #160, #209, #210, #213, #214, #215, and PR #226 completion
 **Created:** 2026-07-09
 **Source:** Review of open GitHub issues and requested follow-up list
 
@@ -40,16 +40,45 @@ Reviewed all open GitHub issues for `everydaydevopsio/ballast` and compared them
   - Added local/pre-push/CI placement guidance for fast unit tests, targeted smoke checks, deterministic build/typecheck, and full smoke/E2E gates.
   - Added packaged-command smoke guidance for installable CLIs.
   - Synced canonical guidance into generated `.claude/` and `.codex/` outputs and package mirrors, with tests covering the generated content.
+- #215: Define deployment guidance with local Helm chart and external ArgoCD config — completed and merged via PR #223.
+  - Broadened the original Kubernetes-specific request into a repository-level `deploymentModel` setting with supported values `none`, `kubernetes`, `serverless`, `server`, and `hosted`.
+  - Added CLI flags, interactive prompting, non-interactive defaults, config persistence, doctor output, and wrapper forwarding/monorepo preservation across Ballast CLIs.
+  - Rendered deployment-model-specific publishing guidance while keeping baseline web/API guidance platform-neutral.
+  - Kept Kubernetes guidance explicit about app-local Helm charts in `charts/<app>/` and external ArgoCD/GitOps environment state.
+  - Synced package mirrors, regenerated managed `.claude/` and `.codex/` outputs, and resolved Copilot review threads.
+- #160: Review Terraform linting and testing rules for best practices alignment — completed and merged via PR #224.
+  - Updated Terraform linting and testing guidance for `terraform fmt`, `terraform validate`, recursive TFLint, Trivy-first IaC scanning, Terraform 1.6+ native tests, Terratest live coverage, and OpenTofu equivalents.
+  - Clarified CI placement for format, validation, static analysis, plan, native tests, and live apply/destroy test gates.
+  - Updated backend git-hook renderers to include `terraform init -backend=false`, `tflint --init`, `tflint --recursive`, and `trivy config .`.
+  - Synced package mirrors and generated `.claude/` and `.codex/` Terraform outputs, with focused TypeScript, Python, and Go test coverage.
+- PR #226: Fix required option prompts and support file patching — completed and merged on 2026-07-18.
+  - Patched existing `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` support files by default instead of skipping them when `--force` is not set.
+  - Preserved unmanaged or legacy same-heading support sections by default unless the section carries the Ballast-managed notice or the user explicitly selects patch behavior.
+  - Shared required `taskSystem` and `deploymentModel` option resolution across wrapper and Go install paths, including first-run prompts, saved config reuse, and CI/non-interactive defaults.
+  - Clarified deployment-model prompt copy for CLI/library/SDK-only projects where `none` is the correct choice.
+  - Treated common CI environment variables as non-interactive for wrapper support-file confirmation and required-option defaults.
+  - Added e2e coverage for first-run Go prompts and default support-file patching, plus regression tests for CRLF support-file patching and unreadable support-file preservation.
+- #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps — completed and merged via PR #230.
+  - Added PRD requirements for language-aware integration framework detection and browser E2E framework selection.
+  - Updated TypeScript, Python, and Go testing guidance to detect existing unit, integration, API/service, and browser E2E frameworks before introducing new tooling.
+  - Preserved existing browser E2E stacks and narrowed Playwright preference to existing Playwright repositories or browser apps with no existing browser E2E framework.
+  - Added guardrails against adding browser E2E tooling to library-only, CLI-only, infrastructure-only, or backend-only repositories.
+  - Synced package mirrors and corresponding `.claude/` and `.codex/` testing outputs, with generated-content and generated-artifact tests passing.
+- #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages — completed and merged via PR #231.
+  - Added `.github/workflows/ci.yml` as the canonical pull-request and `main` CI workflow with concurrency cancellation.
+  - Folded TypeScript lint, test matrix, coverage, Python lint/test/import validation, Go package validation, and wrapper CLI validation into parallel CI jobs.
+  - Removed superseded primary CI workflows: `.github/workflows/lint.yaml`, `.github/workflows/test.yml`, and `.github/workflows/language-packs.yml`.
+  - Updated README CI badges and PRD requirements to point at the consolidated workflow.
+  - Added dedicated `ci-workflow.test.ts` regression coverage for the workflow contract.
+  - PR #231 passed CI, CodeQL, Examples Smoke Tests, and Codecov; Copilot feedback was addressed and resolved before merge.
 
 ## Open Issue Inventory
 
-As of 2026-07-10 after closing completed #209, #210, #213, and #214, the repository has these open issues:
+As of 2026-07-18 after #93 closed, the repository has these open issues:
 
-- #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config
 - #188: Re-enable OpenCode as a first-class Ballast target
 - #175: Consider TTY detection for non-interactive mode in support file confirmation
 - #166: feat(doctor): detect drift and remove stale rules files
-- #160: Review Terraform linting and testing rules for best practices alignment
 - #159: Add TDD process discipline to testing agent rules
 - #158: Reconcile tasks/todo.md format with global EXECUTION_TEMPLATES standard
 - #154: Add plan-lifecycle rule: Plan -> ADR lifecycle for non-trivial features
@@ -57,13 +86,11 @@ As of 2026-07-10 after closing completed #209, #210, #213, and #214, the reposit
 - #151: Review ansible rules: dependabot not supported, verify pre-commit linting setup
 - #149: feat: add interactive setup prompts to github-health-check skill for unconfigured sections
 - #147: Add GitHub repo setup workflow and best practices skill
-- #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps
 - #133: Create MCP server so AI agents can configure and use Ballast directly
 - #128: Detect project package manager during setup and align Node/package-manager defaults to LTS
 - #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
 - #99: Add Next.js-specific TypeScript rules based on current Next.js linting and app best practices
 - #94: Check required local tools for Ballast rules using PATH detection plus Homebrew install guidance
-- #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages
 - #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
 - #90: Add GitHub Actions Slack notifications for successful and failed builds
 - #81: Deploy ballast-python to the everydaydevopsio organization on PyPI
@@ -97,6 +124,7 @@ As of 2026-07-10 after closing completed #209, #210, #213, and #214, the reposit
 - [x] #211: Add a development-environment bootstrap command for AI agents — implemented and merged via PR #217
 - [x] #208: Define .ballast bootstrap behavior and Ballast skill support — completed and merged via PR #218
 - [x] #144: Bug: ballast upgrade refresh skips installed skills instead of updating them — implemented on `main` and verified before closure
+- [x] PR #226: Fix required option prompts and support file patching — completed and merged
 
 These reduce the chance that agents start from a broken environment, edit the wrong branch, or operate with stale Ballast-managed guidance.
 
@@ -105,14 +133,15 @@ These reduce the chance that agents start from a broken environment, edit the wr
 - [x] #210: Configure Husky pre-push hooks to run tests before pushing to GitHub — completed and merged via PR #220
 - [x] #209: Add YAML and YML formatting checks to Husky hook guidance — completed and merged via PR #220
 - [x] #214: Add smoke and E2E test guidance for web apps and CLIs — completed and merged via PR #222
-1. #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps
-2. #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages
+- [x] #145: Detect integration test frameworks per language and prefer Playwright for browser-based apps — completed and merged via PR #230
+- [x] #93: Consolidate CI into a single ci.yml that fans out linting and testing across all languages — completed and merged via PR #231
 
 This builds a coherent path from local hooks to smoke/E2E validation to canonical CI.
 
 ### P2: Improve PR review and delivery workflow
 
 - [x] #213: Codify Copilot review polling and per-thread replies — completed and merged via PR #221
+
 1. #154: Add plan-lifecycle rule: Plan -> ADR lifecycle for non-trivial features
 2. #159: Add TDD process discipline to testing agent rules
 3. #158: Reconcile tasks/todo.md format with global EXECUTION_TEMPLATES standard
@@ -121,10 +150,11 @@ These make agent work easier to review, preserve implementation context, and kee
 
 ### P3: Expand platform and deployment coverage
 
-1. #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config
-2. #188: Re-enable OpenCode as a first-class Ballast target
-3. #133: Create MCP server so AI agents can configure and use Ballast directly
-4. #10: Add agent validation tests: Dockerfiles + rule validation per AI platform
+- [x] #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config — completed and merged via PR #223
+
+1. #188: Re-enable OpenCode as a first-class Ballast target
+2. #133: Create MCP server so AI agents can configure and use Ballast directly
+3. #10: Add agent validation tests: Dockerfiles + rule validation per AI platform
 
 This broadens Ballast from local rules into multi-agent and deployment orchestration.
 
@@ -135,18 +165,17 @@ This broadens Ballast from local rules into multi-agent and deployment orchestra
 3. #94: Check required local tools for Ballast rules using PATH detection plus Homebrew install guidance
 4. #61: Support native Windows executable detection in TypeScript doctor
 5. #65: Improve ballast-go release installer portability by removing shell tool assumptions
-6. #160: Review Terraform linting and testing rules for best practices alignment
-7. #151: Review ansible rules: dependabot not supported, verify pre-commit linting setup
-8. #99: Add Next.js-specific TypeScript rules based on current Next.js linting and app best practices
-9. #175: Consider TTY detection for non-interactive mode in support file confirmation
-10. #153: feat: daily repo health check GitHub Action with structured report
-11. #149: feat: add interactive setup prompts to github-health-check skill for unconfigured sections
-12. #147: Add GitHub repo setup workflow and best practices skill
-13. #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
-14. #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
-15. #90: Add GitHub Actions Slack notifications for successful and failed builds
-16. #81: Deploy ballast-python to the everydaydevopsio organization on PyPI
-17. #11: First-run interview: collect project preferences
+6. #151: Review ansible rules: dependabot not supported, verify pre-commit linting setup
+7. #99: Add Next.js-specific TypeScript rules based on current Next.js linting and app best practices
+8. #175: Consider TTY detection for non-interactive mode in support file confirmation
+9. #153: feat: daily repo health check GitHub Action with structured report
+10. #149: feat: add interactive setup prompts to github-health-check skill for unconfigured sections
+11. #147: Add GitHub repo setup workflow and best practices skill
+12. #124: feat: Enhance Ballast toward a robust Agentic SDLC framework
+13. #92: Define how product requirements documents are created, maintained, synced with the app, and presented over time
+14. #90: Add GitHub Actions Slack notifications for successful and failed builds
+15. #81: Deploy ballast-python to the everydaydevopsio organization on PyPI
+16. #11: First-run interview: collect project preferences
 
 ## Near-Term Execution Plan
 
@@ -158,10 +187,24 @@ This broadens Ballast from local rules into multi-agent and deployment orchestra
 - [x] Implement #209 and #210 as one git-hook workstream, with generated outputs regenerated in the same PR. Completed via PR #220.
 - [x] Implement #214 with #145 in mind so generated testing guidance uses detected framework signals instead of generic defaults. Completed via PR #222.
 - [x] Implement #213 before scaling PR automation or MCP workflows. Completed via PR #221.
-1. Implement #215 next to define Kubernetes deployment guidance with an in-repo Helm chart and separate-repo ArgoCD config.
-2. Implement #145 next in the verification stream, using the #214 guidance as the policy baseline for framework detection and Playwright preference.
-3. Implement #93 after #145 so consolidated CI can incorporate the updated framework-detection and smoke/E2E guidance.
-4. Implement #154 after the task format issue #158 is resolved, or explicitly design #154 to tolerate the current `tasks/TODO.md` format until #158 lands.
+- [x] Implement #215 to define deployment-model guidance, including Kubernetes with an in-repo Helm chart and separate-repo ArgoCD config. Completed via PR #223.
+- [x] Implement #160 to align Terraform rules with current linting, scanning, testing, and CI best practices. Completed via PR #224.
+- [x] Fix first-run required option prompting and support-file default patching. Completed via PR #226.
+- [x] Implement #145 in the verification stream, using the #214 guidance as the policy baseline for framework detection and Playwright preference. Completed via PR #230.
+- [x] Implement #93 so consolidated CI can incorporate the updated framework-detection and smoke/E2E guidance. Completed via PR #231.
+
+1. Implement #154 after the task format issue #158 is resolved, or explicitly design #154 to tolerate the current `tasks/TODO.md` format until #158 lands.
+
+## GitHub Actions Review
+
+As of 2026-07-18 after PR #231 merged:
+
+- PR #231 completed successfully with passing CI, CodeQL, Examples Smoke Tests, and Codecov checks before merge.
+- Copilot reviewed PR #231, all actionable comments were addressed with direct replies, and all review threads were resolved before merge.
+- Issue #93 is closed as of 2026-07-18 21:52:53 UTC.
+- No failing GitHub Actions runs were present in the latest checked run set that require changing the priority plan.
+
+The plan remains accurate: #93 is complete, the open issue inventory now excludes #93, and #154 is the next recommended workflow/process workstream.
 
 ## Notes
 

--- a/plans/issue-priority-plan.md
+++ b/plans/issue-priority-plan.md
@@ -1,6 +1,6 @@
 # Plan: Open Issue Review and Next Priorities
 
-**Status:** Updated after #93 / PR #231, #145 / PR #230, #160, #209, #210, #213, #214, #215, and PR #226 completion
+**Status:** Updated after #93 / PR #231, #145 / PR #230, #160 / PR #224, #209 and #210 / PR #220, #213 / PR #221, #214 / PR #222, #215 / PR #223, and PR #226 completion
 **Created:** 2026-07-09
 **Source:** Review of open GitHub issues and requested follow-up list
 
@@ -150,7 +150,7 @@ These make agent work easier to review, preserve implementation context, and kee
 
 ### P3: Expand platform and deployment coverage
 
-- [x] #215: Define Kubernetes deployment guidance with local Helm chart and external ArgoCD config — completed and merged via PR #223
+- [x] #215: Define deployment guidance with local Helm chart and external ArgoCD config — completed and merged via PR #223
 
 1. #188: Re-enable OpenCode as a first-class Ballast target
 2. #133: Create MCP server so AI agents can configure and use Ballast directly


### PR DESCRIPTION
## Summary
- mark #93 / PR #231 as completed and merged in the priority plan
- remove closed issues from the open issue inventory
- set #154 as the next recommended workstream after #93

## Validation
- git diff --check -- plans/issue-priority-plan.md
- pre-commit hooks during commit
- pre-push unit tests and hooks during push