### PR TITLE
Add plan lifecycle rule

### DIFF
--- a/.claude/rules/common/plan-lifecycle.md
+++ b/.claude/rules/common/plan-lifecycle.md
@@ -1,0 +1,199 @@
+# Plan Lifecycle
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/.claude/rules/common/plan-lifecycle.md
+++ b/.claude/rules/common/plan-lifecycle.md
@@ -32,13 +32,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -105,7 +105,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -115,7 +115,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -192,8 +192,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/.codex/rules/common/plan-lifecycle.md
+++ b/.codex/rules/common/plan-lifecycle.md
@@ -34,13 +34,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -107,7 +107,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -117,7 +117,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -194,8 +194,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/.codex/rules/common/plan-lifecycle.md
+++ b/.codex/rules/common/plan-lifecycle.md
@@ -1,0 +1,201 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/.codex/rules/common/tasks-task-system.md
+++ b/.codex/rules/common/tasks-task-system.md
@@ -103,11 +103,11 @@ For Linear:
 
 - Create issues/tickets in **github** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **github** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **github** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/.codex/rules/common/tasks-todo.md
+++ b/.codex/rules/common/tasks-todo.md
@@ -2,28 +2,28 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -36,7 +36,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -50,27 +50,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/.codex/rules/tasks-task-system.md
+++ b/.codex/rules/tasks-task-system.md
@@ -103,11 +103,11 @@ For Linear:
 
 - Create issues/tickets in **github** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **github** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **github** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/.codex/rules/tasks-todo.md
+++ b/.codex/rules/tasks-todo.md
@@ -2,28 +2,28 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -36,7 +36,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -50,27 +50,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/.codex/rules/typescript/typescript-plan-lifecycle.md
+++ b/.codex/rules/typescript/typescript-plan-lifecycle.md
@@ -34,13 +34,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -107,7 +107,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -117,7 +117,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -194,8 +194,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/.codex/rules/typescript/typescript-plan-lifecycle.md
+++ b/.codex/rules/typescript/typescript-plan-lifecycle.md
@@ -1,0 +1,201 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/.codex/rules/typescript/typescript-tasks-task-system.md
+++ b/.codex/rules/typescript/typescript-tasks-task-system.md
@@ -103,11 +103,11 @@ For Linear:
 
 - Create issues/tickets in **github** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **github** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **github** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **github** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/.codex/rules/typescript/typescript-tasks-todo.md
+++ b/.codex/rules/typescript/typescript-tasks-todo.md
@@ -2,28 +2,28 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -36,7 +36,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -50,27 +50,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/.rulesrc.json
+++ b/.rulesrc.json
@@ -10,6 +10,7 @@
     "observability",
     "publishing",
     "git-hooks",
+    "plan-lifecycle",
     "tasks",
     "linting",
     "logging",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Read and follow these rule files in `.codex/rules/` when they apply:
 - `.codex/rules/common/publishing-sdks.md` — Rules for common/publishing-sdks
 - `.codex/rules/common/publishing-apps.md` — Rules for common/publishing-apps
 - `.codex/rules/common/git-hooks.md` — Rules for common/git-hooks
+- `.codex/rules/common/plan-lifecycle.md` — Rules for common/plan-lifecycle
 - `.codex/rules/common/tasks.md` — Rules for common/tasks
 - `.codex/rules/typescript/typescript-linting.md` — Rules for typescript/linting
 - `.codex/rules/typescript/typescript-logging.md` — Rules for typescript/logging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Read and follow these rule files in `.claude/rules/` when they apply:
 - `.claude/rules/common/publishing-sdks.md` — Rules for common/publishing-sdks
 - `.claude/rules/common/publishing-apps.md` — Rules for common/publishing-apps
 - `.claude/rules/common/git-hooks.md` — Rules for common/git-hooks
+- `.claude/rules/common/plan-lifecycle.md` — Rules for common/plan-lifecycle
 - `.claude/rules/common/tasks.md` — Rules for common/tasks
 - `.claude/rules/typescript/typescript-linting.md` — Rules for typescript/linting
 - `.claude/rules/typescript/typescript-logging.md` — Rules for typescript/logging

--- a/PRD.md
+++ b/PRD.md
@@ -140,7 +140,7 @@ Ballast-generated rule files for persistent agent context have accumulated large
 
 ### Problem
 
-Ballast has task-system and branch TODO guidance, but it does not distribute the Plan -> ADR lifecycle for non-trivial features. Agents in Ballast-managed repositories need installable guidance for when to create a plan, how to maintain it during implementation, and how to graduate completed plans into durable ADRs without duplicating `tasks/TODO.md` behavior.
+Ballast has task-system and branch TODO guidance, but it does not distribute the Plan -> ADR lifecycle for non-trivial features. Agents in Ballast-managed repositories need installable guidance for when to create a plan, how to maintain it during implementation, and how to graduate completed plans into durable ADRs without duplicating `tasks/todo.md` behavior.
 
 ### Requirements
 
@@ -148,9 +148,9 @@ Ballast has task-system and branch TODO guidance, but it does not distribute the
 2. The plan-lifecycle rule must define when to create a plan, when to skip one, the expected `plans/`, `tasks/`, and `adr/` directory structure, and the required plan file naming convention.
 3. The rule must include a plan template with status, branch, created date, related ADRs, problem, approach, files affected, phases, verification, rejected alternatives, open questions, and change log.
 4. The rule must describe maintaining the plan during implementation, including checking off phases, updating the approach when it changes, committing plan updates with related code, reading the plan at session start, and routing out-of-scope work to the TODO rule.
-5. The rule must define the graduation trigger and steps for turning a plan into an ADR, including checking `tasks/TODO.md`, creating generic task-system work items for incomplete TODOs, assigning the next ADR number, creating the ADR, updating indexes, removing the plan, and committing the graduation.
+5. The rule must define the graduation trigger and steps for turning a plan into an ADR, including checking `tasks/todo.md`, creating generic task-system work items for incomplete TODOs, assigning the next ADR number, creating the ADR, updating indexes, removing the plan, and committing the graduation.
 6. The rule must include an ADR template and ADR management rules for status values, sequential numbering, one decision per ADR, and never deleting ADR history.
-7. The rule must defer to the existing `tasks-todo` rule for `tasks/TODO.md` behavior instead of restating that rule in detail.
+7. The rule must defer to the existing `tasks-todo` rule for `tasks/todo.md` behavior instead of restating that rule in detail.
 8. The generated rule and installed support-file entries must use generic task-system terminology, not Jira-specific wording.
 
 ### Acceptance Criteria
@@ -159,7 +159,7 @@ Ballast has task-system and branch TODO guidance, but it does not distribute the
 2. Generated `.claude/rules/common/plan-lifecycle.md` and `.codex/rules/common/plan-lifecycle.md` exist in this repository when the checked-in Ballast-managed outputs are refreshed.
 3. `CLAUDE.md` and `AGENTS.md` installed rules lists include the new `plan-lifecycle` rule under common task rules.
 4. Generated plan-lifecycle content includes the create/skip criteria, directory structure, plan template, maintenance rules, graduation steps, ADR template, ADR management rules, and quick reference.
-5. Generated plan-lifecycle content explicitly defers `tasks/TODO.md` behavior to the branch-local TODO tracking rule.
+5. Generated plan-lifecycle content explicitly defers `tasks/todo.md` behavior to the branch-local TODO tracking rule.
 6. Automated tests cover rule suffix discovery, generated content, and support-file listing for the new rule.
 
 ## TypeScript Husky Git Hook Guidance

--- a/PRD.md
+++ b/PRD.md
@@ -136,6 +136,32 @@ Ballast-generated rule files for persistent agent context have accumulated large
 7. Root `.rulesrc.json` includes `claude` and `codex` so tracked generated artifacts for both targets can be refreshed by config-driven installs.
 8. `AGENTS.md` documents that PRs touching Ballast generator inputs or target policy must include regenerated local `.claude` and `.codex` artifacts.
 
+## Plan Lifecycle Rule Distribution
+
+### Problem
+
+Ballast has task-system and branch TODO guidance, but it does not distribute the Plan -> ADR lifecycle for non-trivial features. Agents in Ballast-managed repositories need installable guidance for when to create a plan, how to maintain it during implementation, and how to graduate completed plans into durable ADRs without duplicating `tasks/TODO.md` behavior.
+
+### Requirements
+
+1. Ballast must distribute `plan-lifecycle` as a language-agnostic common agent rule alongside the existing task rules.
+2. The plan-lifecycle rule must define when to create a plan, when to skip one, the expected `plans/`, `tasks/`, and `adr/` directory structure, and the required plan file naming convention.
+3. The rule must include a plan template with status, branch, created date, related ADRs, problem, approach, files affected, phases, verification, rejected alternatives, open questions, and change log.
+4. The rule must describe maintaining the plan during implementation, including checking off phases, updating the approach when it changes, committing plan updates with related code, reading the plan at session start, and routing out-of-scope work to the TODO rule.
+5. The rule must define the graduation trigger and steps for turning a plan into an ADR, including checking `tasks/TODO.md`, creating generic task-system work items for incomplete TODOs, assigning the next ADR number, creating the ADR, updating indexes, removing the plan, and committing the graduation.
+6. The rule must include an ADR template and ADR management rules for status values, sequential numbering, one decision per ADR, and never deleting ADR history.
+7. The rule must defer to the existing `tasks-todo` rule for `tasks/TODO.md` behavior instead of restating that rule in detail.
+8. The generated rule and installed support-file entries must use generic task-system terminology, not Jira-specific wording.
+
+### Acceptance Criteria
+
+1. Installing the `plan-lifecycle` agent produces plan-lifecycle rule files for supported targets.
+2. Generated `.claude/rules/common/plan-lifecycle.md` and `.codex/rules/common/plan-lifecycle.md` exist in this repository when the checked-in Ballast-managed outputs are refreshed.
+3. `CLAUDE.md` and `AGENTS.md` installed rules lists include the new `plan-lifecycle` rule under common task rules.
+4. Generated plan-lifecycle content includes the create/skip criteria, directory structure, plan template, maintenance rules, graduation steps, ADR template, ADR management rules, and quick reference.
+5. Generated plan-lifecycle content explicitly defers `tasks/TODO.md` behavior to the branch-local TODO tracking rule.
+6. Automated tests cover rule suffix discovery, generated content, and support-file listing for the new rule.
+
 ## TypeScript Husky Git Hook Guidance
 
 ### Problem

--- a/agents/common/plan-lifecycle/content.md
+++ b/agents/common/plan-lifecycle/content.md
@@ -1,0 +1,194 @@
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/agents/common/plan-lifecycle/content.md
+++ b/agents/common/plan-lifecycle/content.md
@@ -27,13 +27,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -100,7 +100,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -110,7 +110,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -187,8 +187,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/agents/common/plan-lifecycle/templates/claude-header.md
+++ b/agents/common/plan-lifecycle/templates/claude-header.md
@@ -1,0 +1,5 @@
+# Plan Lifecycle
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/agents/common/plan-lifecycle/templates/codex-header.md
+++ b/agents/common/plan-lifecycle/templates/codex-header.md
@@ -1,0 +1,7 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -4,7 +4,7 @@ alwaysApply: false
 globs:
   - 'plans/**/*.md'
   - 'adr/**/*.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -1,0 +1,10 @@
+---
+description: 'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+alwaysApply: false
+globs:
+  - 'plans/**/*.md'
+  - 'adr/**/*.md'
+  - 'tasks/TODO.md'
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+---

--- a/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
+++ b/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
@@ -1,0 +1,17 @@
+---
+description: Plan lifecycle - create, maintain, and graduate plans to ADRs
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/agents/common/tasks/content-task-system.md
+++ b/agents/common/tasks/content-task-system.md
@@ -96,11 +96,11 @@ For Linear:
 
 - Create issues/tickets in **{{taskSystem}}** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **{{taskSystem}}** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **{{taskSystem}}** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/agents/common/tasks/content-todo.md
+++ b/agents/common/tasks/content-todo.md
@@ -1,22 +1,22 @@
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -29,7 +29,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -43,27 +43,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/agents/common/tasks/templates/claude-header-todo.md
+++ b/agents/common/tasks/templates/claude-header-todo.md
@@ -1,5 +1,5 @@
 # Branch-Local TODO Tracking
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/agents/common/tasks/templates/codex-header-todo.md
+++ b/agents/common/tasks/templates/codex-header-todo.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -4,5 +4,5 @@ alwaysApply: false
 globs:
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
 ---

--- a/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
+++ b/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
@@ -1,8 +1,8 @@
 ---
-description: 'Branch-local TODO tracking - manage tasks/TODO.md and triage before PR'
+description: 'Branch-local TODO tracking - manage tasks/todo.md and triage before PR'
 alwaysApply: false
 globs:
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
+++ b/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
@@ -1,5 +1,5 @@
 ---
-description: Branch-local TODO tracking - manage tasks/TODO.md and triage before PR
+description: Branch-local TODO tracking - manage tasks/todo.md and triage before PR
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/cli/ballast/registry.go
+++ b/cli/ballast/registry.go
@@ -60,6 +60,7 @@ var agentRegistry = []agentEntry{
 	{ID: "publishing", Kind: kindCommon, Status: statusActive},
 	{ID: "git-hooks", Kind: kindCommon, Status: statusActive},
 	{ID: "tasks", Kind: kindCommon, Status: statusActive},
+	{ID: "plan-lifecycle", Kind: kindCommon, Status: statusActive},
 
 	// Language agents — installed once per language sub-project.
 	{ID: "linting", Kind: kindLanguage, Status: statusActive},

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/content.md
@@ -1,0 +1,194 @@
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/content.md
@@ -27,13 +27,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -100,7 +100,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -110,7 +110,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -187,8 +187,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/claude-header.md
@@ -1,0 +1,5 @@
+# Plan Lifecycle
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/codex-header.md
@@ -1,0 +1,7 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -4,7 +4,7 @@ alwaysApply: false
 globs:
   - 'plans/**/*.md'
   - 'adr/**/*.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -1,0 +1,10 @@
+---
+description: 'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+alwaysApply: false
+globs:
+  - 'plans/**/*.md'
+  - 'adr/**/*.md'
+  - 'tasks/TODO.md'
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
@@ -1,0 +1,17 @@
+---
+description: Plan lifecycle - create, maintain, and graduate plans to ADRs
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-task-system.md
@@ -96,11 +96,11 @@ For Linear:
 
 - Create issues/tickets in **{{taskSystem}}** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **{{taskSystem}}** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **{{taskSystem}}** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-todo.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-todo.md
@@ -1,22 +1,22 @@
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -29,7 +29,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -43,27 +43,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/claude-header-todo.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/claude-header-todo.md
@@ -1,5 +1,5 @@
 # Branch-Local TODO Tracking
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/codex-header-todo.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/codex-header-todo.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -4,5 +4,5 @@ alwaysApply: false
 globs:
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
@@ -1,8 +1,8 @@
 ---
-description: 'Branch-local TODO tracking - manage tasks/TODO.md and triage before PR'
+description: 'Branch-local TODO tracking - manage tasks/todo.md and triage before PR'
 alwaysApply: false
 globs:
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
@@ -1,5 +1,5 @@
 ---
-description: Branch-local TODO tracking - manage tasks/TODO.md and triage before PR
+description: Branch-local TODO tracking - manage tasks/todo.md and triage before PR
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/content.md
@@ -1,0 +1,194 @@
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/content.md
@@ -27,13 +27,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -100,7 +100,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -110,7 +110,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -187,8 +187,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/claude-header.md
@@ -1,0 +1,5 @@
+# Plan Lifecycle
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/codex-header.md
@@ -1,0 +1,7 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -4,7 +4,7 @@ alwaysApply: false
 globs:
   - 'plans/**/*.md'
   - 'adr/**/*.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -1,0 +1,10 @@
+---
+description: 'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+alwaysApply: false
+globs:
+  - 'plans/**/*.md'
+  - 'adr/**/*.md'
+  - 'tasks/TODO.md'
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+---

--- a/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
@@ -1,0 +1,17 @@
+---
+description: Plan lifecycle - create, maintain, and graduate plans to ADRs
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/content-task-system.md
@@ -96,11 +96,11 @@ For Linear:
 
 - Create issues/tickets in **{{taskSystem}}** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **{{taskSystem}}** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **{{taskSystem}}** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/content-todo.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/content-todo.md
@@ -1,22 +1,22 @@
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -29,7 +29,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -43,27 +43,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/claude-header-todo.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/claude-header-todo.md
@@ -1,5 +1,5 @@
 # Branch-Local TODO Tracking
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/codex-header-todo.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/codex-header-todo.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -4,5 +4,5 @@ alwaysApply: false
 globs:
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
@@ -1,8 +1,8 @@
 ---
-description: 'Branch-local TODO tracking - manage tasks/TODO.md and triage before PR'
+description: 'Branch-local TODO tracking - manage tasks/todo.md and triage before PR'
 alwaysApply: false
 globs:
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
@@ -1,5 +1,5 @@
 ---
-description: Branch-local TODO tracking - manage tasks/TODO.md and triage before PR
+description: Branch-local TODO tracking - manage tasks/todo.md and triage before PR
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/content.md
@@ -1,0 +1,194 @@
+# Plan -> ADR Lifecycle Rules
+
+These rules define the Plan -> ADR lifecycle: when agents create plans, how plans stay current during implementation, and how completed plans graduate into architecture decision records.
+
+---
+You are a plan lifecycle specialist. Your role is to preserve implementation context for non-trivial work and turn completed decisions into durable ADRs before merge.
+
+## When To Create A Plan
+
+Create a plan when:
+- The change touches more than two files.
+- You are unsure of the approach.
+- The feature takes more than one session to complete.
+- The work involves architectural decisions.
+
+Skip a plan when:
+- The change is a single-file fix such as a typo, log line, or rename.
+- The entire change fits in one sentence.
+
+## Directory Structure
+
+Use this project-root structure:
+
+```text
+<project-root>/
++-- plans/
+|   +-- README.md
+|   +-- plan-<feature-name>.md
++-- tasks/
+|   +-- TODO.md
++-- adr/
+    +-- README.md
+    +-- NNN-<decision-title>.md
+```
+
+Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+
+## Plan File Naming
+
+Create plans at `plans/plan-<feature-name>.md`.
+
+- Use kebab-case.
+- Be specific: `plan-oauth-google.md`, not `plan-auth.md`.
+- After creating the plan, update `plans/README.md` and commit both files.
+
+## Plan Template
+
+```markdown
+# Plan: <Feature Name>
+
+**Status:** In Progress
+**Branch:** <branch-name>
+**Created:** YYYY-MM-DD
+**Related ADRs:** _(link any relevant existing ADRs)_
+
+## Problem
+
+What are we solving and why does it matter now?
+
+## Approach
+
+The chosen solution in plain language. What will change and how.
+
+## Files Affected
+
+- `src/...` - reason
+- `tests/...` - reason
+
+## Phases
+
+- [ ] Phase 1: Explore and confirm approach
+- [ ] Phase 2: Core implementation
+- [ ] Phase 3: Tests and edge cases
+- [ ] Phase 4: Documentation and cleanup
+
+## Verification
+
+How will we know this works? Commands, tests, or checks to run.
+
+## Alternatives Rejected
+
+| Option | Why rejected |
+| --- | --- |
+| ... | ... |
+
+## Open Questions
+
+Things still to resolve. Remove entries as they are answered.
+
+## Change Log
+
+| Date | Change |
+| --- | --- |
+| YYYY-MM-DD | Plan created |
+```
+
+## Maintaining The Plan
+
+- Check off phases as they complete.
+- If the approach changes, update **Approach** and record the change in **Change Log**.
+- Commit plan updates alongside related code changes.
+- At the start of each session, read the plan to restore context.
+- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+
+## Graduation Trigger
+
+When the feature is ready to merge, use this trigger phrase:
+
+> "Graduate `plans/plan-<feature-name>.md` to an ADR"
+
+## Graduation Steps
+
+1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
+3. Determine the next ADR number from `adr/README.md`.
+4. Create `adr/NNN-<decision-title>.md` from the plan content.
+5. Update `adr/README.md` with the new row.
+6. Remove `plans/plan-<feature-name>.md`.
+7. Update `plans/README.md` to remove the entry.
+8. Commit with `docs: graduate plan-<feature-name> to ADR-NNN`.
+
+Graduation is blocked until every feature-related TODO item is checked off or has a task system work item reference.
+
+## ADR Template
+
+```markdown
+# ADR-NNN: <Decision Title>
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+**Branch:** <branch-name>
+**PR:** #<number>
+**Supersedes:** _(ADR-NNN if replacing an earlier decision)_
+**Superseded by:** _(leave blank)_
+
+## Context
+
+Why did this decision need to be made?
+
+## Decision
+
+What was chosen and why.
+
+## Alternatives Considered
+
+| Option | Reason not chosen |
+| --- | --- |
+| ... | ... |
+
+## Consequences
+
+### Positive
+
+- What becomes easier
+
+### Negative or trade-offs
+
+- What becomes harder or what we gave up
+
+## Implementation Notes
+
+Key details future readers should know.
+
+## Verification
+
+How the decision was validated.
+
+## Lessons Learned
+
+What would you do differently? What worked better than expected?
+```
+
+## ADR Management Rules
+
+| Rule | Detail |
+| --- | --- |
+| Never delete | Mark superseded and create a new ADR |
+| Sequential numbering | Zero-padded three digits: `001`, `002`, `003` |
+| One decision per ADR | Do not bundle unrelated decisions |
+| Status values | `Accepted`, `Deprecated`, `Superseded` |
+
+## Quick Reference
+
+| Situation | Action |
+| --- | --- |
+| Starting a feature | Create `plans/plan-<name>.md`, commit it |
+| New session on existing feature | Continue implementing `plans/plan-<name>.md` |
+| Approach changed | Update plan and Change Log, commit with code |
+| Phase complete | Check off in plan, commit |
+| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Decision reversed later | Mark ADR superseded, create a new ADR |
+| Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/content.md
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/content.md
@@ -27,13 +27,13 @@ Use this project-root structure:
 |   +-- README.md
 |   +-- plan-<feature-name>.md
 +-- tasks/
-|   +-- TODO.md
+|   +-- todo.md
 +-- adr/
     +-- README.md
     +-- NNN-<decision-title>.md
 ```
 
-Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
+Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule. Use it for discovered out-of-scope work instead of expanding the plan beyond the feature boundary.
 
 ## Plan File Naming
 
@@ -100,7 +100,7 @@ Things still to resolve. Remove entries as they are answered.
 - If the approach changes, update **Approach** and record the change in **Change Log**.
 - Commit plan updates alongside related code changes.
 - At the start of each session, read the plan to restore context.
-- When you discover real out-of-scope work, add it to `tasks/TODO.md` under the branch-local TODO tracking rule instead of widening the plan.
+- When you discover real out-of-scope work, add it to `tasks/todo.md` under the branch-local TODO tracking rule instead of widening the plan.
 
 ## Graduation Trigger
 
@@ -110,7 +110,7 @@ When the feature is ready to merge, use this trigger phrase:
 
 ## Graduation Steps
 
-1. Check `tasks/TODO.md` for incomplete items (`- [ ]`) added during this feature.
+1. Check `tasks/todo.md` for incomplete items (`- [ ]`) added during this feature.
 2. For each incomplete item, create a task system work item, then update the line to `- [x] TASK-NNN: <description>`.
 3. Determine the next ADR number from `adr/README.md`.
 4. Create `adr/NNN-<decision-title>.md` from the plan content.
@@ -187,8 +187,8 @@ What would you do differently? What worked better than expected?
 | New session on existing feature | Continue implementing `plans/plan-<name>.md` |
 | Approach changed | Update plan and Change Log, commit with code |
 | Phase complete | Check off in plan, commit |
-| Discovered out-of-scope work | Add to `tasks/TODO.md`, commit alongside current change |
+| Discovered out-of-scope work | Add to `tasks/todo.md`, commit alongside current change |
 | Ready to merge | Graduate `plans/plan-<name>.md` to an ADR |
-| Graduation finds open TODO items | Create task system issues, add references to `tasks/TODO.md`, then proceed |
+| Graduation finds open TODO items | Create task system issues, add references to `tasks/todo.md`, then proceed |
 | Decision reversed later | Mark ADR superseded, create a new ADR |
 | Small single-file fix | Skip the plan entirely |

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/claude-header.md
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/claude-header.md
@@ -1,0 +1,5 @@
+# Plan Lifecycle
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/codex-header.md
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/codex-header.md
@@ -1,0 +1,7 @@
+# Plan Lifecycle
+
+These rules are intended for Codex (CLI and app).
+
+Create and maintain plans for non-trivial work, then graduate completed plans to ADRs.
+
+---

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -4,7 +4,7 @@ alwaysApply: false
 globs:
   - 'plans/**/*.md'
   - 'adr/**/*.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/cursor-frontmatter.yaml
@@ -1,0 +1,10 @@
+---
+description: 'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+alwaysApply: false
+globs:
+  - 'plans/**/*.md'
+  - 'adr/**/*.md'
+  - 'tasks/TODO.md'
+  - '**/AGENTS.md'
+  - '**/CLAUDE.md'
+---

--- a/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
+++ b/packages/ballast-python/ballast/agents/common/plan-lifecycle/templates/opencode-frontmatter.yaml
@@ -1,0 +1,17 @@
+---
+description: Plan lifecycle - create, maintain, and graduate plans to ADRs
+mode: subagent
+model: anthropic/claude-sonnet-4-20250514
+temperature: 0.2
+tools:
+  write: true
+  edit: true
+  bash: true
+  read: true
+  glob: true
+  grep: true
+permission:
+  bash:
+    'git *': ask
+    '*': ask
+---

--- a/packages/ballast-python/ballast/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/content-task-system.md
@@ -96,11 +96,11 @@ For Linear:
 
 - Create issues/tickets in **{{taskSystem}}** for any planned work, bugs, or follow-up items that extend beyond the current branch.
 - When starting a new piece of work, check **{{taskSystem}}** first for an existing issue to link against.
-- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/TODO.md`.
+- When closing a PR, ensure any remaining work has a corresponding issue in **{{taskSystem}}** — do not leave it only in `tasks/todo.md`.
 - Reference issue IDs in commit messages and PR descriptions so work is traceable.
 
 ## Important Notes
 
-- Do not use `tasks/TODO.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/TODO.md` rule).
+- Do not use `tasks/todo.md` as a substitute for durable issue tracking. It is branch-scoped working memory only (see the `tasks/todo.md` rule).
 - If the MCP server is unavailable, fall back to using the **{{taskSystem}}** web UI and link issues manually in PR descriptions.
 - Keep credentials out of committed files; use environment variables or platform secret stores.

--- a/packages/ballast-python/ballast/agents/common/tasks/content-todo.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/content-todo.md
@@ -1,22 +1,22 @@
 # Branch-Local TODO Tracking Rules
 
-These rules define how to use `tasks/TODO.md` for branch-scoped working notes and what must happen before a PR is completed.
+These rules define how to use `tasks/todo.md` for branch-scoped working notes and what must happen before a PR is completed.
 
 ---
-You are a branch task tracking specialist. Your role is to keep `tasks/TODO.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
+You are a branch task tracking specialist. Your role is to keep `tasks/todo.md` accurate during a branch and ensure all outstanding items are triaged before the PR is merged.
 
-## What `tasks/TODO.md` Is For
+## What `tasks/todo.md` Is For
 
-`tasks/TODO.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
+`tasks/todo.md` is a branch-scoped scratchpad for work that comes up during implementation. Use it to capture:
 - Sub-tasks discovered while working that are too small to warrant a ticket right now but must not be forgotten.
 - Deferred decisions or follow-up questions for the current branch.
 - Small cleanup items that should happen before the PR is done.
 
-`tasks/TODO.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
+`tasks/todo.md` is **not** a substitute for the configured task system. It is working memory for the current branch, not durable issue tracking.
 
 ## When to Add Items Here vs. Create a Ticket Immediately
 
-Add to `tasks/TODO.md` when:
+Add to `tasks/todo.md` when:
 - The item is small and likely to be resolved within the current branch.
 - The item is a reminder for yourself mid-implementation.
 - You are not sure yet whether it warrants a tracked issue.
@@ -29,7 +29,7 @@ Create a ticket in the configured task system immediately when:
 
 ## File Format
 
-Keep `tasks/TODO.md` as a simple markdown checklist:
+Keep `tasks/todo.md` as a simple markdown checklist:
 
 ```markdown
 # TODO
@@ -43,27 +43,27 @@ Mark items done with `[x]` as you complete them. Leave unchecked items visible s
 
 ## Before Creating a PR
 
-When the user is about to create a PR or asks you to help prepare one, check whether `tasks/TODO.md` exists and has any unchecked items (`- [ ]`).
+When the user is about to create a PR or asks you to help prepare one, check whether `tasks/todo.md` exists and has any unchecked items (`- [ ]`).
 
 If unchecked items remain, **do not proceed with creating the PR** until each item has been triaged. For each unchecked item, ask the user to choose one of:
 
 1. **Resolve it now** — implement or address it before the PR is opened.
 2. **Create a task** — open an issue in the configured task system and replace the TODO entry with a link to that issue.
-3. **Delete it** — remove it from `tasks/TODO.md` because it is no longer relevant.
+3. **Delete it** — remove it from `tasks/todo.md` because it is no longer relevant.
 
 Only proceed with the PR once every item is either checked off, linked to a tracked issue, or removed.
 
 ## After Triage
 
-Once all items are resolved, the `tasks/TODO.md` file may be:
+Once all items are resolved, the `tasks/todo.md` file may be:
 - Left as a fully checked list (all `[x]`) — this is fine and gives a useful record of what was done.
 - Cleared to an empty checklist if there are no remaining items worth keeping.
 
-Do **not** delete `tasks/TODO.md` from the branch. It should merge into `main` so the record of branch work is preserved.
+Do **not** delete `tasks/todo.md` from the branch. It should merge into `main` so the record of branch work is preserved.
 
 ## Important Notes
 
-- `tasks/TODO.md` merges into `main` intentionally — it is not gitignored.
+- `tasks/todo.md` merges into `main` intentionally — it is not gitignored.
 - Items that get promoted to tracked issues should have the issue URL noted in the file before the PR is merged.
 - Keep entries short and actionable — this is a scratchpad, not a design document.
-- If `tasks/TODO.md` does not exist at PR time, that is fine; no triage is needed.
+- If `tasks/todo.md` does not exist at PR time, that is fine; no triage is needed.

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/claude-header-todo.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/claude-header-todo.md
@@ -1,5 +1,5 @@
 # Branch-Local TODO Tracking
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/codex-header-todo.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/codex-header-todo.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Manage `tasks/TODO.md` during branch work. Triage all unchecked items before creating a PR.
+Manage `tasks/todo.md` during branch work. Triage all unchecked items before creating a PR.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -4,5 +4,5 @@ alwaysApply: false
 globs:
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-todo.yaml
@@ -1,8 +1,8 @@
 ---
-description: 'Branch-local TODO tracking - manage tasks/TODO.md and triage before PR'
+description: 'Branch-local TODO tracking - manage tasks/todo.md and triage before PR'
 alwaysApply: false
 globs:
-  - 'tasks/TODO.md'
+  - 'tasks/todo.md'
   - '**/AGENTS.md'
   - '**/CLAUDE.md'
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/opencode-frontmatter-todo.yaml
@@ -1,5 +1,5 @@
 ---
-description: Branch-local TODO tracking - manage tasks/TODO.md and triage before PR
+description: Branch-local TODO tracking - manage tasks/todo.md and triage before PR
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-typescript/src/agents.test.ts
+++ b/packages/ballast-typescript/src/agents.test.ts
@@ -23,6 +23,7 @@ describe('agents', () => {
       expect(listAgents()).toContain('publishing');
       expect(listAgents()).toContain('git-hooks');
       expect(listAgents()).toContain('tasks');
+      expect(listAgents()).toContain('plan-lifecycle');
       expect(listAgents()).toContain('testing');
     });
   });
@@ -50,6 +51,7 @@ describe('agents', () => {
       expect(isValidAgent('publishing')).toBe(true);
       expect(isValidAgent('git-hooks')).toBe(true);
       expect(isValidAgent('tasks')).toBe(true);
+      expect(isValidAgent('plan-lifecycle')).toBe(true);
       expect(isValidAgent('testing')).toBe(true);
     });
 

--- a/packages/ballast-typescript/src/agents.ts
+++ b/packages/ballast-typescript/src/agents.ts
@@ -58,7 +58,8 @@ export const COMMON_AGENT_IDS = [
   'observability',
   'publishing',
   'git-hooks',
-  'tasks'
+  'tasks',
+  'plan-lifecycle'
 ] as const;
 export const LANGUAGE_AGENT_IDS = ['linting', 'logging', 'testing'] as const;
 export const AGENT_IDS = [...COMMON_AGENT_IDS, ...LANGUAGE_AGENT_IDS] as const;

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -152,7 +152,7 @@ describe('build', () => {
 
     test('returns tasks todo content', () => {
       const content = getContent('tasks', 'todo');
-      expect(content).toContain('tasks/TODO.md');
+      expect(content).toContain('tasks/todo.md');
       expect(content).toContain('triage');
       expect(content).not.toContain('{{taskSystem}}');
     });
@@ -171,7 +171,7 @@ describe('build', () => {
       expect(content).toContain('## ADR Management Rules');
       expect(content).toContain('## Quick Reference');
       expect(content).toContain(
-        'Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule'
+        'Defer `tasks/todo.md` behavior to the branch-local TODO tracking rule'
       );
       expect(content).toContain('task system work item');
       expect(content).not.toContain('Jira');

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -64,6 +64,10 @@ describe('build', () => {
       expect(listRuleSuffixes('publishing').length).toBe(8);
     });
 
+    test('returns only main rule for plan-lifecycle', () => {
+      expect(listRuleSuffixes('plan-lifecycle')).toEqual(['']);
+    });
+
     test('throws for unknown agent', () => {
       expect(() => listRuleSuffixes('nonexistent')).toThrow(/content.md/);
     });
@@ -151,6 +155,26 @@ describe('build', () => {
       expect(content).toContain('tasks/TODO.md');
       expect(content).toContain('triage');
       expect(content).not.toContain('{{taskSystem}}');
+    });
+
+    test('returns plan-lifecycle content', () => {
+      const content = getContent('plan-lifecycle');
+      expect(content).toContain('Plan -> ADR lifecycle');
+      expect(content).toContain('Create a plan when');
+      expect(content).toContain('Skip a plan when');
+      expect(content).toContain('plans/plan-<feature-name>.md');
+      expect(content).toContain('## Maintaining The Plan');
+      expect(content).toContain(
+        'Graduate `plans/plan-<feature-name>.md` to an ADR'
+      );
+      expect(content).toContain('## ADR Template');
+      expect(content).toContain('## ADR Management Rules');
+      expect(content).toContain('## Quick Reference');
+      expect(content).toContain(
+        'Defer `tasks/TODO.md` behavior to the branch-local TODO tracking rule'
+      );
+      expect(content).toContain('task system work item');
+      expect(content).not.toContain('Jira');
     });
 
     test('returns tasks task-system content unsubstituted when no variables', () => {
@@ -732,6 +756,14 @@ alwaysApply: false
       expect(content).toContain('## Installed skills');
       expect(content).toContain('`.codex/rules/owasp-security-scan.md`');
     });
+
+    test('lists plan-lifecycle rule for codex', () => {
+      const content = buildCodexAgentsMd(['plan-lifecycle']);
+      expect(content).toContain('`.codex/rules/plan-lifecycle.md`');
+      expect(content).toContain(
+        'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+      );
+    });
   });
 
   describe('buildClaudeMd', () => {
@@ -747,6 +779,14 @@ alwaysApply: false
       expect(content).toContain('TypeScript linting specialist');
       expect(content).toContain('## Installed skills');
       expect(content).toContain('`.claude/skills/owasp-security-scan.skill`');
+    });
+
+    test('lists plan-lifecycle rule for claude', () => {
+      const content = buildClaudeMd(['plan-lifecycle']);
+      expect(content).toContain('`.claude/rules/plan-lifecycle.md`');
+      expect(content).toContain(
+        'Plan lifecycle - create, maintain, and graduate plans to ADRs'
+      );
     });
   });
 
@@ -905,6 +945,18 @@ alwaysApply: false
       expect(dir).toBe(path.join(projectRoot, '.cursor', 'rules'));
       expect(file).toBe(
         path.join(projectRoot, '.cursor', 'rules', 'local-dev-env.mdc')
+      );
+    });
+
+    test('claude with plan-lifecycle returns common rule path', () => {
+      const { dir, file } = getDestination(
+        'plan-lifecycle',
+        'claude',
+        projectRoot
+      );
+      expect(dir).toBe(path.join(projectRoot, '.claude', 'rules'));
+      expect(file).toBe(
+        path.join(projectRoot, '.claude', 'rules', 'plan-lifecycle.md')
       );
     });
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 - [x] Add canonical plan-lifecycle task rule content and platform headers.
 - [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
 - [x] Run focused tests and required sync/generation checks.
-- [ ] Push branch, open PR for #154, request Copilot review, and resolve actionable review comments.
+- [x] Push branch, open PR for #154, request Copilot review, and resolve actionable review comments. No actionable review comments were present at the latest poll.
 
 ## Previous Tasks
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,15 @@
 # Tasks
 
+- [x] Confirm issue #154 scope, operating mode, and governing PRD requirements.
+- [x] Add PRD requirements for distributing plan-lifecycle guidance through Ballast.
+- [x] Add failing generated-content coverage for the plan-lifecycle rule and installed support-file entries.
+- [x] Add canonical plan-lifecycle task rule content and platform headers.
+- [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
+- [x] Run focused tests and required sync/generation checks.
+- [ ] Push branch, open PR for #154, request Copilot review, and resolve actionable review comments.
+
+## Previous Tasks
+
 - [x] Confirm issue #145 scope, operating mode, and governing PRD gap.
 - [x] Add PRD requirements for integration-framework detection and Playwright preference across supported languages.
 - [x] Add failing generated-content coverage for framework detection markers and browser E2E framework selection.
@@ -7,8 +17,6 @@
 - [x] Sync package mirrors and corresponding `.codex`/`.claude` testing outputs from the updated source templates.
 - [x] Run focused tests.
 - [x] Update `tasks/lessons.md` if implementation reveals a repeatable failure pattern. No new repeatable failure pattern found.
-
-## Previous Tasks
 
 - [x] Confirm issue #160 scope, operating mode, and Terraform/OpenTofu tooling sources.
 - [x] Add PRD requirements for Terraform linting, testing, CI, security scanner, and OpenTofu guidance.


### PR DESCRIPTION
## Summary

- Adds the common `plan-lifecycle` agent rule for creating plans, maintaining them during implementation, and graduating completed plans to ADRs.
- Registers `plan-lifecycle` across the wrapper and TypeScript backend, updates `.rulesrc.json`, and refreshes checked-in Codex/Claude generated outputs plus Python/Go package mirrors.
- Adds PRD requirements and generated-content/support-file tests for issue #154.

## Validation

- [x] Tests or checks run: `pnpm --dir packages/ballast-typescript test`; `pnpm --dir packages/ballast-typescript run lint`; `go test ./...` in `cli/ballast`; `git diff --check`
- [x] Docs updated or not needed: `PRD.md`, `AGENTS.md`, and `CLAUDE.md` updated
- [x] Generated files updated or not needed: `.claude/rules/common/plan-lifecycle.md`, `.codex/rules/common/plan-lifecycle.md`, `.codex/rules/typescript/typescript-plan-lifecycle.md`, and package mirrors refreshed

## Agent Notes

- Related issue/PRD: Closes #154; `PRD.md` Plan Lifecycle Rule Distribution
- Risk level: Low; generated guidance and registry/config update only
- Follow-up needed: None