### PR TITLE
Clarify generated rule activation

### DIFF
--- a/.claude/rules/cicd.md
+++ b/.claude/rules/cicd.md
@@ -1,17 +1,17 @@
 # CI/CD Rules
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -45,14 +45,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.claude/rules/local-dev-env.md
+++ b/.claude/rules/local-dev-env.md
@@ -1,23 +1,46 @@
 # Local Development Environment Rules
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
+
+Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+
+For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Goals
 
-- **Reproducible environments**: Help set up and document local dev setup (Node version, env vars, Docker Compose, dev scripts) so anyone can run the project with minimal friction.
-- **Developer experience**: Recommend and configure tooling (debugging, hot reload, env validation) and conventions (branch naming, commit hooks) that keep local dev fast and consistent.
-- **Documentation**: Keep README and runbooks (e.g. "Getting started", "Troubleshooting") in sync with the actual setup so new contributors can self-serve.
+- Keep local setup reproducible.
+- Keep the first-run path short for new contributors.
+- Keep README and runbooks aligned with the actual developer workflow.
+
+## Agent Startup
+
+- If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
+- Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
+- If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 
 ## Apply This Rule When
 
 - The task is about local setup, onboarding, `.nvmrc`, env files, Docker, Compose, or dev scripts.
 - The user asks to prepare a repository for contributor use.
 - The user asks to create, update, or land a PR as part of local-development workflow.
+
+## Branch Before Code
+
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+
+- If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
+- If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.
+- Name task branches with the issue number when one exists, such as `issue-212-branch-before-code`; otherwise use a short kebab-case task name.
+- Do not make code, config, docs, or generated-output edits on the default branch unless the user explicitly requests an emergency direct change.
+- Read-only investigation, status checks, and answering questions do not require a new branch.
+- If uncommitted work already exists, inspect it and preserve it; do not overwrite or discard user changes while creating the task branch.
 
 ## Core Responsibilities
 
@@ -41,9 +64,13 @@ You are a local development environment specialist for TypeScript/JavaScript pro
    - Prefer fast checks in local hooks and heavier checks in pre-push or CI.
 
 5. Treat PR hygiene as part of local-dev workflow.
-   - Verify the correct reviewers are assigned when the repo expects that workflow.
-   - Inspect failing checks with `gh` and summarize the concrete failure.
-   - Reply directly on resolved review threads instead of leaving line comments unresolved.
+   - Verify expected reviewers are assigned.
+   - Inspect failing checks with `gh`; summarize the failure.
+   - After PR creation and every push, poll Copilot and human review comments until the PR is ready.
+   - Before changes, summarize actionable Copilot asks and related human-review asks.
+   - Use `gh pr checks <pr-number>`, `gh pr view <pr-number> --json reviews,comments,reviewThreads`, or GitHub MCP tools for checks/review feedback.
+   - Reply directly on addressed Copilot and human comments; resolve addressed review threads when supported.
+   - Stop only when required checks are green and no unresolved actionable Copilot or human review comments remain.
 
 ## Node Guidance
 
@@ -68,359 +95,3 @@ You are a local development environment specialist for TypeScript/JavaScript pro
 1. Summarize the local-dev workflow you added or preserved.
 2. Call out any new entrypoints such as `.nvmrc`, `docker-compose.local.yaml`, `Makefile`, or `make up-local`.
 3. Identify any remaining gaps in onboarding or PR workflow coverage.
-
-## Scope
-
-- Local run scripts, env files (.env.example), and optional containerized dev (e.g. Docker Compose for services).
-- Version managers (nvm, volta) and required Node/npm versions.
-- Pre-commit or pre-push hooks that run tests/lint locally before pushing. For TypeScript projects, run `build` before `test` in these hooks (e.g. `pnpm run build && pnpm test`). Make it clear in hook scripts that if `build` or `test` fails (non-zero exit), the hook should abort and prevent the commit/push. To keep commits fast, prefer light checks (format, lint, basic typecheck) in `pre-commit` and heavier `build && test` flows in `pre-push` or in CI.
-
-## Pull Request Workflow
-
-When the user is creating or landing a pull request as part of local development workflow, treat PR hygiene as part of the job.
-
-### Your Responsibilities
-
-1. **Ensure Copilot is assigned to the PR**
-   - When a PR exists or is being created, check whether GitHub Copilot is assigned for code review/agent assistance when the repository workflow expects it.
-   - If Copilot is not assigned, assign it before considering the PR ready.
-   - Do not assume assignment happened automatically; verify it.
-   - For Copilot or any other reviewer, summarize the review comments and requested changes so the user can decide what should be fixed next.
-
-2. **Use a sub-agent to monitor PR checks**
-   - After pushing commits or creating/updating a PR, use a sub-agent to watch the PR checks while the main agent continues with other work.
-   - Have the sub-agent report back when checks succeed or when a check fails.
-   - Treat pending or failing checks as part of the task, not as an afterthought.
-   - Do not tell the user the PR is ready until the sub-agent confirms the required checks are green.
-
-3. **Use `gh` to inspect failures**
-   - If PR checks fail, use the GitHub CLI to inspect the failing runs, jobs, logs, and annotations.
-   - Prefer `gh pr checks`, `gh run view`, and related `gh` commands so the user gets concrete failure context tied to the PR.
-   - Pass the failing details from the sub-agent back to the main agent, then summarize the failing check, the relevant error, and what needs to be fixed next.
-
-4. **Reply directly to GitHub review comments when fixing them**
-   - When a specific GitHub review comment is addressed, reply on that review comment thread directly instead of posting a general summary comment on the PR.
-   - The reply should say what was changed or why the requested change was not made.
-   - Use general PR comments only for overall status or cross-cutting updates, not for resolving line-specific review feedback.
-   - This applies to Copilot review comments and human review comments alike.
-   - Do not stop at making the code change locally; if the review comment was addressed, add the thread reply.
-   - If multiple review comments were addressed, reply on each relevant thread rather than collapsing them into one PR-level summary.
-
-5. **Summarize review asks before changing code**
-   - For Copilot reviews and human reviews alike, summarize the concrete asks, group duplicates, and identify which comments actually require code changes.
-   - If a comment is informational or already satisfied, say that explicitly.
-
-### When to Apply
-
-- When the user asks to create, update, review, or land a PR.
-- When the task includes “open a PR”, “get the PR ready”, “make sure CI passes”, or similar language.
-- When local work is complete and the next step is validating PR readiness.
-
----
-
-## Node Version Management (nvm)
-
-When setting up or working on Node.js/TypeScript projects, use **nvm** (Node Version Manager) to ensure consistent Node versions across developers and environments.
-
-### Your Responsibilities
-
-1. **Create or update `.nvmrc`**
-   - If the project has no `.nvmrc`, create one with the **current Node LTS** version (e.g. `24`). Check [Node.js Releases](https://nodejs.org/en/about/releases/) for the current Active LTS; as of this writing it is Node 24 (Krypton).
-   - If a specific version is already used elsewhere, match it (e.g. `22`, `20`, `lts/hydrogen`).
-   - For **package.json** `engines` and **README** prerequisites/support text, use the **previous LTS** (one LTS back) as the minimum supported version (e.g. `22`) so the project documents support for both current and previous LTS. Example `engines`: `"node": ">=22"`. In the README, state e.g. "Node.js 22 (LTS) or 24 (Active LTS)" or "Use the version in `.nvmrc` (Node 24). Supported: Node 22+."
-
-2. **Use `.nvmrc` in the project**
-   - Instruct developers to run `nvm use` (or `nvm install` if the version is not yet installed) when entering the project directory.
-   - Consider adding shell integration (e.g. `direnv` with `use nvm`, or `.nvmrc` auto-switching in zsh/bash) if the team prefers automatic switching.
-
-3. **Update the README**
-   - Add a "Prerequisites" or "Getting started" subsection that states supported Node version (previous LTS and current LTS, e.g. "Node.js 22 (LTS) or 24 (Active LTS)") and instructs new contributors to:
-     1. Install nvm (e.g. `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash` or the latest from https://github.com/nvm-sh/nvm).
-     2. Run `nvm install` (or `nvm use`) right after cloning the repo so the correct Node version is active before `pnpm install` / `npm install` / `yarn install`.
-   - In **package.json**, add or update `engines` with the previous LTS as minimum, e.g. `"engines": { "node": ">=22" }`.
-
-### Example README Addition
-
-````markdown
-
-## Prerequisites
-
-- **Node.js**: Use the version in `.nvmrc`. Supported: Node 22 (LTS) or 24 (Active LTS). Run `nvm install` (or `nvm use`) after cloning so the correct Node version is active before `pnpm install`.
-- [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager)
-
-After cloning the repo, install and use the project's Node version:
-
-```bash
-nvm install   # installs the version from .nvmrc
-nvm use       # switches to it (or run `nvm install` which does both)
-```
-
-Then install dependencies: `pnpm install` (or `npm install` / `yarn`).
-````
-
-### Example package.json engines
-
-Use the previous LTS as the minimum supported version (one LTS back from `.nvmrc`):
-
-```json
-"engines": {
-  "node": ">=22"
-}
-```
-
-### Key Commands
-
-- `nvm install` — installs the version from `.nvmrc` (or `lts/*` if `.nvmrc` is missing)
-- `nvm use` — switches the current shell to the version in `.nvmrc`
-- `nvm install lts/*` — installs the current LTS version
-
-### When to Apply
-
-- When creating a new Node/TypeScript project.
-- When a project lacks `.nvmrc` or README setup instructions.
-- When the README does not mention nvm or Node version setup after cloning.
-
----
-
-## Dockerfile for Local Development (Node.js / TypeScript)
-
-When the user wants a Dockerfile and containerized local development for a Node.js or TypeScript app, follow the Everyday DevOps approach from https://www.markcallen.com/dockerfile-for-typescript/
-
-### Your Responsibilities
-
-1. **Create a production-style Dockerfile**
-   - Use a Node LTS image matching `.nvmrc` (e.g. `node:24-bookworm` for current Active LTS).
-   - Set `WORKDIR /app`.
-   - Copy only `package.json` and lockfile (`yarn.lock`, `pnpm-lock.yaml`, or `package-lock.json`) first.
-   - Install dependencies with frozen lockfile and `--ignore-scripts` (e.g. `yarn install --frozen-lockfile --ignore-scripts`, or `pnpm install --frozen-lockfile --ignore-scripts`, or `npm ci --ignore-scripts`).
-   - Copy the rest of the application.
-   - Run the build script (e.g. `yarn build` / `pnpm run build`).
-   - Set `CMD` to start the app (e.g. `node dist/index.js` or `npm start`).
-
-2. **Add a .dockerignore**
-   - Exclude: `node_modules`, `dist`, `.env`, `.vscode`, `*.log`, `.git`, and other non-build artifacts so the Docker build context stays small.
-
-3. **Create both `docker-compose.yaml` and `docker-compose.local.yaml`**
-   - `docker-compose.yaml` should be the default, production-style local stack:
-     - Use `build: .` for the app service so the image is built from the local Dockerfile.
-     - Run the built app with a production-style command such as `npm start`, `pnpm start`, or `node dist/index.js`.
-     - Include the other required services for the application (for example Postgres, Redis, or other local dependencies) with sensible ports, volumes, healthchecks, and `depends_on` wiring.
-     - For CLI apps, set `tty: true` so the app container stays attached when appropriate.
-   - `docker-compose.local.yaml` should be the developer override for fast iteration:
-     - Reuse the app service from `docker-compose.yaml`.
-     - Add Compose `develop.watch` so code changes are reflected without a full manual rebuild.
-     - Use `action: sync+restart` for source directories (for example `src/`) so edits sync into the container and the process restarts.
-     - Use `action: rebuild` for dependency manifests such as `package.json` and the lockfile so dependency changes rebuild the image.
-     - Set `command` to the dev script (for example `yarn dev`, `pnpm run dev`, or `tsx src/index.ts`) so the app runs with watch or hot reload inside the container.
-   - Keep shared services defined once where practical so `docker-compose.local.yaml` layers on top of the base stack instead of duplicating everything.
-
-4. **Create a Makefile for Docker Compose workflows**
-   - Add targets for the base stack:
-     - `make up` runs `docker compose up --build`.
-     - `make down` runs `docker compose down`.
-     - `make logs` runs `docker compose logs -f`.
-   - Add targets for the local/watch stack using both compose files:
-     - `make up-local` runs `docker compose -f docker-compose.yaml -f docker-compose.local.yaml up --build --watch`.
-     - `make down-local` runs `docker compose -f docker-compose.yaml -f docker-compose.local.yaml down`.
-     - `make logs-local` runs `docker compose -f docker-compose.yaml -f docker-compose.local.yaml logs -f`.
-   - If the project already has a Makefile, extend it instead of replacing it.
-   - Keep target names simple and aligned with the documented developer workflow.
-
-5. **Ensure package.json scripts**
-   - `build`: compile/bundle (e.g. `rimraf ./dist && tsc`, or project equivalent).
-   - `start`: run the built app (e.g. `node dist/index.js`).
-   - `dev`: run for local development with watch (e.g. `tsx src/index.ts` or `ts-node-dev`, etc.).
-
-### Implementation Order
-
-1. Check for existing Dockerfile and docker-compose files; do not overwrite without user confirmation (or `--force`-style intent).
-2. Identify package manager (yarn, pnpm, npm) and lockfile name.
-3. Create `.dockerignore` with appropriate exclusions.
-4. Create `Dockerfile` with multi-stage or single-stage build as above.
-5. Create or update `docker-compose.yaml` for the built app and required services.
-6. Create or update `docker-compose.local.yaml` for `develop.watch` and the dev `command`.
-7. Create or update the `Makefile` with `up`, `down`, and `logs` targets for both the base and local/watch stacks.
-8. Verify `package.json` has `build`, `start`, and `dev` scripts; suggest additions if missing.
-9. Document in README: how to use `make up`, `make down`, `make logs`, `make up-local`, `make down-local`, and `make logs-local`, plus optional `docker build` / `docker run`.
-
-### Key Snippets
-
-**Dockerfile (yarn example):**
-
-```dockerfile
-FROM node:24-bookworm
-
-WORKDIR /app
-
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --ignore-scripts
-
-COPY . .
-RUN yarn build
-
-CMD [ "yarn", "start" ]
-```
-
-**Dockerfile (pnpm example):**
-
-```dockerfile
-FROM node:24-bookworm
-
-WORKDIR /app
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --ignore-scripts
-
-COPY . .
-RUN pnpm run build
-
-CMD [ "pnpm", "start" ]
-```
-
-**.dockerignore:**
-
-```
-node_modules
-dist
-.env
-.vscode
-*.log
-.git
-```
-
-**docker-compose.yaml (base stack):**
-
-```yaml
-services:
-  app:
-    build: .
-    command: pnpm start
-    depends_on:
-      db:
-        condition: service_healthy
-
-  db:
-    image: postgres:17
-    environment:
-      POSTGRES_DB: app
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app"]
-```
-
-**docker-compose.local.yaml (watch override):**
-
-```yaml
-services:
-  app:
-    develop:
-      watch:
-        - action: sync+restart
-          path: src/
-          target: /app/src
-        - action: rebuild
-          path: package.json
-    command: pnpm run dev
-```
-
-**Makefile:**
-
-```makefile
-COMPOSE := docker compose
-LOCAL_COMPOSE := $(COMPOSE) -f docker-compose.yaml -f docker-compose.local.yaml
-
-up:
-	$(COMPOSE) up --build
-
-down:
-	$(COMPOSE) down
-
-logs:
-	$(COMPOSE) logs -f
-
-up-local:
-	$(LOCAL_COMPOSE) up --build --watch
-
-down-local:
-	$(LOCAL_COMPOSE) down
-
-logs-local:
-	$(LOCAL_COMPOSE) logs -f
-```
-
-Use `pnpm run dev` or `npm run dev` in `docker-compose.local.yaml` if the project uses that package manager. Adjust watched paths, targets, and service names if the app uses a different layout (for example `app/` instead of `src/`).
-
-### Important Notes
-
-- Keep the Docker build context small: always use a `.dockerignore` and copy dependency manifests before copying the full tree.
-- Use `--frozen-lockfile` (yarn/pnpm) or `npm ci` so production and CI builds are reproducible.
-- Prefer `docker-compose.yaml` as the stable base stack and `docker-compose.local.yaml` as the watch-mode overlay so developers can choose between built-app and hot-reload workflows without maintaining two unrelated stacks.
-- For local dev, `develop.watch` with `sync+restart` on source dirs avoids full image rebuilds on every code change; reserve `rebuild` for dependency or manifest changes.
-- For web apps (e.g. Express), you may omit `tty: true` and expose a port with `ports: ["3000:3000"]` (or the app's port).
-- When the app depends on backing services, include them in the compose stack instead of documenting them separately so `make up` and `make up-local` start a complete working environment.
-- If the project has no `dev` script, suggest adding one (e.g. using `tsx`, `ts-node-dev`, or `node --watch`) so `docker compose up --watch` is useful.
-
-### When Completed
-
-1. Summarize what was created or updated (`Dockerfile`, `.dockerignore`, `docker-compose.yaml`, `docker-compose.local.yaml`, `Makefile`, and any script changes).
-2. Tell the user how to run the built stack with `make up`, inspect it with `make logs`, and stop it with `make down`.
-3. Tell the user how to run the watch-mode stack with `make up-local`, inspect it with `make logs-local`, and stop it with `make down-local`.
-4. Mention that editing files under the watched path will sync and restart the service, and changing `package.json` or the lockfile will trigger a rebuild.
-4. Optionally suggest adding a short "Docker" or "Local development" section to the README with these commands.
-
----
-
-## TypeScript Path Aliases (@/)
-
-When working with TypeScript projects, use the `@/` path alias for imports so that paths stay clean and stable regardless of file depth.
-
-### Your Responsibilities
-
-1. **Use `@/` for TypeScript imports**
-   - Prefer `import { foo } from '@/components/foo'` over `import { foo } from '../../../components/foo'`.
-   - The `@/` alias should resolve to the project's source root (typically `src/`).
-
-2. **Configure `tsconfig.json`**
-   - Add `baseUrl` and `paths` so TypeScript resolves `@/*` correctly.
-   - Ensure `baseUrl` points to the project root (or the directory containing `src/`).
-   - Map `@/*` to the source directory (e.g. `src/*`).
-
-3. **Configure the bundler/runtime**
-   - If using `tsc` only: `paths` in `tsconfig.json` is sufficient for type-checking, but the build output may need a resolver (e.g. `tsconfig-paths`) unless the bundler handles it.
-   - If using Vite, Next.js, or similar: they read `tsconfig.json` paths automatically.
-   - If using plain `tsc`: consider `tsconfig-paths` at runtime, or a bundler that resolves paths.
-
-### Example tsconfig.json
-
-```json
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "include": ["src"]
-}
-```
-
-If the project root is the repo root and source lives in `src/`, this maps `@/utils/foo` → `src/utils/foo`.
-
-### Example Imports
-
-```typescript
-// Prefer
-import { formatDate } from '@/utils/date';
-import { Button } from '@/components/Button';
-
-// Avoid deep relative paths
-import { formatDate } from '../../../utils/date';
-```
-
-### When to Apply
-
-- When creating or configuring a new TypeScript project.
-- When a project uses long relative import chains (`../../../`).
-- When `tsconfig.json` exists but has no `paths` or `baseUrl` for `@/`.

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -1,11 +1,11 @@
 # Observability Rules
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -15,7 +15,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/.claude/rules/publishing-api.md
+++ b/.claude/rules/publishing-api.md
@@ -1,3 +1,9 @@
+---
+# Publishing Rules
+
+These rules help design and maintain release workflows for libraries, SDKs, and apps.
+
+---
 # REST API Publishing Agent
 
 You are a publishing specialist for REST API services deployed as Docker containers or platform-native service artifacts.
@@ -13,7 +19,7 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## CI Workflow
 

--- a/.claude/rules/publishing-apps.md
+++ b/.claude/rules/publishing-apps.md
@@ -64,18 +64,9 @@ For TypeScript or Node CLI apps distributed through npmjs:
 - Prefer npm trusted publishing with `id-token: write`.
 - Verify the packaged CLI starts successfully from the built artifact before publishing.
 
-## Web Apps: Docker Image + Separate Helm Chart Repo
+## App Deployment Model
 
-For web apps deployed to Kubernetes, prefer a two-repository release model:
-
-- Application repository:
-  - build and publish the Docker image
-  - produce immutable image references
-  - do not keep deployment-environment chart changes in the same release commit by default
-- Helm chart repository:
-  - owns the chart, values, and deployment metadata
-  - is updated after the application image is published
-  - records the new image tag or digest in a chart release commit
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 
@@ -110,36 +101,14 @@ When building the workflow:
   - GHCR: `contents: read`, `packages: write`
   - Docker Hub: `contents: read` plus Docker Hub credentials from secrets
 
-### Separate Helm Chart Repository
-
-After the image publish succeeds, update a separate Helm chart repository rather than mixing chart release state into the app repository.
-
-The Helm chart repo should contain:
-
-- one chart per deployable app
-- `values.yaml` defaults
-- environment-specific values files only when the team intentionally stores them there
-- image repository and tag or digest fields that can be updated automatically
-
-Preferred automation flow:
-
-1. Publish the app image to GHCR or Docker Hub.
-2. Capture the pushed tag and digest.
-3. Check out the separate Helm chart repository in a later job or workflow.
-4. Update chart values to the new image tag or digest.
-5. Bump the chart version when chart contents changed.
-6. Commit and push the chart update.
-7. Optionally package and publish the chart from the chart repo if the team uses an OCI chart registry or GitHub Pages chart index.
-
-### Helm Update Rules
+### Image Reference Rules
 
 - Prefer digest pinning for production deployments when the platform supports it.
-- Keep the application version and chart version distinct:
+- Keep the application version and deployment-manifest version distinct:
   - app version tracks the shipped container
-  - chart version tracks deployment-manifest changes
-- Do not overwrite unrelated chart values during automation.
-- If multiple environments exist, make the target environment or values file explicit in the workflow inputs.
-- If the chart repo is private, use a dedicated token scoped to that repository only.
+  - chart, manifest, or platform config version tracks deployment-shape changes
+- Do not overwrite unrelated environment values during automation.
+- If multiple environments exist, make the target environment explicit in workflow inputs or promotion controls.
 
 ### What to Generate
 
@@ -147,15 +116,15 @@ For a web app release workflow, generate:
 
 - a Docker image publish job for GHCR or Docker Hub
 - outputs exposing the published image tag and digest
-- a follow-up job or reusable workflow that updates the separate Helm chart repo
+- a deployment-model-specific follow-up job or reusable workflow when an environment should move to the new image
 - clear secrets and permissions documentation in the workflow comments or README
 
 ### What Not to Do
 
 - Do not deploy mutable `latest` tags by default.
 - Do not hardcode long-lived registry passwords in workflow files.
-- Do not keep the chart repo update step hidden inside a shell script with no visible diff.
-- Do not update a Helm chart in-place in the app repo when the team has chosen a separate chart repository model.
+- Do not hide deployment state changes inside a shell script with no visible diff or audit trail.
+- Do not assume Kubernetes-specific Helm or ArgoCD ownership when `deploymentModel` is not `kubernetes`.
 
 ## Python Apps: PyPI
 
@@ -193,7 +162,7 @@ For Go apps and CLIs:
 - Keep installation instructions in `README.md` aligned with the actual release channel.
 - Publish checksums for downloadable binaries when the app ships archives.
 - Ensure version output from the binary or CLI matches the release tag.
-- For web apps, keep the published container image and Helm chart update linked by version or digest in release notes or workflow outputs.
+- For web apps, keep the published container image or app artifact linked to the deployment-state update by version, digest, or platform release ID.
 - The workflow-dispatch `release_type` input should decide whether the next app tag is patch, minor, or major.
 
 ## When to Apply
@@ -201,4 +170,4 @@ For Go apps and CLIs:
 - When a repository publishes a CLI, desktop helper, or installable service package.
 - When the release artifact is intended for direct installation by end users.
 - When a project needs app-focused packaging guidance instead of library-only rules.
-- When a web app is released as a container image and deployed through a separate Helm chart repository.
+- When a web app is released as a container image and deployed through the configured deployment model.

--- a/.claude/rules/publishing-web.md
+++ b/.claude/rules/publishing-web.md
@@ -1,3 +1,9 @@
+---
+# Publishing Rules
+
+These rules help design and maintain release workflows for libraries, SDKs, and apps.
+
+---
 # Web App Publishing Agent
 
 You are a publishing specialist for web applications deployed as Docker containers or platform-native app artifacts.
@@ -13,7 +19,7 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## Workflow Trigger and Concurrency
 

--- a/.claude/rules/tasks-task-system.md
+++ b/.claude/rules/tasks-task-system.md
@@ -1,7 +1,5 @@
 # Task System Integration
 
-These rules are intended for Codex (CLI and app).
-
 Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/.codex/rules/cicd.md
+++ b/.codex/rules/cicd.md
@@ -2,18 +2,18 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -47,14 +47,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.codex/rules/local-dev-env.md
+++ b/.codex/rules/local-dev-env.md
@@ -2,24 +2,47 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
+
+Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+
+For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Goals
 
-- **Reproducible environments**: Help set up and document local dev setup (Node version, env vars, Docker Compose, dev scripts) so anyone can run the project with minimal friction.
-- **Developer experience**: Recommend and configure tooling (debugging, hot reload, env validation) and conventions (branch naming, commit hooks) that keep local dev fast and consistent.
-- **Documentation**: Keep README and runbooks (e.g. "Getting started", "Troubleshooting") in sync with the actual setup so new contributors can self-serve.
+- Keep local setup reproducible.
+- Keep the first-run path short for new contributors.
+- Keep README and runbooks aligned with the actual developer workflow.
+
+## Agent Startup
+
+- If the `ballast` wrapper is available, run `ballast setup-dev` before inspecting or changing code.
+- Use `ballast doctor` to inspect Ballast-managed local state; if `.ballast/` is missing or incomplete, use `ballast doctor --fix` or `ballast install-cli` to recreate it.
+- Treat `.ballast/` as generated local tool state. Do not commit it.
+- Treat setup output as the source of truth for missing tools, skipped steps, and manual remediation.
+- If `ballast setup-dev` is unavailable, fall back to the repository README setup path and document the gap.
 
 ## Apply This Rule When
 
 - The task is about local setup, onboarding, `.nvmrc`, env files, Docker, Compose, or dev scripts.
 - The user asks to prepare a repository for contributor use.
 - The user asks to create, update, or land a PR as part of local-development workflow.
+
+## Branch Before Code
+
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+
+- If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
+- If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.
+- Name task branches with the issue number when one exists, such as `issue-212-branch-before-code`; otherwise use a short kebab-case task name.
+- Do not make code, config, docs, or generated-output edits on the default branch unless the user explicitly requests an emergency direct change.
+- Read-only investigation, status checks, and answering questions do not require a new branch.
+- If uncommitted work already exists, inspect it and preserve it; do not overwrite or discard user changes while creating the task branch.
 
 ## Core Responsibilities
 
@@ -43,9 +66,13 @@ You are a local development environment specialist for TypeScript/JavaScript pro
    - Prefer fast checks in local hooks and heavier checks in pre-push or CI.
 
 5. Treat PR hygiene as part of local-dev workflow.
-   - Verify the correct reviewers are assigned when the repo expects that workflow.
-   - Inspect failing checks with `gh` and summarize the concrete failure.
-   - Reply directly on resolved review threads instead of leaving line comments unresolved.
+   - Verify expected reviewers are assigned.
+   - Inspect failing checks with `gh`; summarize the failure.
+   - After PR creation and every push, poll Copilot and human review comments until the PR is ready.
+   - Before changes, summarize actionable Copilot asks and related human-review asks.
+   - Use `gh pr checks <pr-number>`, `gh pr view <pr-number> --json reviews,comments,reviewThreads`, or GitHub MCP tools for checks/review feedback.
+   - Reply directly on addressed Copilot and human comments; resolve addressed review threads when supported.
+   - Stop only when required checks are green and no unresolved actionable Copilot or human review comments remain.
 
 ## Node Guidance
 
@@ -70,251 +97,3 @@ You are a local development environment specialist for TypeScript/JavaScript pro
 1. Summarize the local-dev workflow you added or preserved.
 2. Call out any new entrypoints such as `.nvmrc`, `docker-compose.local.yaml`, `Makefile`, or `make up-local`.
 3. Identify any remaining gaps in onboarding or PR workflow coverage.
-
-## Scope
-
-- Local run scripts, env files (.env.example), and optional containerized dev (e.g. Docker Compose for services).
-- Version managers (nvm, volta) and required Node/npm versions.
-- Pre-commit or pre-push hooks that run tests/lint locally before pushing. For TypeScript projects, run `build` before `test` in these hooks (e.g. `pnpm run build && pnpm test`). Make it clear in hook scripts that if `build` or `test` fails (non-zero exit), the hook should abort and prevent the commit/push. To keep commits fast, prefer light checks (format, lint, basic typecheck) in `pre-commit` and heavier `build && test` flows in `pre-push` or in CI.
-
----
-
-## Node Version Management (nvm)
-
-When setting up or working on Node.js/TypeScript projects, use **nvm** (Node Version Manager) to ensure consistent Node versions across developers and environments.
-
-### Your Responsibilities
-
-1. **Create or update `.nvmrc`**
-   - If the project has no `.nvmrc`, create one with the **current Node LTS** version (e.g. `24`). Check [Node.js Releases](https://nodejs.org/en/about/releases/) for the current Active LTS; as of this writing it is Node 24 (Krypton).
-   - If a specific version is already used elsewhere, match it (e.g. `22`, `20`, `lts/hydrogen`).
-   - For **package.json** `engines` and **README** prerequisites/support text, use the **previous LTS** (one LTS back) as the minimum supported version (e.g. `22`) so the project documents support for both current and previous LTS. Example `engines`: `"node": ">=22"`. In the README, state e.g. "Node.js 22 (LTS) or 24 (Active LTS)" or "Use the version in `.nvmrc` (Node 24). Supported: Node 22+."
-
-2. **Use `.nvmrc` in the project**
-   - Instruct developers to run `nvm use` (or `nvm install` if the version is not yet installed) when entering the project directory.
-   - Consider adding shell integration (e.g. `direnv` with `use nvm`, or `.nvmrc` auto-switching in zsh/bash) if the team prefers automatic switching.
-
-3. **Update the README**
-   - Add a "Prerequisites" or "Getting started" subsection that states supported Node version (previous LTS and current LTS, e.g. "Node.js 22 (LTS) or 24 (Active LTS)") and instructs new contributors to:
-     1. Install nvm (e.g. `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash` or the latest from https://github.com/nvm-sh/nvm).
-     2. Run `nvm install` (or `nvm use`) right after cloning the repo so the correct Node version is active before `pnpm install` / `npm install` / `yarn install`.
-   - In **package.json**, add or update `engines` with the previous LTS as minimum, e.g. `"engines": { "node": ">=22" }`.
-
-### Example README Addition
-
-````markdown
-
-## Prerequisites
-
-- **Node.js**: Use the version in `.nvmrc`. Supported: Node 22 (LTS) or 24 (Active LTS). Run `nvm install` (or `nvm use`) after cloning so the correct Node version is active before `pnpm install`.
-- [nvm](https://github.com/nvm-sh/nvm) (Node Version Manager)
-
-After cloning the repo, install and use the project's Node version:
-
-```bash
-nvm install   # installs the version from .nvmrc
-nvm use       # switches to it (or run `nvm install` which does both)
-```
-
-Then install dependencies: `pnpm install` (or `npm install` / `yarn`).
-````
-
-### Example package.json engines
-
-Use the previous LTS as the minimum supported version (one LTS back from `.nvmrc`):
-
-```json
-"engines": {
-  "node": ">=22"
-}
-```
-
-### Key Commands
-
-- `nvm install` — installs the version from `.nvmrc` (or `lts/*` if `.nvmrc` is missing)
-- `nvm use` — switches the current shell to the version in `.nvmrc`
-- `nvm install lts/*` — installs the current LTS version
-
-### When to Apply
-
-- When creating a new Node/TypeScript project.
-- When a project lacks `.nvmrc` or README setup instructions.
-- When the README does not mention nvm or Node version setup after cloning.
-
----
-
-## Dockerfile for Local Development (Node.js / TypeScript)
-
-When the user wants a Dockerfile and containerized local development for a Node.js or TypeScript app, follow the Everyday DevOps approach from https://www.markcallen.com/dockerfile-for-typescript/
-
-### Your Responsibilities
-
-1. **Create a production-style Dockerfile**
-   - Use a Node LTS image matching `.nvmrc` (e.g. `node:24-bookworm` for current Active LTS).
-   - Set `WORKDIR /app`.
-   - Copy only `package.json` and lockfile (`yarn.lock`, `pnpm-lock.yaml`, or `package-lock.json`) first.
-   - Install dependencies with frozen lockfile and `--ignore-scripts` (e.g. `yarn install --frozen-lockfile --ignore-scripts`, or `pnpm install --frozen-lockfile --ignore-scripts`, or `npm ci --ignore-scripts`).
-   - Copy the rest of the application.
-   - Run the build script (e.g. `yarn build` / `pnpm run build`).
-   - Set `CMD` to start the app (e.g. `node dist/index.js` or `npm start`).
-
-2. **Add a .dockerignore**
-   - Exclude: `node_modules`, `dist`, `.env`, `.vscode`, `*.log`, `.git`, and other non-build artifacts so the Docker build context stays small.
-
-3. **Create docker-compose.yml for local development**
-   - Use `build: .` for the app service.
-   - For CLI apps, set `tty: true` so the container doesn't exit immediately.
-   - Use Compose's `develop.watch` so code changes are reflected without full rebuilds:
-     - `action: sync+restart` for source directories (e.g. `src/`) so edits sync in and the process restarts.
-     - `action: rebuild` for `package.json` (and lockfile) so dependency changes trigger an image rebuild.
-   - Set `command` to the dev script (e.g. `yarn dev`, `pnpm run dev`, or `tsx src/index.ts`) so the app runs with watch/hot reload inside the container.
-
-4. **Ensure package.json scripts**
-   - `build`: compile/bundle (e.g. `rimraf ./dist && tsc`, or project equivalent).
-   - `start`: run the built app (e.g. `node dist/index.js`).
-   - `dev`: run for local development with watch (e.g. `tsx src/index.ts` or `ts-node-dev`, etc.).
-
-### Implementation Order
-
-1. Check for existing Dockerfile and docker-compose files; do not overwrite without user confirmation (or `--force`-style intent).
-2. Identify package manager (yarn, pnpm, npm) and lockfile name.
-3. Create `.dockerignore` with appropriate exclusions.
-4. Create `Dockerfile` with multi-stage or single-stage build as above.
-5. Create or update `docker-compose.yml` with `develop.watch` and dev `command`.
-6. Verify `package.json` has `build`, `start`, and `dev` scripts; suggest additions if missing.
-7. Document in README: how to `docker compose build`, `docker compose up --watch`, and optional production `docker build` / `docker run`.
-
-### Key Snippets
-
-**Dockerfile (yarn example):**
-
-```dockerfile
-FROM node:24-bookworm
-
-WORKDIR /app
-
-COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile --ignore-scripts
-
-COPY . .
-RUN yarn build
-
-CMD [ "yarn", "start" ]
-```
-
-**Dockerfile (pnpm example):**
-
-```dockerfile
-FROM node:24-bookworm
-
-WORKDIR /app
-
-RUN corepack enable && corepack prepare pnpm@latest --activate
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --ignore-scripts
-
-COPY . .
-RUN pnpm run build
-
-CMD [ "pnpm", "start" ]
-```
-
-**.dockerignore:**
-
-```
-node_modules
-dist
-.env
-.vscode
-*.log
-.git
-```
-
-**docker-compose.yml (with watch):**
-
-```yaml
-services:
-  app:
-    build: .
-    tty: true # omit or set false for long-running servers (e.g. Express)
-    develop:
-      watch:
-        - action: sync+restart
-          path: src/
-          target: /app/src
-        - action: rebuild
-          path: package.json
-    command: yarn dev
-```
-
-Use `pnpm run dev` or `npm run dev` in `command` if the project uses that package manager. Adjust `path`/`target` if the app uses a different layout (e.g. `app/` instead of `src/`).
-
-### Important Notes
-
-- Keep the Docker build context small: always use a `.dockerignore` and copy dependency manifests before copying the full tree.
-- Use `--frozen-lockfile` (yarn/pnpm) or `npm ci` so production and CI builds are reproducible.
-- For local dev, `develop.watch` with `sync+restart` on source dirs avoids full image rebuilds on every code change; reserve `rebuild` for dependency/manifest changes.
-- For web apps (e.g. Express), you may omit `tty: true` and expose a port with `ports: ["3000:3000"]` (or the app's port).
-- If the project has no `dev` script, suggest adding one (e.g. using `tsx`, `ts-node-dev`, or `node --watch`) so `docker compose up --watch` is useful.
-
-### When Completed
-
-1. Summarize what was created or updated (Dockerfile, .dockerignore, docker-compose.yml, and any script changes).
-2. Tell the user how to build and run: `docker compose build`, then `docker compose up --watch` for local development.
-3. Mention that editing files under the watched path will sync and restart the service, and changing `package.json` will trigger a rebuild.
-4. Optionally suggest adding a short "Docker" or "Local development" section to the README with these commands.
-
----
-
-## TypeScript Path Aliases (@/)
-
-When working with TypeScript projects, use the `@/` path alias for imports so that paths stay clean and stable regardless of file depth.
-
-### Your Responsibilities
-
-1. **Use `@/` for TypeScript imports**
-   - Prefer `import { foo } from '@/components/foo'` over `import { foo } from '../../../components/foo'`.
-   - The `@/` alias should resolve to the project's source root (typically `src/`).
-
-2. **Configure `tsconfig.json`**
-   - Add `baseUrl` and `paths` so TypeScript resolves `@/*` correctly.
-   - Ensure `baseUrl` points to the project root (or the directory containing `src/`).
-   - Map `@/*` to the source directory (e.g. `src/*`).
-
-3. **Configure the bundler/runtime**
-   - If using `tsc` only: `paths` in `tsconfig.json` is sufficient for type-checking, but the build output may need a resolver (e.g. `tsconfig-paths`) unless the bundler handles it.
-   - If using Vite, Next.js, or similar: they read `tsconfig.json` paths automatically.
-   - If using plain `tsc`: consider `tsconfig-paths` at runtime, or a bundler that resolves paths.
-
-### Example tsconfig.json
-
-```json
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"]
-    }
-  },
-  "include": ["src"]
-}
-```
-
-If the project root is the repo root and source lives in `src/`, this maps `@/utils/foo` → `src/utils/foo`.
-
-### Example Imports
-
-```typescript
-// Prefer
-import { formatDate } from '@/utils/date';
-import { Button } from '@/components/Button';
-
-// Avoid deep relative paths
-import { formatDate } from '../../../utils/date';
-```
-
-### When to Apply
-
-- When creating or configuring a new TypeScript project.
-- When a project uses long relative import chains (`../../../`).
-- When `tsconfig.json` exists but has no `paths` or `baseUrl` for `@/`.

--- a/.codex/rules/observability.md
+++ b/.codex/rules/observability.md
@@ -2,12 +2,12 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -17,7 +17,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/.codex/rules/publishing-api.md
+++ b/.codex/rules/publishing-api.md
@@ -8,33 +8,37 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 ---
 # REST API Publishing Agent
 
-You are a publishing specialist for REST API services deployed as Docker containers to Kubernetes.
+You are a publishing specialist for REST API services deployed as Docker containers or platform-native service artifacts.
 
 ## Goals
 
-- Use the same container publishing and Helm chart update model as web apps.
-- Ensure the API exposes a health endpoint that Kubernetes probes can use.
-- Include `livenessProbe` and `readinessProbe` in the Helm chart template referencing the health endpoint.
+- Use the same container publishing and deployment model as web apps.
+- Ensure the API exposes health and readiness endpoints that the configured runtime can use for rollout safety.
+- Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are the health endpoint requirements and Helm chart probe configuration.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
 - Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update the Helm chart repo with the new image digest.
+- Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
 
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+
 ## Health Endpoint Requirements
 
-Before enabling Kubernetes probes, ensure the API exposes at least one health endpoint:
+Before enabling automated rollout health checks, ensure the API exposes at least one health endpoint:
 
 ### Recommended Endpoints
 
@@ -43,7 +47,7 @@ Before enabling Kubernetes probes, ensure the API exposes at least one health en
 | `/health` or `/healthz` | Liveness — is the process alive? | Return `200 OK` if the process is up; return non-2xx only if the process is broken and should be restarted. |
 | `/ready` or `/readyz` | Readiness — is the service ready for traffic? | Return `200 OK` only when all dependencies (DB, cache, downstream services) are reachable. Return `503` during startup or when a dependency is down. |
 
-Separate liveness and readiness checks. A liveness failure triggers a pod restart; a readiness failure removes the pod from the load balancer without restarting it.
+Separate liveness and readiness checks when the runtime supports both. In Kubernetes, a liveness failure triggers a pod restart and a readiness failure removes the pod from service without restarting it. In hosted, serverless, or server models, map these endpoints to the platform's health check and traffic cutover controls.
 
 ### Minimal Go Implementation
 
@@ -80,9 +84,9 @@ app.get('/readyz', async (_req, res) => {
 });
 ```
 
-## Helm Chart: Probes Configuration
+## Kubernetes Helm Chart: Probes Configuration
 
-Add `livenessProbe` and `readinessProbe` to the deployment template in your Helm chart:
+Apply this section only when `deploymentModel` is `kubernetes`. Add `livenessProbe` and `readinessProbe` to the deployment template in your Helm chart:
 
 ```yaml
 # charts/<your-chart>/templates/deployment.yaml
@@ -137,7 +141,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 | `GITHUB_TOKEN` | GHCR push (automatic) |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `HELM_CHART_REPO_TOKEN` | Helm chart repo write access |
+| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
 
 ## README Badge
 
@@ -147,14 +151,14 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 
 ## Important Notes
 
-- Liveness and readiness probes must be separate endpoints with different semantics. Do not reuse the same handler for both.
-- Set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
-- Prefer `httpGet` probes over `exec` probes for HTTP services.
-- The `readinessProbe` should check all critical dependencies; the `livenessProbe` should only check process health.
-- Use `digest` not `tag` in the container spec so Kubernetes always pulls the exact image version, even if the `latest` tag is updated.
+- Liveness and readiness endpoints should have different semantics. Do not reuse the same handler for both unless the runtime only supports a single health check.
+- For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
+- For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
+- Readiness checks should cover critical dependencies; liveness checks should only verify process health.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
 
 ## When to Apply
 
-- When a REST API service is deployed to Kubernetes via a Helm chart.
-- When every merge to `main` should trigger a new deployment.
-- When the API needs health and readiness probes for safe Kubernetes lifecycle management.
+- When a REST API service is deployed from a container image or platform-native service artifact.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/publishing-apps.md
+++ b/.codex/rules/publishing-apps.md
@@ -66,18 +66,9 @@ For TypeScript or Node CLI apps distributed through npmjs:
 - Prefer npm trusted publishing with `id-token: write`.
 - Verify the packaged CLI starts successfully from the built artifact before publishing.
 
-## Web Apps: Docker Image + Separate Helm Chart Repo
+## App Deployment Model
 
-For web apps deployed to Kubernetes, prefer a two-repository release model:
-
-- Application repository:
-  - build and publish the Docker image
-  - produce immutable image references
-  - do not keep deployment-environment chart changes in the same release commit by default
-- Helm chart repository:
-  - owns the chart, values, and deployment metadata
-  - is updated after the application image is published
-  - records the new image tag or digest in a chart release commit
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 
@@ -112,36 +103,14 @@ When building the workflow:
   - GHCR: `contents: read`, `packages: write`
   - Docker Hub: `contents: read` plus Docker Hub credentials from secrets
 
-### Separate Helm Chart Repository
-
-After the image publish succeeds, update a separate Helm chart repository rather than mixing chart release state into the app repository.
-
-The Helm chart repo should contain:
-
-- one chart per deployable app
-- `values.yaml` defaults
-- environment-specific values files only when the team intentionally stores them there
-- image repository and tag or digest fields that can be updated automatically
-
-Preferred automation flow:
-
-1. Publish the app image to GHCR or Docker Hub.
-2. Capture the pushed tag and digest.
-3. Check out the separate Helm chart repository in a later job or workflow.
-4. Update chart values to the new image tag or digest.
-5. Bump the chart version when chart contents changed.
-6. Commit and push the chart update.
-7. Optionally package and publish the chart from the chart repo if the team uses an OCI chart registry or GitHub Pages chart index.
-
-### Helm Update Rules
+### Image Reference Rules
 
 - Prefer digest pinning for production deployments when the platform supports it.
-- Keep the application version and chart version distinct:
+- Keep the application version and deployment-manifest version distinct:
   - app version tracks the shipped container
-  - chart version tracks deployment-manifest changes
-- Do not overwrite unrelated chart values during automation.
-- If multiple environments exist, make the target environment or values file explicit in the workflow inputs.
-- If the chart repo is private, use a dedicated token scoped to that repository only.
+  - chart, manifest, or platform config version tracks deployment-shape changes
+- Do not overwrite unrelated environment values during automation.
+- If multiple environments exist, make the target environment explicit in workflow inputs or promotion controls.
 
 ### What to Generate
 
@@ -149,15 +118,15 @@ For a web app release workflow, generate:
 
 - a Docker image publish job for GHCR or Docker Hub
 - outputs exposing the published image tag and digest
-- a follow-up job or reusable workflow that updates the separate Helm chart repo
+- a deployment-model-specific follow-up job or reusable workflow when an environment should move to the new image
 - clear secrets and permissions documentation in the workflow comments or README
 
 ### What Not to Do
 
 - Do not deploy mutable `latest` tags by default.
 - Do not hardcode long-lived registry passwords in workflow files.
-- Do not keep the chart repo update step hidden inside a shell script with no visible diff.
-- Do not update a Helm chart in-place in the app repo when the team has chosen a separate chart repository model.
+- Do not hide deployment state changes inside a shell script with no visible diff or audit trail.
+- Do not assume Kubernetes-specific Helm or ArgoCD ownership when `deploymentModel` is not `kubernetes`.
 
 ## Python Apps: PyPI
 
@@ -195,7 +164,7 @@ For Go apps and CLIs:
 - Keep installation instructions in `README.md` aligned with the actual release channel.
 - Publish checksums for downloadable binaries when the app ships archives.
 - Ensure version output from the binary or CLI matches the release tag.
-- For web apps, keep the published container image and Helm chart update linked by version or digest in release notes or workflow outputs.
+- For web apps, keep the published container image or app artifact linked to the deployment-state update by version, digest, or platform release ID.
 - The workflow-dispatch `release_type` input should decide whether the next app tag is patch, minor, or major.
 
 ## When to Apply
@@ -203,4 +172,4 @@ For Go apps and CLIs:
 - When a repository publishes a CLI, desktop helper, or installable service package.
 - When the release artifact is intended for direct installation by end users.
 - When a project needs app-focused packaging guidance instead of library-only rules.
-- When a web app is released as a container image and deployed through a separate Helm chart repository.
+- When a web app is released as a container image and deployed through the configured deployment model.

--- a/.codex/rules/publishing-web.md
+++ b/.codex/rules/publishing-web.md
@@ -8,20 +8,24 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 ---
 # Web App Publishing Agent
 
-You are a publishing specialist for web applications deployed as Docker containers to Kubernetes.
+You are a publishing specialist for web applications deployed as Docker containers or platform-native app artifacts.
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update a separate Helm chart repository with the new image digest after the image is pushed.
+- Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+
+No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -36,6 +40,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -96,33 +102,37 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_helm_chart:
+  update_deployment_state:
     needs: build_and_push
     runs-on: ubuntu-latest
+    # Include this job only when the configured deployment model has external
+    # state to update. Hosted, serverless, server, or none models may replace
+    # or omit this job entirely.
     steps:
-      - name: Checkout Helm chart repo
+      - name: Checkout deployment state repo
         uses: actions/checkout@v4
         with:
-          repository: OWNER/helm-charts   # your Helm chart repo
-          token: ${{ secrets.HELM_CHART_REPO_TOKEN }}
-          path: helm-charts
+          repository: OWNER/deployment-state
+          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
+          path: deployment-state
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in values.yaml
+      - name: Update image digest in deployment state
         run: |
-          cd helm-charts
+          cd deployment-state
           # Prefer digest pinning for immutable deploys
           IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
           IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Update the chart values — adjust yq path to match your chart structure
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' charts/<your-chart>/values.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' charts/<your-chart>/values.yaml
+          # Kubernetes model: update the environment values referenced by ArgoCD.
+          # Hosted/serverless/server models: replace or remove this block.
+          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
+          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
 
-      - name: Commit and push chart update
+      - name: Commit and push deployment state update
         run: |
-          cd helm-charts
+          cd deployment-state
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
@@ -147,13 +157,15 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
-## Helm Chart Update Rules
+## Deployment State Update Rules
+
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
-- Do not overwrite unrelated chart values in the automation step.
-- If the chart repo is private, use a fine-grained PAT (`HELM_CHART_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
-- Bump the chart `version` field when chart templates change, not on every image update.
+- Do not overwrite unrelated environment values in the automation step.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
 
 ## Required Secrets and Permissions
 
@@ -162,7 +174,7 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 | `GITHUB_TOKEN` | GHCR push (automatic) |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `HELM_CHART_REPO_TOKEN` | Helm chart repo write access |
+| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
 
 ## README Badge
 
@@ -176,12 +188,13 @@ Add a badge for the deploy workflow:
 
 - Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
-- The Helm chart update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- Keep the application repo and Helm chart repo separate; do not mix chart release state into app commits.
+- The deployment state update job should be omitted when the deployment model does not use an external state repository.
+- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
+- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
 - If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
-- When a web application is deployed to Kubernetes via a Helm chart.
-- When every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references in their Helm chart.
+- When a web application is deployed from a container image or platform-native app artifact.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When the team wants immutable image references or artifact identifiers in deployment state.

--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,29 @@
 # Product Requirements
 
+## Generated Rule Activation Clarity
+
+### Problem
+
+Ballast common rules can be installed in Go, Python, Terraform, Ansible, or mixed-language repositories, but some generated common guidance still frames CI/CD, local development, and observability as TypeScript/JavaScript-only. Publishing rules can also be generated as a broad pack even when `.rulesrc.json` sets `deploymentModel: "none"`, which makes deploy-on-main web/API templates look mandatory. The tasks install flow asks operators for a task system including `none`, but the config model and generated task-system rule must make that no-tracker mode explicit.
+
+### Requirements
+
+1. Common CI/CD, local-dev, and observability rule sources must use language-neutral framing.
+2. Language-specific examples in common rules must be labeled as examples or ecosystem-specific guidance.
+3. Generated web/API publishing rules must distinguish active deployment models from `deploymentModel: none`.
+4. With `deploymentModel: none`, generated web/API publishing content must not require deploy-on-main workflows or deployment-state updates.
+5. Ballast must support `taskSystem: none` as a valid configured value for repositories that do not use a durable issue tracker.
+6. With `taskSystem: none`, generated task-system rules must clearly state that no external task system is configured and that issue/ticket creation guidance is conditional.
+
+### Acceptance Criteria
+
+1. Generated common CI/CD, local-dev, and observability rules no longer describe themselves as TypeScript/JavaScript-only.
+2. Generated publishing web/API rules with `deploymentModel: none` contain explicit inactive-deployment guidance.
+3. Generated publishing web/API rules with `deploymentModel: none` do not say every merge to `main` deploys as a mandatory rule.
+4. `TASK_SYSTEMS` accepts `none`, config load/save preserves it, and invalid values remain ignored or rejected.
+5. Generated task-system content with `taskSystem: none` contains no `{{taskSystem}}` placeholder and does not require MCP setup or issue creation.
+6. Tests cover the language-neutral common wording, inactive deployment guidance, and `taskSystem: none` rendering.
+
 ## Consolidated CI Workflow
 
 ### Problem

--- a/agents/common/cicd/content.md
+++ b/agents/common/cicd/content.md
@@ -1,12 +1,12 @@
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -40,14 +40,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/agents/common/cicd/templates/claude-header.md
+++ b/agents/common/cicd/templates/claude-header.md
@@ -1,5 +1,5 @@
 # CI/CD Rules
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/agents/common/cicd/templates/codex-header.md
+++ b/agents/common/cicd/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/agents/common/local-dev/content-env.md
+++ b/agents/common/local-dev/content-env.md
@@ -1,6 +1,6 @@
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
 
 Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
 

--- a/agents/common/local-dev/templates/claude-header.md
+++ b/agents/common/local-dev/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Local Development Environment Rules
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/agents/common/local-dev/templates/codex-header.md
+++ b/agents/common/local-dev/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/agents/common/observability/content.md
+++ b/agents/common/observability/content.md
@@ -1,6 +1,6 @@
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -10,7 +10,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/agents/common/observability/templates/claude-header.md
+++ b/agents/common/observability/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Observability Rules
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/agents/common/observability/templates/codex-header.md
+++ b/agents/common/observability/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/agents/common/tasks/content-task-system.md
+++ b/agents/common/tasks/content-task-system.md
@@ -1,13 +1,11 @@
 # Task System Integration Rules
 
-These rules define how to use {{taskSystem}} as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
-
-This repository uses **{{taskSystem}}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+{{BALLAST_TASK_SYSTEM_GUIDANCE}}
 
 ## MCP Server Setup
 

--- a/agents/common/tasks/templates/claude-header-task-system.md
+++ b/agents/common/tasks/templates/claude-header-task-system.md
@@ -1,5 +1,5 @@
 # Task System Integration
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/agents/common/tasks/templates/codex-header-task-system.md
+++ b/agents/common/tasks/templates/codex-header-task-system.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: 'Task system integration - use {{taskSystem}} for work items and configure the MCP server'
+description: 'Task system integration - use the configured work item system and configure MCP when active'
 alwaysApply: false
 globs:
   - '**/AGENTS.md'

--- a/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
+++ b/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: Task system integration - use {{taskSystem}} for work items and configure the MCP server
+description: Task system integration - use the configured work item system and configure MCP when active
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-go/cmd/ballast-go/agents/common/cicd/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/cicd/content.md
@@ -1,12 +1,12 @@
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -40,14 +40,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/packages/ballast-go/cmd/ballast-go/agents/common/cicd/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/cicd/templates/claude-header.md
@@ -1,5 +1,5 @@
 # CI/CD Rules
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/cicd/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/cicd/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
@@ -1,6 +1,6 @@
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
 
 Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Local Development Environment Rules
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/observability/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/observability/content.md
@@ -1,6 +1,6 @@
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -10,7 +10,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/observability/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/observability/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Observability Rules
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/observability/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/observability/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
@@ -11,13 +11,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
@@ -25,6 +25,8 @@ Use the same `deploy-web.yml` workflow template as the web app publishing rule:
 - Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -150,5 +152,5 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
@@ -4,18 +4,20 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -30,6 +32,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -147,6 +151,8 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ## Deployment State Update Rules
 
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
+
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
@@ -182,5 +188,5 @@ Add a badge for the deploy workflow:
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the team wants immutable image references or artifact identifiers in deployment state.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/content-task-system.md
@@ -1,13 +1,11 @@
 # Task System Integration Rules
 
-These rules define how to use {{taskSystem}} as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
-
-This repository uses **{{taskSystem}}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+{{BALLAST_TASK_SYSTEM_GUIDANCE}}
 
 ## MCP Server Setup
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/claude-header-task-system.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/claude-header-task-system.md
@@ -1,5 +1,5 @@
 # Task System Integration
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/codex-header-task-system.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/codex-header-task-system.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: 'Task system integration - use {{taskSystem}} for work items and configure the MCP server'
+description: 'Task system integration - use the configured work item system and configure MCP when active'
 alwaysApply: false
 globs:
   - '**/AGENTS.md'

--- a/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: Task system integration - use {{taskSystem}} for work items and configure the MCP server
+description: Task system integration - use the configured work item system and configure MCP when active
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -44,8 +44,9 @@ var topLevelYAMLKeyRegex = regexp.MustCompile(`^([A-Za-z0-9_-]+):(.*)$`)
 var gitHooksGuidanceToken = "{{BALLAST_GIT_HOOKS_GUIDANCE}}"
 var gitHooksPreCommitGlobToken = "{{BALLAST_GIT_HOOKS_PRE_COMMIT_GLOB}}"
 var deploymentModelGuidanceToken = "{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}"
+var taskSystemGuidanceToken = "{{BALLAST_TASK_SYSTEM_GUIDANCE}}"
 var taskSystemToken = "{{taskSystem}}"
-var taskSystems = []string{"github", "jira", "linear"}
+var taskSystems = []string{"github", "jira", "linear", "none"}
 var deploymentModels = []string{"none", "kubernetes", "serverless", "server", "hosted"}
 
 func withImplicitAgents(agents []string) []string {
@@ -215,7 +216,7 @@ func runInstall(args []string) int {
 	force := fs.Bool("force", false, "overwrite existing rule and skill files; prompts before replacing support files")
 	patch := fs.Bool("patch", false, "merge upstream rule and skill updates into existing files")
 	fs.BoolVar(patch, "p", false, "merge upstream rule and skill updates into existing files")
-	taskSystemFlag := fs.String("task-system", "", "task system for tasks: github|jira|linear")
+	taskSystemFlag := fs.String("task-system", "", "task system for tasks: github|jira|linear|none")
 	deploymentModelFlag := fs.String("deployment-model", "", "app/service deployment model for publishing; use none for CLI/library/SDK-only projects: none|kubernetes|serverless|server|hosted")
 	yes := fs.Bool("yes", false, "non-interactive mode")
 	fs.BoolVar(yes, "y", false, "non-interactive mode")
@@ -2054,7 +2055,7 @@ func renderDeploymentModelGuidance(deploymentModel string) string {
 			"- CI should validate builds and let the hosted platform own rollout mechanics unless the repo defines a separate release gate.",
 		}, "\n")
 	default:
-		return "No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`."
+		return "No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`."
 	}
 }
 
@@ -2066,10 +2067,40 @@ func applyDeploymentModelGuidance(content, agentID, deploymentModel string) stri
 }
 
 func applyTaskSystemVariables(content, agentID, taskSystem string) string {
-	if agentID != "tasks" || !strings.Contains(content, taskSystemToken) {
+	if agentID != "tasks" {
 		return content
 	}
-	return strings.ReplaceAll(content, taskSystemToken, normalizeRequiredInstallOptionValue(taskSystem))
+	normalized := normalizeRequiredInstallOptionValue(taskSystem)
+	if strings.Contains(content, taskSystemGuidanceToken) {
+		if normalized == "none" {
+			return content[:strings.Index(content, taskSystemGuidanceToken)] + strings.Join([]string{
+				"## Configured Task System",
+				"",
+				"This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
+				"",
+				"Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.",
+				"",
+				"## MCP Server Setup",
+				"",
+				"No task-system MCP server is required while `taskSystem` is `none`. Configure GitHub Issues, Jira, or Linear MCP only after the repository changes its saved `taskSystem` value or the user explicitly asks for that integration.",
+				"",
+				"## Using Work Items",
+				"",
+				"- Do not create external issues or tickets by default.",
+				"- When preparing a PR, triage `tasks/todo.md` and either resolve items, keep them in branch-local notes, or ask the user where durable follow-up belongs.",
+				"- Keep credentials out of committed files; use environment variables or platform secret stores if a task-system integration is added later.",
+			}, "\n")
+		}
+		content = strings.ReplaceAll(content, taskSystemGuidanceToken, strings.Join([]string{
+			"## Configured Task System",
+			"",
+			fmt.Sprintf("This repository uses **%s** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.", normalized),
+		}, "\n"))
+	}
+	if strings.Contains(content, taskSystemToken) {
+		return strings.ReplaceAll(content, taskSystemToken, normalized)
+	}
+	return content
 }
 
 func applyHookTemplateVariables(content, agentID, language, hookMode string) string {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -880,6 +880,40 @@ func TestBuildContentRendersPublishingDeploymentModelToken(t *testing.T) {
 	}
 }
 
+func TestBuildContentRendersInactiveDeploymentModel(t *testing.T) {
+	content, err := buildContent("publishing", "codex", "go", "web", "standalone", "github", "none")
+	if err != nil {
+		t.Fatalf("buildContent(publishing): %v", err)
+	}
+
+	if strings.Contains(content, deploymentModelGuidanceToken) {
+		t.Fatalf("expected deployment model token to be replaced, got %q", content)
+	}
+	if !strings.Contains(content, "Deployment is inactive") {
+		t.Fatalf("expected inactive deployment guidance, got %q", content)
+	}
+	if !strings.Contains(content, "do not create deploy-on-main workflows") {
+		t.Fatalf("expected deploy-on-main guardrail, got %q", content)
+	}
+}
+
+func TestBuildContentRendersNoneTaskSystem(t *testing.T) {
+	content, err := buildContent("tasks", "codex", "go", "task-system", "standalone", "none", "none")
+	if err != nil {
+		t.Fatalf("buildContent(tasks): %v", err)
+	}
+
+	if strings.Contains(content, taskSystemGuidanceToken) || strings.Contains(content, taskSystemToken) {
+		t.Fatalf("expected task system tokens to be replaced, got %q", content)
+	}
+	if !strings.Contains(content, "taskSystem: none") {
+		t.Fatalf("expected none task system guidance, got %q", content)
+	}
+	if strings.Contains(content, "All durable work items must be created there") {
+		t.Fatalf("expected no mandatory tracker guidance, got %q", content)
+	}
+}
+
 func TestInstallCreatesGeminiSupportFileOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/packages/ballast-go/cmd/ballast/agents/common/cicd/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/cicd/content.md
@@ -1,12 +1,12 @@
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -40,14 +40,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/packages/ballast-go/cmd/ballast/agents/common/cicd/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/cicd/templates/claude-header.md
@@ -1,5 +1,5 @@
 # CI/CD Rules
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/cicd/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/cicd/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
@@ -1,6 +1,6 @@
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
 
 Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
 

--- a/packages/ballast-go/cmd/ballast/agents/common/local-dev/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/local-dev/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Local Development Environment Rules
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/local-dev/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/local-dev/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/observability/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/observability/content.md
@@ -1,6 +1,6 @@
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -10,7 +10,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/packages/ballast-go/cmd/ballast/agents/common/observability/templates/claude-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/observability/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Observability Rules
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/observability/templates/codex-header.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/observability/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
@@ -11,13 +11,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
@@ -25,6 +25,8 @@ Use the same `deploy-web.yml` workflow template as the web app publishing rule:
 - Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -150,5 +152,5 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
@@ -4,18 +4,20 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -30,6 +32,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -147,6 +151,8 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ## Deployment State Update Rules
 
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
+
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
@@ -182,5 +188,5 @@ Add a badge for the deploy workflow:
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the team wants immutable image references or artifact identifiers in deployment state.

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/content-task-system.md
@@ -1,13 +1,11 @@
 # Task System Integration Rules
 
-These rules define how to use {{taskSystem}} as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
-
-This repository uses **{{taskSystem}}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+{{BALLAST_TASK_SYSTEM_GUIDANCE}}
 
 ## MCP Server Setup
 

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/claude-header-task-system.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/claude-header-task-system.md
@@ -1,5 +1,5 @@
 # Task System Integration
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/codex-header-task-system.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/codex-header-task-system.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: 'Task system integration - use {{taskSystem}} for work items and configure the MCP server'
+description: 'Task system integration - use the configured work item system and configure MCP when active'
 alwaysApply: false
 globs:
   - '**/AGENTS.md'

--- a/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
+++ b/packages/ballast-go/cmd/ballast/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: Task system integration - use {{taskSystem}} for work items and configure the MCP server
+description: Task system integration - use the configured work item system and configure MCP when active
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-python/ballast/agents/common/cicd/content.md
+++ b/packages/ballast-python/ballast/agents/common/cicd/content.md
@@ -1,12 +1,12 @@
 # CI/CD Agent
 
-You are a CI/CD specialist for TypeScript/JavaScript projects.
+You are a CI/CD specialist for software projects across the repository's configured languages and runtimes.
 
 ## Goals
 
 - **Pipeline design**: Help define workflows (build, test, lint, deploy) in the team’s chosen platform (e.g. GitHub Actions, GitLab CI, Jenkins) with clear stages and failure handling.
-- **Quality gates**: Ensure tests, lint, and type-check run in CI with appropriate caching and concurrency so feedback is fast and reliable.
-- **TypeScript**: For TypeScript projects, always run `build` before `test` in CI and local hooks—tests often run against compiled output in `dist/`, and build ensures type-checking and compilation succeed first.
+- **Quality gates**: Ensure tests, lint, type-check, vet, format, or equivalent repo-standard checks run in CI with appropriate caching and concurrency so feedback is fast and reliable.
+- **Ecosystem ordering**: Follow the repository's established build order. For TypeScript projects, run `build` before `test` when tests depend on compiled output; for Go projects, run format/vet/test/build checks according to the repo's Makefile or CI convention.
 - **Deployment and secrets**: Guide safe use of secrets, environments, and deployment steps (e.g. preview vs production) without hardcoding credentials.
 - **Dependency updates**: Set up Dependabot for automated dependency and GitHub Actions version updates, with grouped PRs for related packages.
 
@@ -40,14 +40,14 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 ## Dependabot
 
-Create a `.github/dependabot.yml` file for the current project. Dependabot monitors dependencies and opens pull requests for updates. Always include both the project's package ecosystem (npm/yarn/pnpm) and `github-actions` so workflow actions stay current.
+Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
 ### Basic Structure
 
 ```yaml
 version: 2
 updates:
-  # Project dependencies (npm, yarn, or pnpm - detected from lockfile)
+  # Project dependencies (example: npm, yarn, or pnpm detected from lockfile)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/packages/ballast-python/ballast/agents/common/cicd/templates/claude-header.md
+++ b/packages/ballast-python/ballast/agents/common/cicd/templates/claude-header.md
@@ -1,5 +1,5 @@
 # CI/CD Rules
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/cicd/templates/codex-header.md
+++ b/packages/ballast-python/ballast/agents/common/cicd/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help design and maintain CI/CD pipelines for TypeScript/JavaScript projects.
+These rules help design and maintain CI/CD pipelines for the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
@@ -1,6 +1,6 @@
 # Local Development Environment Agent
 
-You are a local development environment specialist for TypeScript/JavaScript projects.
+You are a local development environment specialist for the repository's configured languages and runtimes.
 
 Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
 

--- a/packages/ballast-python/ballast/agents/common/local-dev/templates/claude-header.md
+++ b/packages/ballast-python/ballast/agents/common/local-dev/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Local Development Environment Rules
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/local-dev/templates/codex-header.md
+++ b/packages/ballast-python/ballast/agents/common/local-dev/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help set up and maintain a consistent local development environment for TypeScript/JavaScript projects, including Dockerfile and Docker Compose for local development following https://www.markcallen.com/dockerfile-for-typescript/
+These rules help set up and maintain a consistent local development environment for the repository's configured languages and runtimes, including Dockerfile and Docker Compose when they fit the project.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/observability/content.md
+++ b/packages/ballast-python/ballast/agents/common/observability/content.md
@@ -1,6 +1,6 @@
 # Observability Agent
 
-You are an observability specialist for TypeScript/JavaScript applications.
+You are an observability specialist for applications and services in the repository's configured languages and runtimes.
 
 ## Goals
 
@@ -10,7 +10,7 @@ You are an observability specialist for TypeScript/JavaScript applications.
 
 ## Scope
 
-- Instrumentation in app code and runtimes (Node, edge, serverless).
+- Instrumentation in app code and runtimes such as Go services, Node services, edge functions, serverless functions, and background workers.
 - Integration with common backends (e.g. Datadog, Grafana, CloudWatch) and open standards (OTel, Prometheus).
 - Runbooks and alerting rules that match the team’s tooling.
 

--- a/packages/ballast-python/ballast/agents/common/observability/templates/claude-header.md
+++ b/packages/ballast-python/ballast/agents/common/observability/templates/claude-header.md
@@ -1,5 +1,5 @@
 # Observability Rules
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/observability/templates/codex-header.md
+++ b/packages/ballast-python/ballast/agents/common/observability/templates/codex-header.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-These rules help add logging, tracing, metrics, and SLOs to TypeScript/JavaScript applications.
+These rules help add logging, tracing, metrics, and SLOs to applications and services in the repository's configured languages and runtimes.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-api.md
@@ -11,13 +11,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
@@ -25,6 +25,8 @@ Use the same `deploy-web.yml` workflow template as the web app publishing rule:
 - Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -150,5 +152,5 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-python/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-web.md
@@ -4,18 +4,20 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
 {{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -30,6 +32,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -147,6 +151,8 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ## Deployment State Update Rules
 
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
+
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
@@ -182,5 +188,5 @@ Add a badge for the deploy workflow:
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the team wants immutable image references or artifact identifiers in deployment state.

--- a/packages/ballast-python/ballast/agents/common/tasks/content-task-system.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/content-task-system.md
@@ -1,13 +1,11 @@
 # Task System Integration Rules
 
-These rules define how to use {{taskSystem}} as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
-
-This repository uses **{{taskSystem}}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+{{BALLAST_TASK_SYSTEM_GUIDANCE}}
 
 ## MCP Server Setup
 

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/claude-header-task-system.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/claude-header-task-system.md
@@ -1,5 +1,5 @@
 # Task System Integration
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/codex-header-task-system.md
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/codex-header-task-system.md
@@ -2,6 +2,6 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use {{taskSystem}} as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/cursor-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: 'Task system integration - use {{taskSystem}} for work items and configure the MCP server'
+description: 'Task system integration - use the configured work item system and configure MCP when active'
 alwaysApply: false
 globs:
   - '**/AGENTS.md'

--- a/packages/ballast-python/ballast/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
+++ b/packages/ballast-python/ballast/agents/common/tasks/templates/opencode-frontmatter-task-system.yaml
@@ -1,5 +1,5 @@
 ---
-description: Task system integration - use {{taskSystem}} for work items and configure the MCP server
+description: Task system integration - use the configured work item system and configure MCP when active
 mode: subagent
 model: anthropic/claude-sonnet-4-20250514
 temperature: 0.2

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -50,6 +50,8 @@ SKILLS_BY_LANGUAGE = {
 GIT_HOOKS_GUIDANCE_TOKEN = "{{BALLAST_GIT_HOOKS_GUIDANCE}}"
 GIT_HOOKS_PRE_COMMIT_GLOB_TOKEN = "{{BALLAST_GIT_HOOKS_PRE_COMMIT_GLOB}}"
 DEPLOYMENT_MODEL_GUIDANCE_TOKEN = "{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}"
+TASK_SYSTEM_GUIDANCE_TOKEN = "{{BALLAST_TASK_SYSTEM_GUIDANCE}}"
+TASK_SYSTEM_TOKEN = "{{taskSystem}}"
 DEPLOYMENT_MODELS = ["none", "kubernetes", "serverless", "server", "hosted"]
 
 
@@ -813,7 +815,7 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
             ]
         case _:
             lines = [
-                "No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.",
+                "No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.",
             ]
     return "\n".join(lines)
 
@@ -827,6 +829,61 @@ def apply_deployment_model_guidance(
         DEPLOYMENT_MODEL_GUIDANCE_TOKEN,
         render_deployment_model_guidance(deployment_model),
     )
+
+
+def normalize_task_system(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def render_task_system_guidance(task_system: str | None) -> str:
+    normalized = normalize_task_system(task_system) or "{{taskSystem}}"
+    if normalized == "none":
+        return "\n".join(
+            [
+                "## Configured Task System",
+                "",
+                "This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
+                "",
+                "Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.",
+                "",
+                "## MCP Server Setup",
+                "",
+                "No task-system MCP server is required while `taskSystem` is `none`. Configure GitHub Issues, Jira, or Linear MCP only after the repository changes its saved `taskSystem` value or the user explicitly asks for that integration.",
+                "",
+                "## Using Work Items",
+                "",
+                "- Do not create external issues or tickets by default.",
+                "- When preparing a PR, triage `tasks/todo.md` and either resolve items, keep them in branch-local notes, or ask the user where durable follow-up belongs.",
+                "- Keep credentials out of committed files; use environment variables or platform secret stores if a task-system integration is added later.",
+            ]
+        )
+    return "\n".join(
+        [
+            "## Configured Task System",
+            "",
+            f"This repository uses **{normalized}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.",
+        ]
+    )
+
+
+def apply_task_system_guidance(
+    content: str, agent: str, task_system: str | None
+) -> str:
+    if agent != "tasks":
+        return content
+    normalized = normalize_task_system(task_system)
+    if TASK_SYSTEM_GUIDANCE_TOKEN in content:
+        if normalized == "none":
+            return content[
+                : content.index(TASK_SYSTEM_GUIDANCE_TOKEN)
+            ] + render_task_system_guidance(task_system)
+        content = content.replace(
+            TASK_SYSTEM_GUIDANCE_TOKEN,
+            render_task_system_guidance(task_system),
+        )
+    if TASK_SYSTEM_TOKEN in content:
+        content = content.replace(TASK_SYSTEM_TOKEN, normalized)
+    return content
 
 
 def read_template(agent: str, language: str, filename: str, suffix: str = "") -> str:
@@ -868,13 +925,18 @@ def build_content(
     suffix: str = "",
     root: Path | None = None,
     deployment_model: str | None = None,
+    task_system: str | None = None,
 ) -> str:
-    body = apply_deployment_model_guidance(
-        apply_hook_guidance(
-            read_content(agent, language, suffix), agent, language, root
+    body = apply_task_system_guidance(
+        apply_deployment_model_guidance(
+            apply_hook_guidance(
+                read_content(agent, language, suffix), agent, language, root
+            ),
+            agent,
+            deployment_model,
         ),
         agent,
-        deployment_model,
+        task_system,
     )
     if target == "cursor":
         return (
@@ -1809,6 +1871,9 @@ def install(
         if config_for_support_files
         else skills
     )
+    task_system = (
+        config_for_support_files.get("taskSystem") if config_for_support_files else None
+    )
     skipped_support_files = skip_support_files or set()
 
     for agent in agents:
@@ -1825,7 +1890,13 @@ def install(
                 basename = rule_basename(agent, language, suffix)
                 dst = destination(root, target, basename)
                 content = build_content(
-                    agent, target, language, suffix, root, deployment_model
+                    agent,
+                    target,
+                    language,
+                    suffix,
+                    root,
+                    deployment_model,
+                    task_system if isinstance(task_system, str) else None,
                 )
                 if dst.exists() and not force and not patch:
                     agent_skipped = True

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -52,6 +52,7 @@ GIT_HOOKS_PRE_COMMIT_GLOB_TOKEN = "{{BALLAST_GIT_HOOKS_PRE_COMMIT_GLOB}}"
 DEPLOYMENT_MODEL_GUIDANCE_TOKEN = "{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}"
 TASK_SYSTEM_GUIDANCE_TOKEN = "{{BALLAST_TASK_SYSTEM_GUIDANCE}}"
 TASK_SYSTEM_TOKEN = "{{taskSystem}}"
+DEFAULT_TASK_SYSTEM = "github"
 DEPLOYMENT_MODELS = ["none", "kubernetes", "serverless", "server", "hosted"]
 
 
@@ -836,7 +837,7 @@ def normalize_task_system(value: object) -> str:
 
 
 def render_task_system_guidance(task_system: str | None) -> str:
-    normalized = normalize_task_system(task_system) or "{{taskSystem}}"
+    normalized = normalize_task_system(task_system) or DEFAULT_TASK_SYSTEM
     if normalized == "none":
         return "\n".join(
             [
@@ -871,7 +872,7 @@ def apply_task_system_guidance(
 ) -> str:
     if agent != "tasks":
         return content
-    normalized = normalize_task_system(task_system)
+    normalized = normalize_task_system(task_system) or DEFAULT_TASK_SYSTEM
     if TASK_SYSTEM_GUIDANCE_TOKEN in content:
         if normalized == "none":
             return content[

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -130,6 +130,15 @@ class PatchInstallTests(unittest.TestCase):
         self.assertIn("charts/<app>/", content)
         self.assertNotIn("{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}", content)
 
+    def test_build_content_renders_none_task_system(self) -> None:
+        content = cli.render_task_system_guidance("none")
+
+        self.assertIn("taskSystem: none", content)
+        self.assertIn("No task-system MCP server is required", content)
+        self.assertNotIn("{{BALLAST_TASK_SYSTEM_GUIDANCE}}", content)
+        self.assertNotIn("{{taskSystem}}", content)
+        self.assertNotIn("All durable work items must be created there", content)
+
     def test_destination_rejects_invalid_rule_subdir(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -139,6 +139,23 @@ class PatchInstallTests(unittest.TestCase):
         self.assertNotIn("{{taskSystem}}", content)
         self.assertNotIn("All durable work items must be created there", content)
 
+    def test_apply_task_system_guidance_defaults_missing_task_system(self) -> None:
+        content = cli.apply_task_system_guidance(
+            "\n".join(
+                [
+                    "{{BALLAST_TASK_SYSTEM_GUIDANCE}}",
+                    'When asked, "configure MCP for {{taskSystem}}"',
+                ]
+            ),
+            "tasks",
+            None,
+        )
+
+        self.assertIn("**github** as the system of record", content)
+        self.assertIn('"configure MCP for github"', content)
+        self.assertNotIn("{{BALLAST_TASK_SYSTEM_GUIDANCE}}", content)
+        self.assertNotIn("{{taskSystem}}", content)
+
     def test_destination_rejects_invalid_rule_subdir(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -133,6 +133,29 @@ describe('build', () => {
       expect(content).toContain('ballast install');
     });
 
+    test('returns language-neutral common rule content', () => {
+      const cicd = buildCodexFormat('cicd', undefined, 'go');
+      const localDev = buildCodexFormat('local-dev', 'env', 'go');
+      const observability = buildCodexFormat('observability', undefined, 'go');
+
+      expect(cicd).toContain("repository's configured languages and runtimes");
+      expect(localDev).toContain(
+        "repository's configured languages and runtimes"
+      );
+      expect(observability).toContain(
+        "repository's configured languages and runtimes"
+      );
+      expect(cicd).not.toContain(
+        'CI/CD specialist for TypeScript/JavaScript projects'
+      );
+      expect(localDev).not.toContain(
+        'local development environment specialist for TypeScript/JavaScript projects'
+      );
+      expect(observability).not.toContain(
+        'observability specialist for TypeScript/JavaScript applications'
+      );
+    });
+
     test('returns tasks task-system content with default variable substitution', () => {
       const content = getContent('tasks', 'task-system', 'typescript', {
         variables: { taskSystem: 'github' }
@@ -148,6 +171,23 @@ describe('build', () => {
       });
       expect(content).toContain('linear');
       expect(content).not.toContain('{{taskSystem}}');
+    });
+
+    test('returns tasks task-system content for none without mandatory tracker guidance', () => {
+      const content = getContent('tasks', 'task-system', 'typescript', {
+        variables: { taskSystem: 'none' }
+      });
+
+      expect(content).toContain('taskSystem: none');
+      expect(content).toContain('No task-system MCP server is required');
+      expect(content).toContain(
+        'Do not create external issues or tickets by default.'
+      );
+      expect(content).not.toContain('{{taskSystem}}');
+      expect(content).not.toContain(
+        'All durable work items must be created there'
+      );
+      expect(content).not.toContain('configure MCP for none');
     });
 
     test('returns tasks todo content', () => {
@@ -238,6 +278,9 @@ describe('build', () => {
 
     test('returns platform-neutral web deployment state placeholders', () => {
       const content = getContent('publishing', 'web', 'typescript');
+      expect(content).toContain('deploymentModel: none');
+      expect(content).toContain('Deployment is inactive');
+      expect(content).toContain('do not create deploy-on-main workflows');
       expect(content).toContain('repository: OWNER/deployment-state');
       expect(content).toContain(
         'Hosted, serverless, server, or none models may replace'
@@ -249,6 +292,8 @@ describe('build', () => {
 
     test('keeps REST API baseline goals platform neutral', () => {
       const content = getContent('publishing', 'api', 'typescript');
+      expect(content).toContain('Deployment is inactive');
+      expect(content).toContain('do not create deploy-on-main workflows');
       expect(content).toContain(
         'health and readiness endpoints that the configured runtime can use'
       );

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -17,6 +17,7 @@ const SOURCE_AGENTS_ROOT = path.join(REPO_ROOT, 'agents');
 const GIT_HOOKS_GUIDANCE_TOKEN = '{{BALLAST_GIT_HOOKS_GUIDANCE}}';
 const GIT_HOOKS_PRE_COMMIT_GLOB_TOKEN = '{{BALLAST_GIT_HOOKS_PRE_COMMIT_GLOB}}';
 const DEPLOYMENT_MODEL_GUIDANCE_TOKEN = '{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}';
+const TASK_SYSTEM_GUIDANCE_TOKEN = '{{BALLAST_TASK_SYSTEM_GUIDANCE}}';
 const BALLAST_REPO_URL = 'https://github.com/everydaydevopsio/ballast';
 const BALLAST_MANAGED_COMMENT = `<!-- Created by [Ballast](${BALLAST_REPO_URL}) v${pkg.version}. Do not edit this section. -->`;
 
@@ -301,7 +302,7 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
       ].join('\n');
     case 'none':
     default:
-      return 'No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.';
+      return 'No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.';
   }
 }
 
@@ -319,6 +320,55 @@ function applyDeploymentModelGuidance(
   return content.replaceAll(
     DEPLOYMENT_MODEL_GUIDANCE_TOKEN,
     renderDeploymentModelGuidance(options)
+  );
+}
+
+function renderTaskSystemGuidance(options?: BuildOptions): string {
+  const taskSystem = options?.variables?.taskSystem ?? '{{taskSystem}}';
+  if (taskSystem === 'none') {
+    return [
+      '## Configured Task System',
+      '',
+      'This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.',
+      '',
+      'Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.',
+      '',
+      '## MCP Server Setup',
+      '',
+      'No task-system MCP server is required while `taskSystem` is `none`. Configure GitHub Issues, Jira, or Linear MCP only after the repository changes its saved `taskSystem` value or the user explicitly asks for that integration.',
+      '',
+      '## Using Work Items',
+      '',
+      '- Do not create external issues or tickets by default.',
+      '- When preparing a PR, triage `tasks/todo.md` and either resolve items, keep them in branch-local notes, or ask the user where durable follow-up belongs.',
+      '- Keep credentials out of committed files; use environment variables or platform secret stores if a task-system integration is added later.'
+    ].join('\n');
+  }
+
+  return [
+    '## Configured Task System',
+    '',
+    `This repository uses **${taskSystem}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.`
+  ].join('\n');
+}
+
+function applyTaskSystemGuidance(
+  content: string,
+  agentId: string,
+  options?: BuildOptions
+): string {
+  if (agentId !== 'tasks' || !content.includes(TASK_SYSTEM_GUIDANCE_TOKEN)) {
+    return content;
+  }
+  if (options?.variables?.taskSystem === 'none') {
+    return (
+      content.slice(0, content.indexOf(TASK_SYSTEM_GUIDANCE_TOKEN)) +
+      renderTaskSystemGuidance(options)
+    );
+  }
+  return content.replaceAll(
+    TASK_SYSTEM_GUIDANCE_TOKEN,
+    renderTaskSystemGuidance(options)
   );
 }
 
@@ -383,8 +433,12 @@ export function getContent(
       raw = raw.replaceAll(`{{${key}}}`, value);
     }
   }
-  return applyDeploymentModelGuidance(
-    applyHookGuidance(raw, agentId, language, options),
+  return applyTaskSystemGuidance(
+    applyDeploymentModelGuidance(
+      applyHookGuidance(raw, agentId, language, options),
+      agentId,
+      options
+    ),
     agentId,
     options
   );

--- a/packages/ballast-typescript/src/config.test.ts
+++ b/packages/ballast-typescript/src/config.test.ts
@@ -266,10 +266,11 @@ describe('config', () => {
   });
 
   describe('taskSystem', () => {
-    test('TASK_SYSTEMS contains github, jira, linear', () => {
+    test('TASK_SYSTEMS contains github, jira, linear, none', () => {
       expect(TASK_SYSTEMS).toContain('github');
       expect(TASK_SYSTEMS).toContain('jira');
       expect(TASK_SYSTEMS).toContain('linear');
+      expect(TASK_SYSTEMS).toContain('none');
     });
 
     test('DEFAULT_TASK_SYSTEM is github', () => {
@@ -288,6 +289,20 @@ describe('config', () => {
       );
       const loaded = loadConfig(tmpDir);
       expect(loaded?.taskSystem).toBe('linear');
+    });
+
+    test('saves and loads none taskSystem', () => {
+      saveConfig(
+        {
+          targets: ['claude'],
+          agents: ['tasks'],
+          ballastVersion: BALLAST_VERSION,
+          taskSystem: 'none'
+        },
+        tmpDir
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.taskSystem).toBe('none');
     });
 
     test('loads config without taskSystem field', () => {

--- a/packages/ballast-typescript/src/config.ts
+++ b/packages/ballast-typescript/src/config.ts
@@ -5,7 +5,7 @@ import { LANGUAGES } from './agents';
 const RULESRC_FILENAME = '.rulesrc.json';
 const LEGACY_TYPESCRIPT_RULESRC_FILENAME = '.rulesrc.ts.json';
 const TARGETS = ['cursor', 'claude', 'opencode', 'codex', 'gemini'] as const;
-export const TASK_SYSTEMS = ['github', 'jira', 'linear'] as const;
+export const TASK_SYSTEMS = ['github', 'jira', 'linear', 'none'] as const;
 export const DEFAULT_TASK_SYSTEM = 'github' as const;
 export const DEPLOYMENT_MODELS = [
   'none',


### PR DESCRIPTION
## Summary

- Make common CI/CD, local-dev, and observability generated rules language-neutral instead of TypeScript/JavaScript-framed.
- Make `deploymentModel: none` render explicit inactive-deployment guidance for publishing web/API/app rules.
- Add `taskSystem: none` support to TypeScript and Go config/rendering, plus renderer support in Python for synced task content.
- Regenerate the affected Codex and Claude managed rule outputs.

## Validation

- [x] Tests or checks run:
  - `pnpm --filter @everydaydevopsio/ballast test -- src/build.test.ts src/config.test.ts`
  - `go test ./cmd/ballast-go`
  - `PYTHONPATH=/home/marka/src/ballast/packages/ballast-python python3 -m unittest packages.ballast-python.tests.test_cli`
  - `pnpm --filter @everydaydevopsio/ballast test -- src/repo-generated-artifacts.test.ts`
  - pre-commit hooks during commit
  - pre-push hooks during push
- [x] Docs updated or not needed: PRD updated with generated rule activation requirements.
- [x] Generated files updated or not needed: affected `.codex` and `.claude` rule outputs regenerated.

## Agent Notes

- Related issue/PRD: `PRD.md` Generated Rule Activation Clarity.
- Risk level: Medium. This changes persistent agent guidance text and generated output, but keeps publishing profile granularity backward-compatible for now.
- Follow-up needed:
  - #238 Add profile-aware publishing rule selection
  - #239 Add Python task-system install parity
  - #240 Add activation metadata to conditional generated rules
