### PR TITLE
Fix follow-up rule activation and selection issues

### DIFF
--- a/.claude/rules/common/publishing-apps.md
+++ b/.claude/rules/common/publishing-apps.md
@@ -66,7 +66,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.claude/rules/publishing-api.md
+++ b/.claude/rules/publishing-api.md
@@ -15,11 +15,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## CI Workflow
 

--- a/.claude/rules/publishing-apps.md
+++ b/.claude/rules/publishing-apps.md
@@ -66,7 +66,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.claude/rules/publishing-web.md
+++ b/.claude/rules/publishing-web.md
@@ -15,11 +15,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## Workflow Trigger and Concurrency
 

--- a/.claude/rules/tasks-task-system.md
+++ b/.claude/rules/tasks-task-system.md
@@ -10,9 +10,9 @@ These rules define the configured task system behavior for durable work items an
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
+## Activation
 
-This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+External issue tracking is active (`taskSystem: github`). This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
 
 ## MCP Server Setup
 

--- a/.claude/rules/typescript/typescript-publishing-apps.md
+++ b/.claude/rules/typescript/typescript-publishing-apps.md
@@ -66,7 +66,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.codex/rules/common/publishing-api.md
+++ b/.codex/rules/common/publishing-api.md
@@ -17,15 +17,17 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
@@ -33,6 +35,8 @@ Use the same `deploy-web.yml` workflow template as the web app publishing rule:
 - Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -158,5 +162,5 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/common/publishing-apps.md
+++ b/.codex/rules/common/publishing-apps.md
@@ -68,7 +68,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.codex/rules/common/publishing-apt.md
+++ b/.codex/rules/common/publishing-apt.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -143,6 +147,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/.codex/rules/common/publishing-brew.md
+++ b/.codex/rules/common/publishing-brew.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -107,6 +111,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/.codex/rules/common/publishing-web.md
+++ b/.codex/rules/common/publishing-web.md
@@ -12,18 +12,22 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -38,6 +42,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -155,6 +161,8 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ## Deployment State Update Rules
 
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
+
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
@@ -190,5 +198,5 @@ Add a badge for the deploy workflow:
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the team wants immutable image references or artifact identifiers in deployment state.

--- a/.codex/rules/common/tasks-task-system.md
+++ b/.codex/rules/common/tasks-task-system.md
@@ -2,19 +2,19 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use github as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---
 # Task System Integration Rules
 
-These rules define how to use github as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
+## Activation
 
-This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+External issue tracking is active (`taskSystem: github`). This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
 
 ## MCP Server Setup
 

--- a/.codex/rules/publishing-api.md
+++ b/.codex/rules/publishing-api.md
@@ -17,11 +17,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## CI Workflow
 

--- a/.codex/rules/publishing-apps.md
+++ b/.codex/rules/publishing-apps.md
@@ -68,7 +68,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.codex/rules/publishing-apt.md
+++ b/.codex/rules/publishing-apt.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -143,6 +147,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/.codex/rules/publishing-brew.md
+++ b/.codex/rules/publishing-brew.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -107,6 +111,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/.codex/rules/publishing-web.md
+++ b/.codex/rules/publishing-web.md
@@ -17,11 +17,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ## Workflow Trigger and Concurrency
 

--- a/.codex/rules/tasks-task-system.md
+++ b/.codex/rules/tasks-task-system.md
@@ -12,9 +12,9 @@ These rules define the configured task system behavior for durable work items an
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
+## Activation
 
-This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+External issue tracking is active (`taskSystem: github`). This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
 
 ## MCP Server Setup
 

--- a/.codex/rules/typescript/typescript-publishing-api.md
+++ b/.codex/rules/typescript/typescript-publishing-api.md
@@ -17,15 +17,17 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
-REST API apps use **continuous deployment** — every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
 
 ## CI Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule:
+Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
 
 - Trigger on `push` to `main`.
 - `concurrency: cancel-in-progress: true`.
@@ -33,6 +35,8 @@ Use the same `deploy-web.yml` workflow template as the web app publishing rule:
 - Update deployment state according to the configured deployment model.
 
 Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+
+If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -158,5 +162,5 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/typescript/typescript-publishing-apps.md
+++ b/.codex/rules/typescript/typescript-publishing-apps.md
@@ -68,7 +68,7 @@ For TypeScript or Node CLI apps distributed through npmjs:
 
 ## App Deployment Model
 
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
 
 ### Container Registry Targets
 

--- a/.codex/rules/typescript/typescript-publishing-apt.md
+++ b/.codex/rules/typescript/typescript-publishing-apt.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -143,6 +147,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/.codex/rules/typescript/typescript-publishing-brew.md
+++ b/.codex/rules/typescript/typescript-publishing-brew.md
@@ -10,6 +10,10 @@ These rules help design and maintain release workflows for libraries, SDKs, and 
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -107,6 +111,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/.codex/rules/typescript/typescript-publishing-web.md
+++ b/.codex/rules/typescript/typescript-publishing-web.md
@@ -12,18 +12,22 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- Build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
+- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
 - Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.
+
 ## Release Model
 
-Web apps use **continuous deployment** — every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-No app deployment model is configured. Keep library, SDK, and CLI publishing guidance active, but do not assume Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets `deploymentModel`.
+When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
 
 ## Workflow Trigger and Concurrency
+
+Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
 
 ```yaml
 on:
@@ -38,6 +42,8 @@ concurrency:
 `cancel-in-progress: true` ensures the newest commit's deploy always wins.
 
 ## CI Workflow Template (`deploy-web.yml`)
+
+This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
 
 ```yaml
 name: Deploy Web
@@ -155,6 +161,8 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ## Deployment State Update Rules
 
+These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
+
 - Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
@@ -190,5 +198,5 @@ Add a badge for the deploy workflow:
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When every merge to `main` should trigger a new deployment.
+- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
 - When the team wants immutable image references or artifact identifiers in deployment state.

--- a/.codex/rules/typescript/typescript-tasks-task-system.md
+++ b/.codex/rules/typescript/typescript-tasks-task-system.md
@@ -2,19 +2,19 @@
 
 These rules are intended for Codex (CLI and app).
 
-Use github as the system of record for work items. Check and configure the task system MCP server when asked.
+Use the configured task system for durable work items. Check and configure the task system MCP server when asked and when a non-`none` task system is configured.
 
 ---
 # Task System Integration Rules
 
-These rules define how to use github as the system of record for work items and how to set up the required MCP server.
+These rules define the configured task system behavior for durable work items and MCP setup.
 
 ---
 You are a task system integration specialist. Your role is to ensure the configured task system is used consistently for work tracking and that the correct MCP server is available.
 
-## Configured Task System
+## Activation
 
-This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
+External issue tracking is active (`taskSystem: github`). This repository uses **github** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.
 
 ## MCP Server Setup
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -200,7 +200,7 @@ Notes:
 - `.rulesrc.ts.json`, `.rulesrc.python.json`, and `.rulesrc.go.json` are legacy compatibility filenames.
 - The installer reads legacy files, but writes the canonical `.rulesrc.json`.
 - `findProjectRoot()` still treats either canonical or legacy config files as root markers.
-- `publishingProfiles` is optional. When omitted, `agents: ["publishing"]` expands to all publishing rule suffixes; when present, it filters publishing suffixes to the selected profiles.
+- `publishingProfiles` is optional. When omitted or empty, `agents: ["publishing"]` expands to all publishing rule suffixes; when present with one or more values, it filters publishing suffixes to the selected profiles.
 
 ## CLI Surface
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -188,6 +188,7 @@ Current saved shape:
   "skills": ["owasp-security-scan"],
   "ballastVersion": "5.2.0",
   "languages": ["typescript"],
+  "publishingProfiles": ["cli", "apps"],
   "paths": {
     "typescript": ["."]
   }
@@ -199,6 +200,7 @@ Notes:
 - `.rulesrc.ts.json`, `.rulesrc.python.json`, and `.rulesrc.go.json` are legacy compatibility filenames.
 - The installer reads legacy files, but writes the canonical `.rulesrc.json`.
 - `findProjectRoot()` still treats either canonical or legacy config files as root markers.
+- `publishingProfiles` is optional. When omitted, `agents: ["publishing"]` expands to all publishing rule suffixes; when present, it filters publishing suffixes to the selected profiles.
 
 ## CLI Surface
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,8 @@ When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value,
   - TypeScript CLI: `.rulesrc.ts.json`
   - Python CLI: `.rulesrc.python.json`
   - Go CLI: `.rulesrc.go.json`
-- Saved settings include `target`, `agents`, and `skills`
+- Saved settings include `target`, `agents`, `skills`, and repo-level options such as `taskSystem`, `deploymentModel`, and `publishingProfiles`
+- `publishingProfiles` narrows `agents: ["publishing"]` to selected publishing rule files. Supported canonical values are `cli`, `apps`, `web`, `api`, `libraries`, `sdks`, `apt`, and `brew`; singular aliases `app`, `library`, and `sdk` are accepted when loading config. If `publishingProfiles` is omitted, Ballast keeps the backward-compatible behavior and installs all publishing rule files.
 
 ## Install Locations
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ When `tasks` or `publishing` is selected and `.rulesrc.json` has no saved value,
   - Python CLI: `.rulesrc.python.json`
   - Go CLI: `.rulesrc.go.json`
 - Saved settings include `target`, `agents`, `skills`, and repo-level options such as `taskSystem`, `deploymentModel`, and `publishingProfiles`
-- `publishingProfiles` narrows `agents: ["publishing"]` to selected publishing rule files. Supported canonical values are `cli`, `apps`, `web`, `api`, `libraries`, `sdks`, `apt`, and `brew`; singular aliases `app`, `library`, and `sdk` are accepted when loading config. If `publishingProfiles` is omitted, Ballast keeps the backward-compatible behavior and installs all publishing rule files.
+- `publishingProfiles` narrows `agents: ["publishing"]` to selected publishing rule files. Supported canonical values are `cli`, `apps`, `web`, `api`, `libraries`, `sdks`, `apt`, and `brew`; singular aliases `app`, `library`, and `sdk` are accepted when loading config. If `publishingProfiles` is omitted or empty, Ballast keeps the backward-compatible behavior and installs all publishing rule files.
 
 ## Install Locations
 

--- a/agents/common/publishing/content-api.md
+++ b/agents/common/publishing/content-api.md
@@ -9,11 +9,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 

--- a/agents/common/publishing/content-apt.md
+++ b/agents/common/publishing/content-apt.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -135,6 +139,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/agents/common/publishing/content-brew.md
+++ b/agents/common/publishing/content-brew.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -99,6 +103,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/agents/common/publishing/content-web.md
+++ b/agents/common/publishing/content-web.md
@@ -9,11 +9,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
@@ -9,11 +9,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-apt.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-apt.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -135,6 +139,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-brew.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-brew.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -99,6 +103,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
@@ -9,11 +9,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
 

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -2027,6 +2027,8 @@ func renderDeploymentModelGuidance(deploymentModel string) string {
 	switch normalizeDeploymentModel(deploymentModel) {
 	case "kubernetes":
 		return strings.Join([]string{
+			"Deployment guidance is active (`deploymentModel: kubernetes`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+			"",
 			"Kubernetes deployment model:",
 			"- Treat app deployment ownership as Kubernetes-native unless repo docs say otherwise.",
 			"- Keep application Helm charts in the app repository under `charts/<app>/` with chart tests and schema validation.",
@@ -2035,6 +2037,8 @@ func renderDeploymentModelGuidance(deploymentModel string) string {
 		}, "\n")
 	case "serverless":
 		return strings.Join([]string{
+			"Deployment guidance is active (`deploymentModel: serverless`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+			"",
 			"Serverless deployment model:",
 			"- Treat deployable apps as functions, jobs, queues, event rules, and managed cloud resources.",
 			"- Keep infrastructure definitions close to the owning service unless the repo documents a shared infrastructure boundary.",
@@ -2042,6 +2046,8 @@ func renderDeploymentModelGuidance(deploymentModel string) string {
 		}, "\n")
 	case "server":
 		return strings.Join([]string{
+			"Deployment guidance is active (`deploymentModel: server`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+			"",
 			"Self-managed server deployment model:",
 			"- Treat deployable apps as services on provisioned hosts, VMs, or bare-metal servers.",
 			"- Keep systemd, process manager, reverse proxy, secrets, and rollback instructions aligned with the runtime environment.",
@@ -2049,13 +2055,15 @@ func renderDeploymentModelGuidance(deploymentModel string) string {
 		}, "\n")
 	case "hosted":
 		return strings.Join([]string{
+			"Deployment guidance is active (`deploymentModel: hosted`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+			"",
 			"Hosted platform deployment model:",
 			"- Treat deployable apps as hosted-platform workloads such as Vercel, Netlify, Railway, Render, Fly.io, or similar services.",
 			"- Keep provider configuration, environment variables, preview environments, and production promotion rules documented with the app.",
 			"- CI should validate builds and let the hosted platform own rollout mechanics unless the repo defines a separate release gate.",
 		}, "\n")
 	default:
-		return "No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`."
+		return "No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`."
 	}
 }
 
@@ -2074,9 +2082,9 @@ func applyTaskSystemVariables(content, agentID, taskSystem string) string {
 	if strings.Contains(content, taskSystemGuidanceToken) {
 		if normalized == "none" {
 			return content[:strings.Index(content, taskSystemGuidanceToken)] + strings.Join([]string{
-				"## Configured Task System",
+				"## Activation",
 				"",
-				"This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
+				"External issue tracking is disabled (`taskSystem: none`). This repository has no external task system configured. Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
 				"",
 				"Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.",
 				"",
@@ -2092,9 +2100,9 @@ func applyTaskSystemVariables(content, agentID, taskSystem string) string {
 			}, "\n")
 		}
 		content = strings.ReplaceAll(content, taskSystemGuidanceToken, strings.Join([]string{
-			"## Configured Task System",
+			"## Activation",
 			"",
-			fmt.Sprintf("This repository uses **%s** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.", normalized),
+			fmt.Sprintf("External issue tracking is active (`taskSystem: %s`). This repository uses **%s** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.", normalized, normalized),
 		}, "\n"))
 	}
 	if strings.Contains(content, taskSystemToken) {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -875,6 +875,9 @@ func TestBuildContentRendersPublishingDeploymentModelToken(t *testing.T) {
 	if !strings.Contains(content, "Kubernetes deployment model") {
 		t.Fatalf("expected kubernetes guidance, got %q", content)
 	}
+	if !strings.Contains(content, "Deployment guidance is active (`deploymentModel: kubernetes`).") {
+		t.Fatalf("expected active deployment activation guidance, got %q", content)
+	}
 	if !strings.Contains(content, "charts/<app>/") {
 		t.Fatalf("expected app chart guidance, got %q", content)
 	}
@@ -892,8 +895,37 @@ func TestBuildContentRendersInactiveDeploymentModel(t *testing.T) {
 	if !strings.Contains(content, "Deployment is inactive") {
 		t.Fatalf("expected inactive deployment guidance, got %q", content)
 	}
+	if !strings.Contains(content, "Deployment guidance is reference-only") {
+		t.Fatalf("expected reference-only deployment guidance, got %q", content)
+	}
 	if !strings.Contains(content, "do not create deploy-on-main workflows") {
 		t.Fatalf("expected deploy-on-main guardrail, got %q", content)
+	}
+}
+
+func TestBuildContentMarksOptionalPublishingVariants(t *testing.T) {
+	for _, suffix := range []string{"apt", "brew"} {
+		content, err := buildContent("publishing", "codex", "go", suffix, "standalone", "github", "none")
+		if err != nil {
+			t.Fatalf("buildContent(publishing %s): %v", suffix, err)
+		}
+		if !strings.Contains(content, "This optional publishing variant is inactive by default.") {
+			t.Fatalf("expected optional activation guidance in %s, got %q", suffix, content)
+		}
+		if !strings.Contains(content, "Treat this rule as reference-only unless it is explicitly configured") {
+			t.Fatalf("expected reference-only optional guidance in %s, got %q", suffix, content)
+		}
+	}
+}
+
+func TestBuildContentRendersActiveTaskSystem(t *testing.T) {
+	content, err := buildContent("tasks", "codex", "go", "task-system", "standalone", "github", "none")
+	if err != nil {
+		t.Fatalf("buildContent(tasks): %v", err)
+	}
+
+	if !strings.Contains(content, "External issue tracking is active (`taskSystem: github`).") {
+		t.Fatalf("expected active task-system guidance, got %q", content)
 	}
 }
 
@@ -908,6 +940,9 @@ func TestBuildContentRendersNoneTaskSystem(t *testing.T) {
 	}
 	if !strings.Contains(content, "taskSystem: none") {
 		t.Fatalf("expected none task system guidance, got %q", content)
+	}
+	if !strings.Contains(content, "External issue tracking is disabled (`taskSystem: none`).") {
+		t.Fatalf("expected disabled task-system guidance, got %q", content)
 	}
 	if strings.Contains(content, "All durable work items must be created there") {
 		t.Fatalf("expected no mandatory tracker guidance, got %q", content)

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
@@ -9,11 +9,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-apt.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-apt.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -135,6 +139,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-brew.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-brew.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -99,6 +103,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
@@ -9,11 +9,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
 

--- a/packages/ballast-python/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-api.md
@@ -9,11 +9,13 @@ You are a publishing specialist for REST API services deployed as Docker contain
 - Scope Kubernetes probes and Helm chart templates to repositories with `deploymentModel: kubernetes`.
 - Distinguish private (GHCR) vs public (Docker Hub) image publishing based on the API's audience.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## CI Workflow
 

--- a/packages/ballast-python/ballast/agents/common/publishing/content-apt.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-apt.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Debian package (`.deb`) distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by existing `.deb` packaging or APT repository workflows.
+
 ## Goals
 
 - Produce `.deb` packages alongside binary archives using GoReleaser `nfpms`.
@@ -135,6 +139,7 @@ Sign the Release file with a GPG key so `apt-get` can verify authenticity:
 
 ## When to Apply
 
+- Optional: apply only when Debian/APT distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and users on Debian/Ubuntu are a primary audience.
 - When GoReleaser is already configured for binary releases.
 - When the project wants to make installation easier for Linux users who prefer system package managers.

--- a/packages/ballast-python/ballast/agents/common/publishing/content-brew.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-brew.md
@@ -2,6 +2,10 @@
 
 You are a publishing specialist for Homebrew tap distribution of CLI tools.
 
+## Activation
+
+This optional publishing variant is inactive by default. Treat this rule as reference-only unless it is explicitly configured in the repository, requested by the maintainer, or already represented by an existing Homebrew tap workflow.
+
 ## Goals
 
 - Automatically write a Homebrew formula to a `homebrew-<project>` tap repo after each GitHub Release.
@@ -99,6 +103,7 @@ Download the latest binary from [GitHub Releases](https://github.com/OWNER/REPO/
 
 ## When to Apply
 
+- Optional: apply only when Homebrew distribution is explicitly configured, requested, or already present.
 - When the project ships a Go CLI and wants `brew install` support.
 - When GoReleaser is already configured for binary releases.
 - When the maintainer controls an organization or user account on GitHub where the tap repo can live.

--- a/packages/ballast-python/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-web.md
@@ -9,11 +9,13 @@ You are a publishing specialist for web applications deployed as Docker containe
 - Update deployment state according to the configured deployment model after the image is pushed.
 - Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
 
+## Activation
+
+{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
+
 ## Release Model
 
 When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
-
-{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}
 
 ## Workflow Trigger and Concurrency
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -798,6 +798,8 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
     match normalize_deployment_model(deployment_model):
         case "kubernetes":
             lines = [
+                "Deployment guidance is active (`deploymentModel: kubernetes`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+                "",
                 "Kubernetes deployment model:",
                 "- Treat app deployment ownership as Kubernetes-native unless repo docs say otherwise.",
                 "- Keep application Helm charts in the app repository under `charts/<app>/` with chart tests and schema validation.",
@@ -806,6 +808,8 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
             ]
         case "serverless":
             lines = [
+                "Deployment guidance is active (`deploymentModel: serverless`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+                "",
                 "Serverless deployment model:",
                 "- Treat deployable apps as functions, jobs, queues, event rules, and managed cloud resources.",
                 "- Keep infrastructure definitions close to the owning service unless the repo documents a shared infrastructure boundary.",
@@ -813,6 +817,8 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
             ]
         case "server":
             lines = [
+                "Deployment guidance is active (`deploymentModel: server`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+                "",
                 "Self-managed server deployment model:",
                 "- Treat deployable apps as services on provisioned hosts, VMs, or bare-metal servers.",
                 "- Keep systemd, process manager, reverse proxy, secrets, and rollback instructions aligned with the runtime environment.",
@@ -820,6 +826,8 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
             ]
         case "hosted":
             lines = [
+                "Deployment guidance is active (`deploymentModel: hosted`). Apply web/API deployment workflow guidance for repositories that own this deployment model.",
+                "",
                 "Hosted platform deployment model:",
                 "- Treat deployable apps as hosted-platform workloads such as Vercel, Netlify, Railway, Render, Fly.io, or similar services.",
                 "- Keep provider configuration, environment variables, preview environments, and production promotion rules documented with the app.",
@@ -827,7 +835,7 @@ def render_deployment_model_guidance(deployment_model: str | None) -> str:
             ]
         case _:
             lines = [
-                "No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.",
+                "No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.",
             ]
     return "\n".join(lines)
 
@@ -852,9 +860,9 @@ def render_task_system_guidance(task_system: str | None) -> str:
     if normalized == "none":
         return "\n".join(
             [
-                "## Configured Task System",
+                "## Activation",
                 "",
-                "This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
+                "External issue tracking is disabled (`taskSystem: none`). This repository has no external task system configured. Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.",
                 "",
                 "Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.",
                 "",
@@ -871,9 +879,9 @@ def render_task_system_guidance(task_system: str | None) -> str:
         )
     return "\n".join(
         [
-            "## Configured Task System",
+            "## Activation",
             "",
-            f"This repository uses **{normalized}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.",
+            f"External issue tracking is active (`taskSystem: {normalized}`). This repository uses **{normalized}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.",
         ]
     )
 

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -22,6 +22,7 @@ COMMON_AGENTS = [
     "observability",
     "publishing",
     "git-hooks",
+    "tasks",
 ]
 LANGUAGE_AGENTS = ["linting", "logging", "testing"]
 AGENTS_BY_LANGUAGE = {
@@ -53,6 +54,7 @@ DEPLOYMENT_MODEL_GUIDANCE_TOKEN = "{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}"
 TASK_SYSTEM_GUIDANCE_TOKEN = "{{BALLAST_TASK_SYSTEM_GUIDANCE}}"
 TASK_SYSTEM_TOKEN = "{{taskSystem}}"
 DEFAULT_TASK_SYSTEM = "github"
+TASK_SYSTEMS = ["github", "jira", "linear", "none"]
 DEPLOYMENT_MODELS = ["none", "kubernetes", "serverless", "server", "hosted"]
 
 
@@ -307,11 +309,12 @@ def save_config(
     agents: list[str],
     skills: list[str] | None = None,
     deployment_model: str | None = None,
+    task_system: str | None = None,
 ) -> None:
     file_path = root / rulesrc_filename(language)
     languages: list[str] = []
     paths: dict[str, list[str]] = {}
-    task_system: str | None = None
+    existing_task_system: str | None = None
     existing_deployment_model: str | None = None
     if file_path.exists():
         try:
@@ -332,7 +335,7 @@ def save_config(
                         ):
                             paths[key] = list(value)
                 if isinstance(raw.get("taskSystem"), str):
-                    task_system = raw["taskSystem"]
+                    existing_task_system = raw["taskSystem"].strip().lower()
                 if isinstance(raw.get("deploymentModel"), str):
                     existing_deployment_model = raw["deploymentModel"].strip().lower()
         except (OSError, json.JSONDecodeError):
@@ -350,6 +353,9 @@ def save_config(
     normalized_deployment_model = (
         (deployment_model or existing_deployment_model or "").strip().lower()
     )
+    normalized_task_system = normalize_task_system(
+        task_system or existing_task_system or ""
+    )
     if (
         normalized_deployment_model
         and normalized_deployment_model not in DEPLOYMENT_MODELS
@@ -357,6 +363,11 @@ def save_config(
         raise ValueError(
             "invalid deploymentModel "
             f"{normalized_deployment_model!r}; use one of: {', '.join(DEPLOYMENT_MODELS)}"
+        )
+    if normalized_task_system and normalized_task_system not in TASK_SYSTEMS:
+        raise ValueError(
+            "invalid taskSystem "
+            f"{normalized_task_system!r}; use one of: {', '.join(TASK_SYSTEMS)}"
         )
     payload: dict[str, object] = {
         "targets": targets,
@@ -366,8 +377,8 @@ def save_config(
         "languages": languages,
         "paths": paths,
     }
-    if task_system:
-        payload["taskSystem"] = task_system
+    if normalized_task_system:
+        payload["taskSystem"] = normalized_task_system
     if normalized_deployment_model:
         payload["deploymentModel"] = normalized_deployment_model
 
@@ -1727,6 +1738,33 @@ def prompt_deployment_model() -> str:
     return prompt_deployment_model()
 
 
+def prompt_task_system() -> str:
+    value = prompt(
+        "Task system for tasks "
+        f"[{', '.join(TASK_SYSTEMS)}] (default: {DEFAULT_TASK_SYSTEM}): "
+    )
+    normalized = normalize_task_system(value)
+    if not normalized:
+        return DEFAULT_TASK_SYSTEM
+    if normalized in TASK_SYSTEMS:
+        return normalized
+    print(f"Invalid task system. Choose one of: {', '.join(TASK_SYSTEMS)}")
+    return prompt_task_system()
+
+
+def resolve_task_system_for_tasks(current: str | None, non_interactive: bool) -> str:
+    normalized = normalize_task_system(current)
+    if normalized:
+        if normalized not in TASK_SYSTEMS:
+            raise ValueError(
+                f"invalid taskSystem {normalized!r}; use one of: {', '.join(TASK_SYSTEMS)}"
+            )
+        return normalized
+    if non_interactive:
+        return DEFAULT_TASK_SYSTEM
+    return prompt_task_system()
+
+
 def resolve_deployment_model_for_publishing(
     current: str | None, non_interactive: bool
 ) -> str:
@@ -1754,7 +1792,7 @@ def resolve_requested_targets(raw: object) -> list[str]:
 
 def resolve_target_and_agents(
     args: argparse.Namespace, root: Path, language: str
-) -> tuple[list[str], list[str], list[str], str | None] | None:
+) -> tuple[list[str], list[str], list[str], str | None, str | None] | None:
     cfg = load_config(root, language)
     ci = is_ci_mode() or bool(args.yes)
 
@@ -1772,6 +1810,7 @@ def resolve_target_and_agents(
     deployment_model_from_flag = normalize_deployment_model(
         getattr(args, "deployment_model", "")
     )
+    task_system_from_flag = normalize_task_system(getattr(args, "task_system", ""))
     if (
         deployment_model_from_flag
         and deployment_model_from_flag not in DEPLOYMENT_MODELS
@@ -1779,6 +1818,8 @@ def resolve_target_and_agents(
         raise ValueError(
             f"Invalid --deployment-model. Use: {', '.join(DEPLOYMENT_MODELS)}"
         )
+    if task_system_from_flag and task_system_from_flag not in TASK_SYSTEMS:
+        raise ValueError(f"Invalid --task-system. Use: {', '.join(TASK_SYSTEMS)}")
 
     if (
         cfg
@@ -1788,15 +1829,19 @@ def resolve_target_and_agents(
     ):
         agents = with_implicit_agents(list(cfg["agents"]))
         deployment_model = normalize_deployment_model(cfg.get("deploymentModel"))
+        task_system = normalize_task_system(cfg.get("taskSystem"))
         if "publishing" in agents:
             deployment_model = resolve_deployment_model_for_publishing(
                 deployment_model, ci
             )
+        if "tasks" in agents:
+            task_system = resolve_task_system_for_tasks(task_system, ci)
         return (
             list(cfg["targets"]),
             agents,
             list(cfg.get("skills") or []),
             deployment_model,
+            task_system,
         )
 
     targets = target_from_flag or (list(cfg["targets"]) if cfg else None)
@@ -1813,13 +1858,18 @@ def resolve_target_and_agents(
     deployment_model = deployment_model_from_flag or (
         normalize_deployment_model(cfg.get("deploymentModel")) if cfg else ""
     )
+    task_system = task_system_from_flag or (
+        normalize_task_system(cfg.get("taskSystem")) if cfg else ""
+    )
 
     if targets and ((agents and len(agents) > 0) or len(skills) > 0):
         if agents and "publishing" in agents:
             deployment_model = resolve_deployment_model_for_publishing(
                 deployment_model, ci
             )
-        return targets, agents or [], skills, deployment_model
+        if agents and "tasks" in agents:
+            task_system = resolve_task_system_for_tasks(task_system, ci)
+        return targets, agents or [], skills, deployment_model, task_system
 
     if ci:
         return None
@@ -1829,7 +1879,15 @@ def resolve_target_and_agents(
     resolved_skills = skills if skills else prompt_skills(language)
     if "publishing" in resolved_agents:
         deployment_model = resolve_deployment_model_for_publishing(deployment_model, ci)
-    return resolved_targets, resolved_agents, resolved_skills, deployment_model
+    if "tasks" in resolved_agents:
+        task_system = resolve_task_system_for_tasks(task_system, ci)
+    return (
+        resolved_targets,
+        resolved_agents,
+        resolved_skills,
+        deployment_model,
+        task_system,
+    )
 
 
 def install(
@@ -1845,6 +1903,7 @@ def install(
     patch_gemini_md: bool = False,
     skip_support_files: set[str] | None = None,
     deployment_model: str | None = None,
+    task_system: str | None = None,
 ) -> InstallResult:
     result = InstallResult()
     agents = with_implicit_agents(agents)
@@ -1859,7 +1918,9 @@ def install(
         result.errors.append(("gitignore", str(err)))
 
     if persist:
-        save_config(root, language, target, agents, skills, deployment_model)
+        save_config(
+            root, language, target, agents, skills, deployment_model, task_system
+        )
 
     config_for_support_files = load_config(root, language)
     support_agents = with_implicit_agents(
@@ -1872,8 +1933,11 @@ def install(
         if config_for_support_files
         else skills
     )
-    task_system = (
+    config_task_system = (
         config_for_support_files.get("taskSystem") if config_for_support_files else None
+    )
+    task_system = task_system or (
+        config_task_system if isinstance(config_task_system, str) else None
     )
     skipped_support_files = skip_support_files or set()
 
@@ -2047,11 +2111,14 @@ def install_for_targets(
     patch_claude_md: bool = False,
     patch_gemini_md: bool = False,
     deployment_model: str | None = None,
+    task_system: str | None = None,
 ) -> list[tuple[str, InstallResult]]:
     results: list[tuple[str, InstallResult]] = []
     agents = with_implicit_agents(agents)
     if persist:
-        save_config(root, language, targets, agents, skills, deployment_model)
+        save_config(
+            root, language, targets, agents, skills, deployment_model, task_system
+        )
 
     for target in targets:
         results.append(
@@ -2069,6 +2136,7 @@ def install_for_targets(
                     patch_claude_md,
                     patch_gemini_md,
                     deployment_model=deployment_model,
+                    task_system=task_system,
                 ),
             )
         )
@@ -2138,8 +2206,12 @@ def run_install(args: argparse.Namespace) -> int:
     if len(resolved) == 3:
         targets, agents, skills = resolved
         deployment_model = None
-    else:
+        task_system = None
+    elif len(resolved) == 4:
         targets, agents, skills, deployment_model = resolved
+        task_system = None
+    else:
+        targets, agents, skills, deployment_model, task_system = resolved
     if any(target not in TARGETS for target in targets):
         print(f"Invalid --target. Use: {', '.join(TARGETS)}")
         return 1
@@ -2162,6 +2234,7 @@ def run_install(args: argparse.Namespace) -> int:
         with_implicit_agents(agents),
         skills,
         deployment_model,
+        task_system,
     )
     for target in targets:
         skipped_support_file = support_decisions.get(target)
@@ -2185,6 +2258,7 @@ def run_install(args: argparse.Namespace) -> int:
                     False,
                     {skipped_support_file} if skipped_support_file else None,
                     deployment_model,
+                    task_system,
                 ),
             )
         )
@@ -2244,6 +2318,11 @@ def parser() -> argparse.ArgumentParser:
         "--deployment-model",
         choices=DEPLOYMENT_MODELS,
         help="App/service deployment model for publishing; use none for CLI/library/SDK-only projects",
+    )
+    install_cmd.add_argument(
+        "--task-system",
+        choices=TASK_SYSTEMS,
+        help=f"Task system for the tasks agent; default: {DEFAULT_TASK_SYSTEM}",
     )
     install_cmd.add_argument(
         "--force",

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1912,6 +1912,7 @@ def install(
     skip_support_files: set[str] | None = None,
     deployment_model: str | None = None,
     task_system: str | None = None,
+    refresh_task_rules: bool = False,
 ) -> InstallResult:
     result = InstallResult()
     agents = with_implicit_agents(agents)
@@ -1971,7 +1972,12 @@ def install(
                     deployment_model,
                     task_system if isinstance(task_system, str) else None,
                 )
-                if dst.exists() and not force and not patch:
+                if (
+                    dst.exists()
+                    and not force
+                    and not patch
+                    and not (refresh_task_rules and agent == "tasks")
+                ):
                     agent_skipped = True
                     agent_processed = True
                     continue
@@ -2120,6 +2126,7 @@ def install_for_targets(
     patch_gemini_md: bool = False,
     deployment_model: str | None = None,
     task_system: str | None = None,
+    refresh_task_rules: bool = False,
 ) -> list[tuple[str, InstallResult]]:
     results: list[tuple[str, InstallResult]] = []
     agents = with_implicit_agents(agents)
@@ -2145,6 +2152,7 @@ def install_for_targets(
                     patch_gemini_md,
                     deployment_model=deployment_model,
                     task_system=task_system,
+                    refresh_task_rules=refresh_task_rules,
                 ),
             )
         )
@@ -2235,6 +2243,17 @@ def run_install(args: argparse.Namespace) -> int:
         support_decisions[target] = skipped_support_file
 
     per_target_results: list[tuple[str, InstallResult]] = []
+    prior_config = load_config(root, language)
+    prior_task_system = (
+        normalize_task_system(prior_config.get("taskSystem")) if prior_config else ""
+    )
+    refresh_task_rules = (
+        "tasks" in with_implicit_agents(agents)
+        and task_system is not None
+        and normalize_task_system(task_system)
+        != (prior_task_system or DEFAULT_TASK_SYSTEM)
+    )
+
     save_config(
         root,
         language,
@@ -2267,6 +2286,7 @@ def run_install(args: argparse.Namespace) -> int:
                     {skipped_support_file} if skipped_support_file else None,
                     deployment_model,
                     task_system,
+                    refresh_task_rules,
                 ),
             )
         )

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -433,6 +433,54 @@ class PatchInstallTests(unittest.TestCase):
             self.assertIn("**github** as the system of record", content)
             self.assertNotIn("{{taskSystem}}", content)
 
+    def test_run_install_changing_task_system_refreshes_existing_task_rules(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_git_boundary(root)
+            old_cwd = Path.cwd()
+            os.chdir(root)
+            try:
+                first_args = cli.parser().parse_args(
+                    [
+                        "install",
+                        "--target",
+                        "codex",
+                        "--agent",
+                        "tasks",
+                        "--task-system",
+                        "jira",
+                        "--yes",
+                    ]
+                )
+                second_args = cli.parser().parse_args(
+                    [
+                        "install",
+                        "--target",
+                        "codex",
+                        "--agent",
+                        "tasks",
+                        "--task-system",
+                        "linear",
+                        "--yes",
+                    ]
+                )
+                self.assertEqual(cli.run_install(first_args), 0)
+                self.assertEqual(cli.run_install(second_args), 0)
+            finally:
+                os.chdir(old_cwd)
+
+            config = (root / ".rulesrc.json").read_text(encoding="utf-8")
+            self.assertIn('"taskSystem": "linear"', config)
+            content = (root / ".codex" / "rules" / "tasks-task-system.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("taskSystem: linear", content)
+            self.assertIn("**linear** as the system of record", content)
+            self.assertNotIn("taskSystem: jira", content)
+            self.assertNotIn("**jira** as the system of record", content)
+
     def test_run_install_writes_multi_target_shared_rulesrc(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -157,17 +157,54 @@ class PatchInstallTests(unittest.TestCase):
         )
 
         self.assertIn("Kubernetes deployment model", content)
+        self.assertIn(
+            "Deployment guidance is active (`deploymentModel: kubernetes`).",
+            content,
+        )
         self.assertIn("charts/<app>/", content)
         self.assertNotIn("{{BALLAST_DEPLOYMENT_MODEL_GUIDANCE}}", content)
+
+    def test_build_content_renders_inactive_deployment_model(self) -> None:
+        content = cli.build_content(
+            "publishing", "codex", "python", "web", deployment_model="none"
+        )
+
+        self.assertIn("Deployment guidance is reference-only", content)
+        self.assertIn("Deployment is inactive", content)
+        self.assertIn("do not create deploy-on-main workflows", content)
+
+    def test_build_content_marks_optional_publishing_variants(self) -> None:
+        for suffix in ["apt", "brew"]:
+            content = cli.build_content("publishing", "codex", "python", suffix)
+            self.assertIn(
+                "This optional publishing variant is inactive by default.",
+                content,
+            )
+            self.assertIn(
+                "Treat this rule as reference-only unless it is explicitly configured",
+                content,
+            )
 
     def test_build_content_renders_none_task_system(self) -> None:
         content = cli.render_task_system_guidance("none")
 
         self.assertIn("taskSystem: none", content)
+        self.assertIn(
+            "External issue tracking is disabled (`taskSystem: none`).",
+            content,
+        )
         self.assertIn("No task-system MCP server is required", content)
         self.assertNotIn("{{BALLAST_TASK_SYSTEM_GUIDANCE}}", content)
         self.assertNotIn("{{taskSystem}}", content)
         self.assertNotIn("All durable work items must be created there", content)
+
+    def test_build_content_renders_active_task_system(self) -> None:
+        content = cli.render_task_system_guidance("github")
+
+        self.assertIn(
+            "External issue tracking is active (`taskSystem: github`).",
+            content,
+        )
 
     def test_apply_task_system_guidance_defaults_missing_task_system(self) -> None:
         content = cli.apply_task_system_guidance(

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -115,6 +115,36 @@ class PatchInstallTests(unittest.TestCase):
 
         self.assertEqual(args.deployment_model, "kubernetes")
 
+    def test_parser_accepts_task_system(self) -> None:
+        args = cli.parser().parse_args(
+            [
+                "install",
+                "--target",
+                "codex",
+                "--agent",
+                "tasks",
+                "--task-system",
+                "linear",
+            ]
+        )
+
+        self.assertEqual(args.task_system, "linear")
+
+    def test_parser_rejects_invalid_task_system(self) -> None:
+        with io.StringIO() as buf, mock.patch("sys.stderr", buf):
+            with self.assertRaises(SystemExit) as exc:
+                cli.parser().parse_args(
+                    ["install", "--agent", "tasks", "--task-system", "asana"]
+                )
+            output = buf.getvalue()
+
+        self.assertEqual(exc.exception.code, 2)
+        self.assertIn("invalid choice: 'asana'", output)
+        self.assertIn("github", output)
+        self.assertIn("jira", output)
+        self.assertIn("linear", output)
+        self.assertIn("none", output)
+
     def test_build_content_for_gemini_prefers_non_codex_header(self) -> None:
         content = cli.build_content("linting", "gemini", "python")
 
@@ -302,6 +332,69 @@ class PatchInstallTests(unittest.TestCase):
                 encoding="utf-8"
             )
             self.assertIn("Hosted platform deployment model", content)
+
+    def test_run_install_writes_task_system_for_tasks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_git_boundary(root)
+            old_cwd = Path.cwd()
+            os.chdir(root)
+            try:
+                args = cli.parser().parse_args(
+                    [
+                        "install",
+                        "--target",
+                        "codex",
+                        "--agent",
+                        "tasks",
+                        "--task-system",
+                        "none",
+                        "--yes",
+                    ]
+                )
+                exit_code = cli.run_install(args)
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertEqual(exit_code, 0)
+            config = (root / ".rulesrc.json").read_text(encoding="utf-8")
+            self.assertIn('"taskSystem": "none"', config)
+            task_rule = root / ".codex" / "rules" / "tasks-task-system.md"
+            self.assertTrue(task_rule.exists())
+            content = task_rule.read_text(encoding="utf-8")
+            self.assertIn("taskSystem: none", content)
+            self.assertIn("No task-system MCP server is required", content)
+            self.assertNotIn("{{taskSystem}}", content)
+
+    def test_run_install_defaults_tasks_to_github(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_git_boundary(root)
+            old_cwd = Path.cwd()
+            os.chdir(root)
+            try:
+                args = cli.parser().parse_args(
+                    [
+                        "install",
+                        "--target",
+                        "codex",
+                        "--agent",
+                        "tasks",
+                        "--yes",
+                    ]
+                )
+                exit_code = cli.run_install(args)
+            finally:
+                os.chdir(old_cwd)
+
+            self.assertEqual(exit_code, 0)
+            config = (root / ".rulesrc.json").read_text(encoding="utf-8")
+            self.assertIn('"taskSystem": "github"', config)
+            content = (root / ".codex" / "rules" / "tasks-task-system.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("**github** as the system of record", content)
+            self.assertNotIn("{{taskSystem}}", content)
 
     def test_run_install_writes_multi_target_shared_rulesrc(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -706,7 +799,9 @@ class PatchInstallTests(unittest.TestCase):
             args = cli.parser().parse_args(["install", "--yes"])
             resolved = cli.resolve_target_and_agents(args, root, "python")
 
-            self.assertEqual(resolved, (["claude"], [], ["owasp-security-scan"], ""))
+            self.assertEqual(
+                resolved, (["claude"], [], ["owasp-security-scan"], "", "")
+            )
 
     def test_resolve_target_and_agents_supports_multi_target_config(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -729,8 +824,25 @@ class PatchInstallTests(unittest.TestCase):
                     ["linting", "git-hooks"],
                     ["owasp-security-scan"],
                     "",
+                    "",
                 ),
             )
+
+    def test_resolve_target_and_agents_prompts_for_task_system(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            args = cli.parser().parse_args(["install"])
+
+            with (
+                mock.patch.object(cli, "is_ci_mode", return_value=False),
+                mock.patch.object(cli, "prompt_targets", return_value=["codex"]),
+                mock.patch.object(cli, "prompt_agents", return_value=["tasks"]),
+                mock.patch.object(cli, "prompt_skills", return_value=[]),
+                mock.patch.object(cli, "prompt_task_system", return_value="jira"),
+            ):
+                resolved = cli.resolve_target_and_agents(args, root, "python")
+
+            self.assertEqual(resolved, (["codex"], ["tasks"], [], "", "jira"))
 
     def test_resolve_target_and_agents_prompts_for_multiple_targets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -755,6 +867,7 @@ class PatchInstallTests(unittest.TestCase):
                     ["cursor", "claude"],
                     ["linting"],
                     ["owasp-security-scan"],
+                    "",
                     "",
                 ),
             )

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -74,6 +74,24 @@ describe('build', () => {
       expect(suffixes).toEqual(expect.arrayContaining(['cli', 'apps']));
     });
 
+    test('treats empty publishingProfiles as unfiltered', () => {
+      const suffixes = listRuleSuffixes('publishing', 'typescript', []);
+
+      expect(suffixes).toHaveLength(8);
+      expect(suffixes).toEqual(
+        expect.arrayContaining([
+          'libraries',
+          'sdks',
+          'apps',
+          'cli',
+          'brew',
+          'apt',
+          'web',
+          'api'
+        ])
+      );
+    });
+
     test('returns only main rule for plan-lifecycle', () => {
       expect(listRuleSuffixes('plan-lifecycle')).toEqual(['']);
     });

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -171,6 +171,9 @@ describe('build', () => {
         variables: { taskSystem: 'github' }
       });
       expect(content).toContain('github');
+      expect(content).toContain(
+        'External issue tracking is active (`taskSystem: github`).'
+      );
       expect(content).toContain('MCP Server Setup');
       expect(content).not.toContain('{{taskSystem}}');
     });
@@ -189,6 +192,9 @@ describe('build', () => {
       });
 
       expect(content).toContain('taskSystem: none');
+      expect(content).toContain(
+        'External issue tracking is disabled (`taskSystem: none`).'
+      );
       expect(content).toContain('No task-system MCP server is required');
       expect(content).toContain(
         'Do not create external issues or tickets by default.'
@@ -274,6 +280,9 @@ describe('build', () => {
       expect(content).toContain('GitOps repository');
       expect(content).toContain('image digest');
       expect(content).toContain('## App Deployment Model');
+      expect(content).toContain(
+        'Deployment guidance is active (`deploymentModel: kubernetes`).'
+      );
       expect(content).not.toContain('## Kubernetes');
     });
 
@@ -290,6 +299,7 @@ describe('build', () => {
       const content = getContent('publishing', 'web', 'typescript');
       expect(content).toContain('deploymentModel: none');
       expect(content).toContain('Deployment is inactive');
+      expect(content).toContain('Deployment guidance is reference-only');
       expect(content).toContain('do not create deploy-on-main workflows');
       expect(content).toContain('repository: OWNER/deployment-state');
       expect(content).toContain(
@@ -303,6 +313,7 @@ describe('build', () => {
     test('keeps REST API baseline goals platform neutral', () => {
       const content = getContent('publishing', 'api', 'typescript');
       expect(content).toContain('Deployment is inactive');
+      expect(content).toContain('Deployment guidance is reference-only');
       expect(content).toContain('do not create deploy-on-main workflows');
       expect(content).toContain(
         'health and readiness endpoints that the configured runtime can use'
@@ -316,6 +327,21 @@ describe('build', () => {
       expect(content).not.toContain(
         'Ensure the API exposes a health endpoint that Kubernetes probes can use.'
       );
+    });
+
+    test('marks optional publishing variants as reference-only until configured', () => {
+      const brew = getContent('publishing', 'brew');
+      const apt = getContent('publishing', 'apt');
+
+      for (const content of [brew, apt]) {
+        expect(content).toContain('## Activation');
+        expect(content).toContain(
+          'This optional publishing variant is inactive by default.'
+        );
+        expect(content).toContain(
+          'Treat this rule as reference-only unless it is explicitly configured'
+        );
+      }
     });
 
     test('returns TypeScript testing content with web smoke and E2E placement guidance', () => {

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -52,7 +52,7 @@ describe('build', () => {
       expect(listRuleSuffixes('docs')).toEqual(['']);
     });
 
-    test('returns libraries, sdks, and apps for publishing', () => {
+    test('returns libraries, sdks, and apps for publishing by default', () => {
       expect(listRuleSuffixes('publishing')).toContain('libraries');
       expect(listRuleSuffixes('publishing')).toContain('sdks');
       expect(listRuleSuffixes('publishing')).toContain('apps');
@@ -62,6 +62,16 @@ describe('build', () => {
       expect(listRuleSuffixes('publishing')).toContain('web');
       expect(listRuleSuffixes('publishing')).toContain('api');
       expect(listRuleSuffixes('publishing').length).toBe(8);
+    });
+
+    test('returns selected publishing profiles when configured', () => {
+      const suffixes = listRuleSuffixes('publishing', 'typescript', [
+        'cli',
+        'apps'
+      ]);
+
+      expect(suffixes).toHaveLength(2);
+      expect(suffixes).toEqual(expect.arrayContaining(['cli', 'apps']));
     });
 
     test('returns only main rule for plan-lifecycle', () => {
@@ -809,6 +819,21 @@ alwaysApply: false
         'Plan lifecycle - create, maintain, and graduate plans to ADRs'
       );
     });
+
+    test('lists only selected publishing profiles for codex', () => {
+      const content = buildCodexAgentsMd(['publishing'], [], 'typescript', [
+        'cli',
+        'apps'
+      ]);
+      expect(content).toContain('`.codex/rules/publishing-cli.md`');
+      expect(content).toContain('`.codex/rules/publishing-apps.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-web.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-api.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-libraries.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-sdks.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-apt.md`');
+      expect(content).not.toContain('`.codex/rules/publishing-brew.md`');
+    });
   });
 
   describe('buildClaudeMd', () => {
@@ -832,6 +857,15 @@ alwaysApply: false
       expect(content).toContain(
         'Plan lifecycle - create, maintain, and graduate plans to ADRs'
       );
+    });
+
+    test('lists only selected publishing profiles for claude', () => {
+      const content = buildClaudeMd(['publishing'], [], 'typescript', [
+        'libraries'
+      ]);
+      expect(content).toContain('`.claude/rules/publishing-libraries.md`');
+      expect(content).not.toContain('`.claude/rules/publishing-cli.md`');
+      expect(content).not.toContain('`.claude/rules/publishing-apps.md`');
     });
   });
 

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -248,6 +248,8 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
   switch (deploymentModel) {
     case 'kubernetes':
       return [
+        'Deployment guidance is active (`deploymentModel: kubernetes`). Apply web/API deployment workflow guidance for repositories that own this deployment model.',
+        '',
         'Kubernetes: local Helm chart + external ArgoCD GitOps.',
         '',
         '- Application repository ownership:',
@@ -269,6 +271,8 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
       ].join('\n');
     case 'serverless':
       return [
+        'Deployment guidance is active (`deploymentModel: serverless`). Apply web/API deployment workflow guidance for repositories that own this deployment model.',
+        '',
         'Serverless deployment model for managed function or container platforms such as AWS Lambda, Cloud Run, Azure Functions, or equivalent services.',
         '',
         '- Keep infrastructure definitions or platform manifests close to the service unless the team has a dedicated infra repository.',
@@ -280,6 +284,8 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
       ].join('\n');
     case 'server':
       return [
+        'Deployment guidance is active (`deploymentModel: server`). Apply web/API deployment workflow guidance for repositories that own this deployment model.',
+        '',
         'Server deployment model for self-managed VM, VPS, or bare-metal deployments.',
         '',
         '- Build a versioned artifact or container image in CI; do not build production artifacts manually on the server.',
@@ -291,6 +297,8 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
       ].join('\n');
     case 'hosted':
       return [
+        'Deployment guidance is active (`deploymentModel: hosted`). Apply web/API deployment workflow guidance for repositories that own this deployment model.',
+        '',
         'Hosted app platform deployment model for services such as Vercel, Netlify, Render, Railway, Fly.io, or similar app platforms.',
         '',
         '- Keep platform configuration in the app repo when the platform supports checked-in config files.',
@@ -302,7 +310,7 @@ function renderDeploymentModelGuidance(options?: BuildOptions): string {
       ].join('\n');
     case 'none':
     default:
-      return 'No app deployment model is configured (`deploymentModel: none`). Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.';
+      return 'No app deployment model is configured (`deploymentModel: none`). Deployment guidance is reference-only. Deployment is inactive: keep library, SDK, CLI, and optional container publishing guidance active, but do not create deploy-on-main workflows, deployment-state updates, Kubernetes, serverless, hosted-platform, or self-managed server deployment ownership until the repository sets an active `deploymentModel`.';
   }
 }
 
@@ -327,9 +335,9 @@ function renderTaskSystemGuidance(options?: BuildOptions): string {
   const taskSystem = options?.variables?.taskSystem ?? '{{taskSystem}}';
   if (taskSystem === 'none') {
     return [
-      '## Configured Task System',
+      '## Activation',
       '',
-      'This repository has no external task system configured (`taskSystem: none`). Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.',
+      'External issue tracking is disabled (`taskSystem: none`). This repository has no external task system configured. Do not require GitHub Issues, Jira, Linear, or MCP-backed ticket creation for routine branch work.',
       '',
       'Use `tasks/todo.md` for branch-scoped working notes. If work must survive beyond the current branch, ask the user where they want durable follow-up tracked before creating external issues or tickets.',
       '',
@@ -346,9 +354,9 @@ function renderTaskSystemGuidance(options?: BuildOptions): string {
   }
 
   return [
-    '## Configured Task System',
+    '## Activation',
     '',
-    `This repository uses **${taskSystem}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.`
+    `External issue tracking is active (\`taskSystem: ${taskSystem}\`). This repository uses **${taskSystem}** as the system of record for all planned work, follow-up tasks, bugs, and feature requests. All durable work items must be created there, not left only in local notes or branch files.`
   ].join('\n');
 }
 

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -7,7 +7,7 @@ import {
   getAgentDir,
   getSkillDir
 } from './agents';
-import type { Target } from './config';
+import type { PublishingProfile, Target } from './config';
 import type { Language } from './agents';
 import pkg from '../package.json';
 
@@ -382,7 +382,8 @@ const CONTENT_MAIN = `${CONTENT_PREFIX}.md`;
  */
 export function listRuleSuffixes(
   agentId: string,
-  language: Language = 'typescript'
+  language: Language = 'typescript',
+  publishingProfiles?: readonly PublishingProfile[]
 ): string[] {
   const dir = getPreferredAgentDir(agentId, language);
   if (!fs.existsSync(dir)) {
@@ -406,6 +407,10 @@ export function listRuleSuffixes(
   }
   if (suffixes.length === 0) {
     throw new Error(`Agent "${agentId}" has no content.md or content-*.md`);
+  }
+  if (agentId === 'publishing' && publishingProfiles !== undefined) {
+    const available = new Set(suffixes);
+    return publishingProfiles.filter((profile) => available.has(profile));
   }
   return suffixes;
 }
@@ -925,7 +930,8 @@ function loadRepositoryFactsSection(): string[] | null {
 export function buildCodexAgentsMd(
   agents: string[],
   skills: string[] = [],
-  language: Language = 'typescript'
+  language: Language = 'typescript',
+  publishingProfiles?: readonly PublishingProfile[]
 ): string {
   const lines: string[] = [];
   lines.push('# AGENTS.md');
@@ -945,7 +951,7 @@ export function buildCodexAgentsMd(
   );
   lines.push('');
   for (const agentId of agents) {
-    const suffixes = listRuleSuffixes(agentId, language);
+    const suffixes = listRuleSuffixes(agentId, language, publishingProfiles);
     for (const ruleSuffix of suffixes) {
       const basename = getRuleBasename(agentId, language, ruleSuffix);
       const description =
@@ -977,7 +983,8 @@ export function buildCodexAgentsMd(
 export function buildClaudeMd(
   agents: string[],
   skills: string[] = [],
-  language: Language = 'typescript'
+  language: Language = 'typescript',
+  publishingProfiles?: readonly PublishingProfile[]
 ): string {
   const lines: string[] = [];
   lines.push('# CLAUDE.md');
@@ -997,7 +1004,7 @@ export function buildClaudeMd(
   );
   lines.push('');
   for (const agentId of agents) {
-    const suffixes = listRuleSuffixes(agentId, language);
+    const suffixes = listRuleSuffixes(agentId, language, publishingProfiles);
     for (const ruleSuffix of suffixes) {
       const basename = getRuleBasename(agentId, language, ruleSuffix);
       const description =
@@ -1043,7 +1050,8 @@ export function buildGeminiFormat(
 export function buildGeminiMd(
   agents: string[],
   skills: string[] = [],
-  language: Language = 'typescript'
+  language: Language = 'typescript',
+  publishingProfiles?: readonly PublishingProfile[]
 ): string {
   const lines: string[] = [];
   lines.push('# GEMINI.md');
@@ -1081,7 +1089,7 @@ export function buildGeminiMd(
   );
   lines.push('');
   for (const agentId of agents) {
-    const suffixes = listRuleSuffixes(agentId, language);
+    const suffixes = listRuleSuffixes(agentId, language, publishingProfiles);
     for (const ruleSuffix of suffixes) {
       const basename = getRuleBasename(agentId, language, ruleSuffix);
       const description =

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -416,7 +416,11 @@ export function listRuleSuffixes(
   if (suffixes.length === 0) {
     throw new Error(`Agent "${agentId}" has no content.md or content-*.md`);
   }
-  if (agentId === 'publishing' && publishingProfiles !== undefined) {
+  if (
+    agentId === 'publishing' &&
+    publishingProfiles !== undefined &&
+    publishingProfiles.length > 0
+  ) {
     const available = new Set(suffixes);
     return publishingProfiles.filter((profile) => available.has(profile));
   }

--- a/packages/ballast-typescript/src/config.test.ts
+++ b/packages/ballast-typescript/src/config.test.ts
@@ -12,7 +12,8 @@ import {
   TASK_SYSTEMS,
   DEFAULT_TASK_SYSTEM,
   DEPLOYMENT_MODELS,
-  DEFAULT_DEPLOYMENT_MODEL
+  DEFAULT_DEPLOYMENT_MODEL,
+  PUBLISHING_PROFILES
 } from './config';
 import { BALLAST_VERSION } from './version';
 
@@ -414,6 +415,110 @@ describe('config', () => {
       saveConfig({ targets: ['cursor'], agents: ['publishing'] }, tmpDir);
       const loaded = loadConfig(tmpDir);
       expect(loaded?.deploymentModel).toBe('hosted');
+    });
+  });
+
+  describe('publishingProfiles', () => {
+    test('PUBLISHING_PROFILES contains supported canonical profiles', () => {
+      expect(PUBLISHING_PROFILES).toEqual([
+        'cli',
+        'apps',
+        'web',
+        'api',
+        'libraries',
+        'sdks',
+        'apt',
+        'brew'
+      ]);
+    });
+
+    test('saves and loads publishingProfiles', () => {
+      saveConfig(
+        {
+          targets: ['claude'],
+          agents: ['publishing'],
+          ballastVersion: BALLAST_VERSION,
+          publishingProfiles: ['cli', 'web']
+        },
+        tmpDir
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toEqual(['cli', 'web']);
+    });
+
+    test('normalizes publishing profile aliases from config', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, RULESRC_FILENAME),
+        JSON.stringify({
+          targets: ['claude'],
+          agents: ['publishing'],
+          publishingProfiles: ['APP', 'library', 'sdk', 'cli']
+        })
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toEqual([
+        'apps',
+        'libraries',
+        'sdks',
+        'cli'
+      ]);
+    });
+
+    test('preserves explicit empty publishingProfiles from config', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, RULESRC_FILENAME),
+        JSON.stringify({
+          targets: ['claude'],
+          agents: ['publishing'],
+          publishingProfiles: []
+        })
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toEqual([]);
+    });
+
+    test('loads config without publishingProfiles field', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, RULESRC_FILENAME),
+        JSON.stringify({ targets: ['claude'], agents: ['publishing'] })
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toBeUndefined();
+    });
+
+    test('preserves existing publishingProfiles when saving without one', () => {
+      saveConfig(
+        {
+          targets: ['claude'],
+          agents: ['publishing'],
+          publishingProfiles: ['api']
+        },
+        tmpDir
+      );
+      saveConfig({ targets: ['cursor'], agents: ['publishing'] }, tmpDir);
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toEqual(['api']);
+    });
+
+    test('clears existing publishingProfiles when saving an empty array', () => {
+      saveConfig(
+        {
+          targets: ['claude'],
+          agents: ['publishing'],
+          publishingProfiles: ['api']
+        },
+        tmpDir
+      );
+      saveConfig(
+        {
+          targets: ['cursor'],
+          agents: ['publishing'],
+          publishingProfiles: []
+        },
+        tmpDir
+      );
+      const loaded = loadConfig(tmpDir);
+      expect(loaded?.publishingProfiles).toEqual([]);
     });
   });
 

--- a/packages/ballast-typescript/src/config.ts
+++ b/packages/ballast-typescript/src/config.ts
@@ -15,10 +15,21 @@ export const DEPLOYMENT_MODELS = [
   'hosted'
 ] as const;
 export const DEFAULT_DEPLOYMENT_MODEL = 'none' as const;
+export const PUBLISHING_PROFILES = [
+  'cli',
+  'apps',
+  'web',
+  'api',
+  'libraries',
+  'sdks',
+  'apt',
+  'brew'
+] as const;
 
 export type Target = (typeof TARGETS)[number];
 export type TaskSystem = (typeof TASK_SYSTEMS)[number];
 export type DeploymentModel = (typeof DEPLOYMENT_MODELS)[number];
+export type PublishingProfile = (typeof PUBLISHING_PROFILES)[number];
 
 export interface RulesConfig {
   targets: Target[];
@@ -29,6 +40,7 @@ export interface RulesConfig {
   paths?: Record<string, string[]>;
   taskSystem?: TaskSystem;
   deploymentModel?: DeploymentModel;
+  publishingProfiles?: PublishingProfile[];
 }
 
 export function getRulesrcFilename(): string {
@@ -191,6 +203,12 @@ export function saveConfig(config: RulesConfig, projectRoot?: string): void {
     nextConfig = { ...nextConfig, deploymentModel };
   }
 
+  const publishingProfiles =
+    config.publishingProfiles ?? existing?.publishingProfiles;
+  if (publishingProfiles !== undefined) {
+    nextConfig = { ...nextConfig, publishingProfiles };
+  }
+
   fs.writeFileSync(filePath, JSON.stringify(nextConfig, null, 2), 'utf8');
 }
 
@@ -217,6 +235,7 @@ function normalizeRulesConfig(data: unknown): RulesConfig | null {
     paths?: unknown;
     taskSystem?: unknown;
     deploymentModel?: unknown;
+    publishingProfiles?: unknown;
   };
   const targets = normalizeTargets(record.targets ?? record.target);
   if (targets.length === 0 || !Array.isArray(record.agents)) {
@@ -265,7 +284,32 @@ function normalizeRulesConfig(data: unknown): RulesConfig | null {
       config.deploymentModel = deploymentModel as DeploymentModel;
     }
   }
+  if (Array.isArray(record.publishingProfiles)) {
+    config.publishingProfiles = normalizePublishingProfiles(
+      record.publishingProfiles
+    );
+  }
   return config;
+}
+
+export function normalizePublishingProfiles(
+  values: unknown[]
+): PublishingProfile[] {
+  const aliases: Record<string, PublishingProfile> = {
+    app: 'apps',
+    library: 'libraries',
+    sdk: 'sdks'
+  };
+  const profiles = new Set<PublishingProfile>();
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const token = value.trim().toLowerCase();
+    const profile = aliases[token] ?? token;
+    if ((PUBLISHING_PROFILES as readonly string[]).includes(profile)) {
+      profiles.add(profile as PublishingProfile);
+    }
+  }
+  return Array.from(profiles);
 }
 
 function mergeLanguages(

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -1688,6 +1688,50 @@ Keep my custom responsibilities.
       expect(agentsMd).not.toContain('`.codex/rules/publishing-libraries.md`');
     });
 
+    test('treats empty publishingProfiles as unfiltered during install', () => {
+      saveConfig(
+        {
+          targets: ['codex'],
+          agents: ['publishing'],
+          publishingProfiles: []
+        },
+        tmpDir
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'codex',
+        agents: ['publishing'],
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installed).toEqual(['publishing']);
+      expect(result.installedRules).toHaveLength(8);
+      for (const suffix of [
+        'api',
+        'apps',
+        'apt',
+        'brew',
+        'cli',
+        'libraries',
+        'sdks',
+        'web'
+      ]) {
+        expect(
+          fs.existsSync(
+            path.join(tmpDir, '.codex', 'rules', `publishing-${suffix}.md`)
+          )
+        ).toBe(true);
+      }
+
+      const agentsMd = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+      expect(agentsMd).toContain('`.codex/rules/publishing-cli.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-web.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-api.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-libraries.md`');
+    });
+
     test('adds to errors for unknown agent and continues with valid ones', () => {
       const result = install({
         projectRoot: tmpDir,

--- a/packages/ballast-typescript/src/install.test.ts
+++ b/packages/ballast-typescript/src/install.test.ts
@@ -1634,6 +1634,60 @@ Keep my custom responsibilities.
       );
     });
 
+    test('installs only configured publishing profiles', () => {
+      saveConfig(
+        {
+          targets: ['codex'],
+          agents: ['publishing'],
+          publishingProfiles: ['cli', 'apps']
+        },
+        tmpDir
+      );
+
+      const result = install({
+        projectRoot: tmpDir,
+        target: 'codex',
+        agents: ['publishing'],
+        force: false,
+        saveConfig: false
+      });
+
+      expect(result.installed).toEqual(['publishing']);
+      expect(result.installedRules).toHaveLength(2);
+      expect(result.installedRules).toEqual(
+        expect.arrayContaining([
+          { agentId: 'publishing', ruleSuffix: 'apps' },
+          { agentId: 'publishing', ruleSuffix: 'cli' }
+        ])
+      );
+      expect(
+        fs.existsSync(path.join(tmpDir, '.codex', 'rules', 'publishing-cli.md'))
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(tmpDir, '.codex', 'rules', 'publishing-apps.md')
+        )
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(tmpDir, '.codex', 'rules', 'publishing-web.md'))
+      ).toBe(false);
+      expect(
+        fs.existsSync(path.join(tmpDir, '.codex', 'rules', 'publishing-api.md'))
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(tmpDir, '.codex', 'rules', 'publishing-libraries.md')
+        )
+      ).toBe(false);
+
+      const agentsMd = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+      expect(agentsMd).toContain('`.codex/rules/publishing-cli.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-apps.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-web.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-api.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-libraries.md`');
+    });
+
     test('adds to errors for unknown agent and continues with valid ones', () => {
       const result = install({
         projectRoot: tmpDir,
@@ -2192,6 +2246,78 @@ Read and follow these rule files in \`.codex/rules/\` when they apply:
       expect(errorSpy).toHaveBeenCalledWith(
         'Invalid --deployment-model value: "kuberntes". Valid values: none, kubernetes, serverless, server, hosted'
       );
+    });
+
+    test('installs all publishing profiles when no publishingProfiles are configured', async () => {
+      const exitCode = await runInstall({
+        projectRoot: tmpDir,
+        target: 'codex',
+        agents: ['publishing'],
+        yes: true
+      });
+
+      expect(exitCode).toBe(0);
+      for (const suffix of [
+        'cli',
+        'apps',
+        'web',
+        'api',
+        'libraries',
+        'sdks',
+        'apt',
+        'brew'
+      ]) {
+        expect(
+          fs.existsSync(
+            path.join(tmpDir, '.codex', 'rules', `publishing-${suffix}.md`)
+          )
+        ).toBe(true);
+      }
+      const agentsMd = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+      expect(agentsMd).toContain('`.codex/rules/publishing-web.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-brew.md`');
+    });
+
+    test('installs and lists only configured publishing profiles', async () => {
+      saveConfig(
+        {
+          targets: ['codex'],
+          agents: ['publishing'],
+          publishingProfiles: ['cli', 'apps']
+        },
+        tmpDir
+      );
+
+      const exitCode = await runInstall({
+        projectRoot: tmpDir,
+        yes: true
+      });
+
+      expect(exitCode).toBe(0);
+      expect(
+        fs.existsSync(path.join(tmpDir, '.codex', 'rules', 'publishing-cli.md'))
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(tmpDir, '.codex', 'rules', 'publishing-apps.md')
+        )
+      ).toBe(true);
+      for (const suffix of ['web', 'api', 'libraries', 'sdks', 'apt', 'brew']) {
+        expect(
+          fs.existsSync(
+            path.join(tmpDir, '.codex', 'rules', `publishing-${suffix}.md`)
+          )
+        ).toBe(false);
+      }
+      const agentsMd = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+      expect(agentsMd).toContain('`.codex/rules/publishing-cli.md`');
+      expect(agentsMd).toContain('`.codex/rules/publishing-apps.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-web.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-api.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-libraries.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-sdks.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-apt.md`');
+      expect(agentsMd).not.toContain('`.codex/rules/publishing-brew.md`');
     });
 
     test('prompts for deploymentModel when publishing is selected interactively', async () => {

--- a/packages/ballast-typescript/src/install.ts
+++ b/packages/ballast-typescript/src/install.ts
@@ -42,7 +42,8 @@ import {
   DEFAULT_DEPLOYMENT_MODEL,
   type Target,
   type TaskSystem,
-  type DeploymentModel
+  type DeploymentModel,
+  type PublishingProfile
 } from './config';
 import { BALLAST_VERSION } from './version';
 
@@ -304,6 +305,7 @@ export interface InstallOptions {
   saveConfig?: boolean;
   taskSystem?: TaskSystem;
   deploymentModel?: DeploymentModel;
+  publishingProfiles?: PublishingProfile[];
 }
 
 export interface InstallResult {
@@ -327,8 +329,13 @@ function resolveSupportFileSelections(
   projectRoot: string,
   language: Language,
   fallbackAgents: string[],
-  fallbackSkills: string[]
-): { agents: string[]; skills: string[] } {
+  fallbackSkills: string[],
+  fallbackPublishingProfiles?: PublishingProfile[]
+): {
+  agents: string[];
+  skills: string[];
+  publishingProfiles?: PublishingProfile[];
+} {
   const config = loadConfig(projectRoot, language);
   const rawAgents = config == null ? fallbackAgents : config.agents;
   const rawSkills =
@@ -339,7 +346,8 @@ function resolveSupportFileSelections(
         : [];
   return {
     agents: [...new Set(withImplicitAgents(rawAgents))],
-    skills: [...new Set(rawSkills)]
+    skills: [...new Set(rawSkills)],
+    publishingProfiles: config?.publishingProfiles ?? fallbackPublishingProfiles
   };
 }
 
@@ -554,7 +562,8 @@ export function install(options: InstallOptions): InstallResult {
     skipSupportFiles = [],
     saveConfig: persist,
     taskSystem,
-    deploymentModel
+    deploymentModel,
+    publishingProfiles
   } = options;
   const effectiveAgents = withImplicitAgents(agents);
   const installed: string[] = [];
@@ -594,6 +603,8 @@ export function install(options: InstallOptions): InstallResult {
     deploymentModel ??
     existingConfig?.deploymentModel ??
     DEFAULT_DEPLOYMENT_MODEL;
+  const resolvedPublishingProfiles =
+    publishingProfiles ?? existingConfig?.publishingProfiles;
 
   if (persist) {
     saveConfig(
@@ -608,7 +619,10 @@ export function install(options: InstallOptions): InstallResult {
           : (taskSystem ?? existingConfig?.taskSystem),
         deploymentModel: effectiveAgents.includes('publishing')
           ? resolvedDeploymentModel
-          : (deploymentModel ?? existingConfig?.deploymentModel)
+          : (deploymentModel ?? existingConfig?.deploymentModel),
+        publishingProfiles: effectiveAgents.includes('publishing')
+          ? resolvedPublishingProfiles
+          : (publishingProfiles ?? existingConfig?.publishingProfiles)
       },
       projectRoot
     );
@@ -618,7 +632,8 @@ export function install(options: InstallOptions): InstallResult {
     projectRoot,
     language,
     effectiveAgents,
-    skills
+    skills,
+    resolvedPublishingProfiles
   );
   const skippedSupportSet = new Set(skipSupportFiles);
 
@@ -631,7 +646,11 @@ export function install(options: InstallOptions): InstallResult {
     let agentSkipped = false;
     let agentProcessed = false;
     try {
-      const suffixes = listRuleSuffixes(agentId, language);
+      const suffixes = listRuleSuffixes(
+        agentId,
+        language,
+        resolvedPublishingProfiles
+      );
       for (const ruleSuffix of suffixes) {
         const { dir, file } = getDestination(
           agentId,
@@ -772,7 +791,8 @@ export function install(options: InstallOptions): InstallResult {
         const content = buildClaudeMd(
           supportSelections.agents,
           supportSelections.skills,
-          language
+          language,
+          supportSelections.publishingProfiles
         );
         const nextContent =
           fs.existsSync(claudeMdPath) && !force && shouldPatchClaudeMd
@@ -806,7 +826,8 @@ export function install(options: InstallOptions): InstallResult {
         const content = buildGeminiMd(
           supportSelections.agents,
           supportSelections.skills,
-          language
+          language,
+          supportSelections.publishingProfiles
         );
         const nextContent =
           fs.existsSync(geminiMdPath) && !force && shouldPatchGeminiMd
@@ -838,7 +859,8 @@ export function install(options: InstallOptions): InstallResult {
         const content = buildCodexAgentsMd(
           supportSelections.agents,
           supportSelections.skills,
-          language
+          language,
+          supportSelections.publishingProfiles
         );
         const nextContent =
           fs.existsSync(agentsMdPath) && !force
@@ -887,6 +909,7 @@ export interface RunInstallOptions {
   yes?: boolean;
   taskSystem?: string;
   deploymentModel?: string;
+  publishingProfiles?: PublishingProfile[];
   repositoryFactsFile?: string;
 }
 
@@ -1022,6 +1045,8 @@ export async function runInstall(
       resolvedDeploymentModel = await promptDeploymentModel();
     }
   }
+  const resolvedPublishingProfiles =
+    options.publishingProfiles ?? priorConfig?.publishingProfiles;
 
   const explicitAgentSelection =
     Boolean(options.all) || options.agents !== undefined;
@@ -1053,7 +1078,8 @@ export async function runInstall(
       ballastVersion: BALLAST_VERSION,
       languages: [language],
       taskSystem: resolvedTaskSystem,
-      deploymentModel: resolvedDeploymentModel
+      deploymentModel: resolvedDeploymentModel,
+      publishingProfiles: resolvedPublishingProfiles
     },
     projectRoot
   );
@@ -1081,7 +1107,8 @@ export async function runInstall(
         : [],
       saveConfig: false,
       taskSystem: resolvedTaskSystem,
-      deploymentModel: resolvedDeploymentModel
+      deploymentModel: resolvedDeploymentModel,
+      publishingProfiles: resolvedPublishingProfiles
     });
 
     if (result.errors.length > 0) {


### PR DESCRIPTION
## Summary

- Add Python task-system install parity, including `tasks` support, `--task-system`, persisted `taskSystem`, default `github`, `none`, and stale task-rule refresh when the task system changes.
- Add TypeScript `publishingProfiles` config support so publishing can install/list only selected profiles while preserving the legacy full publishing pack when omitted.
- Add activation/reference-only language for conditional publishing and task-system rules across TypeScript, Python, Go, synced package content, and generated checked-in Codex/Claude outputs.

Closes #238.
Closes #239.
Closes #240.

## Validation

- [x] Tests or checks run: `PYTHONPATH=/tmp/ballast-followups/packages/ballast-python python3 -m unittest packages.ballast-python.tests.test_cli`; `go test ./cmd/ballast-go` from `packages/ballast-go`; `pnpm test -- --runTestsByPath src/config.test.ts src/build.test.ts src/install.test.ts` from `packages/ballast-typescript`; pre-push hooks passed.
- [x] Docs updated or not needed: `README.md` and `ARCHITECTURE.md` document `publishingProfiles`.
- [x] Generated files updated or not needed: regenerated checked-in `.codex/rules/**` and `.claude/rules/**` outputs for affected activation guidance.

## Agent Notes

- Related issue/PRD: #238, #239, #240.
- Risk level: Medium; changes touch install/config behavior plus generated rule text across multiple language packages.
- Follow-up needed: None expected; PR checks should validate the full matrix.