### PR TITLE
Detect doctor config drift

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -313,6 +313,7 @@ Ballast refreshes saved installs from `.rulesrc.json`, but removing managed agen
 ### Problem
 
 Operators use `ballast doctor` to inspect the effective Ballast state for a repository, but the current report omits the saved `languages` and `paths` from `.rulesrc.json`. This makes it hard to confirm which language profiles Ballast considers installed in monorepos or mixed-language repos.
+Operators also need to know when saved language paths have drifted from the repository, such as when a configured target directory was deleted, renamed, or when a new language profile was added after Ballast was installed.
 
 ### Requirements
 
@@ -321,6 +322,9 @@ Operators use `ballast doctor` to inspect the effective Ballast state for a repo
 3. `ballast doctor` must display configured `taskSystem` when `.rulesrc.json` contains it.
 4. The change must apply consistently across the TypeScript, Python, Go, and wrapper CLIs.
 5. Existing `doctor` output for targets, agents, skills, installed CLIs, and recommendations must remain intact.
+6. The wrapper `ballast doctor` report must identify configured language paths that are missing from disk or no longer match detected language profiles.
+7. The wrapper `ballast doctor` report must identify detected language profiles that are not saved in `.rulesrc.json`, including newly added directories and newly added languages.
+8. `ballast doctor --fix` must refresh saved `languages` and `paths` from current repository detection before reapplying the saved install configuration when current detection can produce a supported profile set.
 
 ### Acceptance Criteria
 
@@ -329,6 +333,10 @@ Operators use `ballast doctor` to inspect the effective Ballast state for a repo
 3. Given a `.rulesrc.json` with `taskSystem`, `ballast doctor` prints a `- taskSystem: ...` line in the `Config:` section.
 4. Given a `.rulesrc.json` without `languages`, `paths`, or `taskSystem`, `ballast doctor` does not print empty placeholder lines for those fields.
 5. Automated tests cover the new output in each CLI implementation that renders `doctor` output.
+6. Given a configured path that no longer exists, wrapper `ballast doctor` prints a config drift line that names the missing language path and recommends `ballast doctor --fix`.
+7. Given a repo where current detection finds a profile path not saved in `.rulesrc.json`, wrapper `ballast doctor` prints a config drift line that names the untracked detected profile.
+8. Given a repo where current detection finds a language not saved in `.rulesrc.json`, wrapper `ballast doctor` prints a config drift line that names the untracked detected language.
+9. Given stale saved TypeScript paths and a current detected TypeScript path, wrapper `ballast doctor --fix` rewrites `.rulesrc.json` to the detected path before refreshing generated outputs.
 
 ## JavaScript Detection Warning
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -881,6 +881,17 @@ func runDoctorFixWithVersion(root string, selectedLanguage language, patch bool,
 	if !fileExists(filepath.Join(root, ".rulesrc.json")) {
 		return 0
 	}
+	configPath := filepath.Join(root, ".rulesrc.json")
+	originalConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+	configInfo, err := os.Stat(configPath)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
 	if err := refreshDoctorConfigProfiles(root, selectedLanguage); err != nil {
 		fmt.Println(err)
 		return 1
@@ -898,6 +909,9 @@ func runDoctorFixWithVersion(root string, selectedLanguage language, patch bool,
 	}
 	exitCode := run(refreshArgs)
 	if exitCode != 0 {
+		if err := os.WriteFile(configPath, originalConfig, configInfo.Mode().Perm()); err != nil {
+			fmt.Println(err)
+		}
 		return exitCode
 	}
 	if desiredVersion != "" {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -175,6 +175,14 @@ type ballastLocalState struct {
 	ToolsStatus string
 }
 
+type doctorConfigDrift struct {
+	MissingConfiguredPaths  []string
+	StaleConfiguredProfiles []string
+	UntrackedProfiles       []string
+	UntrackedLanguages      []string
+	ScanError               error
+}
+
 const (
 	localStatePresent    = "present"
 	localStateMissing    = "missing"
@@ -873,6 +881,10 @@ func runDoctorFixWithVersion(root string, selectedLanguage language, patch bool,
 	if !fileExists(filepath.Join(root, ".rulesrc.json")) {
 		return 0
 	}
+	if err := refreshDoctorConfigProfiles(root, selectedLanguage); err != nil {
+		fmt.Println(err)
+		return 1
+	}
 
 	refreshArgs := []string{"install", "--refresh-config"}
 	if patch {
@@ -986,7 +998,205 @@ func printDoctorSummary(root string, selectedLanguage language, fix bool) {
 	if strings.TrimSpace(config.DeploymentModel) != "" {
 		fmt.Printf("- deploymentModel: %s\n", config.DeploymentModel)
 	}
+	printDoctorConfigDrift(root, config)
 	fmt.Println()
+}
+
+func printDoctorConfigDrift(root string, config *monorepoConfig) {
+	drift := analyzeDoctorConfigDrift(root, config)
+	if !drift.hasDrift() && drift.ScanError == nil {
+		return
+	}
+	fmt.Println()
+	fmt.Println("Config drift:")
+	if drift.ScanError != nil {
+		fmt.Printf("- scan error: %v\n", drift.ScanError)
+		return
+	}
+	for _, item := range drift.MissingConfiguredPaths {
+		fmt.Printf("- missing configured path: %s\n", item)
+	}
+	for _, item := range drift.StaleConfiguredProfiles {
+		fmt.Printf("- stale configured profile: %s\n", item)
+	}
+	for _, item := range drift.UntrackedProfiles {
+		fmt.Printf("- untracked detected profile: %s\n", item)
+	}
+	for _, item := range drift.UntrackedLanguages {
+		fmt.Printf("- untracked detected language: %s\n", item)
+	}
+	fmt.Println("- remediation: Run `ballast doctor --fix` to refresh saved languages and paths from current repository detection.")
+}
+
+func (drift doctorConfigDrift) hasDrift() bool {
+	return len(drift.MissingConfiguredPaths) > 0 ||
+		len(drift.StaleConfiguredProfiles) > 0 ||
+		len(drift.UntrackedProfiles) > 0 ||
+		len(drift.UntrackedLanguages) > 0
+}
+
+func analyzeDoctorConfigDrift(root string, config *monorepoConfig) doctorConfigDrift {
+	if config == nil {
+		return doctorConfigDrift{}
+	}
+	detected, err := detectRepoProfiles(root)
+	if err != nil {
+		return doctorConfigDrift{ScanError: err}
+	}
+	detectedPaths := profileRelativePathMap(root, detected)
+	configuredPaths := normalizedConfigPathMap(config)
+	configuredLanguages := configuredLanguageSet(config)
+	drift := doctorConfigDrift{}
+
+	for _, lang := range orderedConfigPathLanguages(config) {
+		for _, configuredPath := range configuredPaths[lang] {
+			if !fileExists(filepath.Join(root, configuredPath)) {
+				drift.MissingConfiguredPaths = append(drift.MissingConfiguredPaths, string(lang)+"="+configuredPath)
+				continue
+			}
+			if !stringSliceContains(detectedPaths[lang], configuredPath) {
+				drift.StaleConfiguredProfiles = append(drift.StaleConfiguredProfiles, string(lang)+"="+configuredPath)
+			}
+		}
+	}
+
+	for _, profile := range detected {
+		paths := detectedPaths[profile.Language]
+		if !configuredLanguages[profile.Language] {
+			drift.UntrackedLanguages = append(drift.UntrackedLanguages, string(profile.Language)+"="+strings.Join(paths, ","))
+			continue
+		}
+		for _, detectedPath := range paths {
+			if !stringSliceContains(configuredPaths[profile.Language], detectedPath) {
+				drift.UntrackedProfiles = append(drift.UntrackedProfiles, string(profile.Language)+"="+detectedPath)
+			}
+		}
+	}
+	return drift
+}
+
+func refreshDoctorConfigProfiles(root string, selectedLanguage language) error {
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		return err
+	}
+	if config == nil {
+		return nil
+	}
+	detected, err := detectRepoProfiles(root)
+	if err != nil {
+		return err
+	}
+	if len(detected) == 0 {
+		return nil
+	}
+	if selectedLanguage == "" {
+		config.Languages = make([]string, 0, len(detected))
+		config.Paths = map[string][]string{}
+	}
+	for _, profile := range detected {
+		if selectedLanguage != "" && profile.Language != selectedLanguage {
+			continue
+		}
+		if selectedLanguage != "" && !slices.Contains(config.Languages, string(profile.Language)) {
+			config.Languages = append(config.Languages, string(profile.Language))
+		}
+		if config.Paths == nil {
+			config.Paths = map[string][]string{}
+		}
+		if selectedLanguage == "" {
+			config.Languages = append(config.Languages, string(profile.Language))
+		}
+		config.Paths[string(profile.Language)] = relativePaths(root, profile.Paths)
+	}
+	return saveMonorepoConfig(root, *config)
+}
+
+func profileRelativePathMap(root string, profiles []repoProfile) map[language][]string {
+	paths := map[language][]string{}
+	for _, profile := range profiles {
+		paths[profile.Language] = relativePaths(root, profile.Paths)
+	}
+	return paths
+}
+
+func normalizedConfigPathMap(config *monorepoConfig) map[language][]string {
+	paths := map[language][]string{}
+	if config == nil {
+		return paths
+	}
+	for rawLanguage, rawPaths := range config.Paths {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if !isSupportedLanguage(lang) {
+			continue
+		}
+		for _, rawPath := range rawPaths {
+			if strings.TrimSpace(rawPath) == "" {
+				continue
+			}
+			paths[lang] = append(paths[lang], filepath.Clean(rawPath))
+		}
+		paths[lang] = uniqueStrings(paths[lang])
+	}
+	return paths
+}
+
+func configuredLanguageSet(config *monorepoConfig) map[language]bool {
+	languages := map[language]bool{}
+	if config == nil {
+		return languages
+	}
+	for _, rawLanguage := range config.Languages {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if isSupportedLanguage(lang) {
+			languages[lang] = true
+		}
+	}
+	for rawLanguage := range config.Paths {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if isSupportedLanguage(lang) {
+			languages[lang] = true
+		}
+	}
+	return languages
+}
+
+func orderedConfigPathLanguages(config *monorepoConfig) []language {
+	if config == nil {
+		return nil
+	}
+	paths := normalizedConfigPathMap(config)
+	ordered := []language{}
+	seen := map[language]bool{}
+	for _, rawLanguage := range config.Languages {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if !isSupportedLanguage(lang) || len(paths[lang]) == 0 || seen[lang] {
+			continue
+		}
+		ordered = append(ordered, lang)
+		seen[lang] = true
+	}
+	remaining := []string{}
+	for lang, values := range paths {
+		if seen[lang] || len(values) == 0 {
+			continue
+		}
+		remaining = append(remaining, string(lang))
+	}
+	sort.Strings(remaining)
+	for _, rawLanguage := range remaining {
+		ordered = append(ordered, language(rawLanguage))
+	}
+	return ordered
+}
+
+func stringSliceContains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func printDoctorLocalState(root string) {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1131,14 +1131,27 @@ func normalizedConfigPathMap(config *monorepoConfig) map[language][]string {
 			continue
 		}
 		for _, rawPath := range rawPaths {
-			if strings.TrimSpace(rawPath) == "" {
+			normalizedPath, ok := normalizeConfigRelativePath(rawPath)
+			if !ok {
 				continue
 			}
-			paths[lang] = append(paths[lang], filepath.Clean(rawPath))
+			paths[lang] = append(paths[lang], normalizedPath)
 		}
 		paths[lang] = uniqueStrings(paths[lang])
 	}
 	return paths
+}
+
+func normalizeConfigRelativePath(rawPath string) (string, bool) {
+	trimmed := strings.TrimSpace(rawPath)
+	if trimmed == "" || filepath.IsAbs(trimmed) {
+		return "", false
+	}
+	cleaned := filepath.Clean(trimmed)
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return cleaned, true
 }
 
 func configuredLanguageSet(config *monorepoConfig) map[language]bool {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1107,6 +1107,8 @@ func refreshDoctorConfigProfiles(root string, selectedLanguage language) error {
 	if selectedLanguage == "" {
 		config.Languages = make([]string, 0, len(detected))
 		config.Paths = map[string][]string{}
+	} else {
+		normalizeDoctorConfigProfiles(config)
 	}
 	for _, profile := range detected {
 		if selectedLanguage != "" && profile.Language != selectedLanguage {
@@ -1124,6 +1126,43 @@ func refreshDoctorConfigProfiles(root string, selectedLanguage language) error {
 		config.Paths[string(profile.Language)] = relativePaths(root, profile.Paths)
 	}
 	return saveMonorepoConfig(root, *config)
+}
+
+func normalizeDoctorConfigProfiles(config *monorepoConfig) {
+	if config == nil {
+		return
+	}
+	languages := make([]string, 0, len(config.Languages))
+	seenLanguages := map[string]bool{}
+	for _, rawLanguage := range config.Languages {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if !isSupportedLanguage(lang) || seenLanguages[string(lang)] {
+			continue
+		}
+		languages = append(languages, string(lang))
+		seenLanguages[string(lang)] = true
+	}
+	paths := map[string][]string{}
+	for rawLanguage, rawPaths := range config.Paths {
+		lang := language(strings.ToLower(strings.TrimSpace(rawLanguage)))
+		if !isSupportedLanguage(lang) {
+			continue
+		}
+		for _, rawPath := range rawPaths {
+			normalizedPath, ok := normalizeConfigRelativePath(rawPath)
+			if !ok {
+				continue
+			}
+			paths[string(lang)] = append(paths[string(lang)], normalizedPath)
+		}
+		paths[string(lang)] = uniqueStrings(paths[string(lang)])
+		if !seenLanguages[string(lang)] {
+			languages = append(languages, string(lang))
+			seenLanguages[string(lang)] = true
+		}
+	}
+	config.Languages = languages
+	config.Paths = paths
 }
 
 func profileRelativePathMap(root string, profiles []repoProfile) map[language][]string {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -332,6 +332,118 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 }
 
+func TestRunDoctorReportsConfigProfileDrift(t *testing.T) {
+	originalCollect := collectDoctorBackendsFunc
+	t.Cleanup(func() {
+		collectDoctorBackendsFunc = originalCollect
+	})
+
+	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
+		return []doctorBackendStatus{
+			{Name: "ballast-typescript", Version: "5.0.2", Location: "/tmp/ts", Found: true},
+			{Name: "ballast-python", Version: "5.0.2", Location: "/tmp/py", Found: true},
+			{Name: "ballast-go", Version: "5.0.2", Location: "/tmp/go", Found: true},
+		}
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["examples/chat-ts"]}
+}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"doctor"})
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+		})
+	})
+
+	for _, expected := range []string{
+		"Config drift:",
+		"- missing configured path: typescript=examples/chat-ts",
+		"- untracked detected profile: typescript=examples/web/ui",
+		"- untracked detected language: python=services/api",
+		"Run `ballast doctor --fix` to refresh saved languages and paths from current repository detection.",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in doctor output, got %q", expected, output)
+		}
+	}
+}
+
+func TestRunDoctorReportsStaleConfiguredProfile(t *testing.T) {
+	originalCollect := collectDoctorBackendsFunc
+	t.Cleanup(func() {
+		collectDoctorBackendsFunc = originalCollect
+	})
+
+	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
+		return []doctorBackendStatus{{Name: "ballast-typescript", Version: "5.0.2", Location: "/tmp/ts", Found: true}}
+	}
+
+	root := resolvedTempDir(t)
+	if err := os.MkdirAll(filepath.Join(root, "legacy", "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(root, "apps", "web", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["legacy/web"]}
+}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"doctor"})
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+		})
+	})
+
+	if !strings.Contains(output, "- stale configured profile: typescript=legacy/web") {
+		t.Fatalf("expected stale configured profile in doctor output, got %q", output)
+	}
+	if !strings.Contains(output, "- untracked detected profile: typescript=apps/web") {
+		t.Fatalf("expected untracked detected profile in doctor output, got %q", output)
+	}
+}
+
+func TestPrintDoctorConfigDriftReportsScanError(t *testing.T) {
+	originalWalk := walkDirFunc
+	t.Cleanup(func() {
+		walkDirFunc = originalWalk
+	})
+	walkDirFunc = func(root string, fn fs.WalkDirFunc) error {
+		return errors.New("scan failed")
+	}
+
+	root := resolvedTempDir(t)
+	output := captureStdout(t, func() {
+		printDoctorConfigDrift(root, &monorepoConfig{
+			Languages: []string{"typescript"},
+			Paths:     map[string][]string{"typescript": {"apps/web"}},
+		})
+	})
+
+	if !strings.Contains(output, "Config drift:") {
+		t.Fatalf("expected config drift heading, got %q", output)
+	}
+	if !strings.Contains(output, "- scan error: scan repo for language profiles: scan failed") {
+		t.Fatalf("expected scan error in config drift output, got %q", output)
+	}
+}
+
 func TestRunDoctorReportsMissingBallastState(t *testing.T) {
 	originalCollect := collectDoctorBackendsFunc
 	t.Cleanup(func() {
@@ -529,6 +641,173 @@ func TestRunDoctorFixInstallsBackendsAndRefreshesConfig(t *testing.T) {
 	}
 	if got := strings.Join(invocation.Args, " "); !strings.Contains(got, "install --yes") {
 		t.Fatalf("expected refresh-config install invocation, got %q", got)
+	}
+}
+
+func TestRunDoctorFixRefreshesConfigProfilesBeforeInstall(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.2"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/project\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript","go"],
+  "paths":{
+    "typescript":["examples/chat-ts","examples/chat-web"],
+    "go":["."]
+  }
+}`)
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"doctor", "--fix"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		t.Fatalf("loadDoctorConfig returned error: %v", err)
+	}
+	if config == nil {
+		t.Fatal("expected .rulesrc.json to remain present")
+	}
+	if !sameStringSet(config.Languages, []string{"typescript", "go"}) {
+		t.Fatalf("expected languages to match detected profiles, got %#v", config.Languages)
+	}
+	if got := config.Paths["typescript"]; !sameStringSet(got, []string{"examples/web/ui"}) {
+		t.Fatalf("expected doctor --fix to replace stale TypeScript paths, got %#v", got)
+	}
+	if got := config.Paths["go"]; !sameStringSet(got, []string{"."}) {
+		t.Fatalf("expected doctor --fix to preserve detected Go path, got %#v", got)
+	}
+}
+
+func TestRefreshDoctorConfigProfilesSelectedLanguageOnly(t *testing.T) {
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/project\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["examples/chat-ts"]}
+}`)
+
+	if err := refreshDoctorConfigProfiles(root, langGo); err != nil {
+		t.Fatalf("refreshDoctorConfigProfiles returned error: %v", err)
+	}
+
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		t.Fatalf("loadDoctorConfig returned error: %v", err)
+	}
+	if config == nil {
+		t.Fatal("expected .rulesrc.json to remain present")
+	}
+	if !sameStringSet(config.Languages, []string{"typescript", "go"}) {
+		t.Fatalf("expected selected language to be added without dropping existing languages, got %#v", config.Languages)
+	}
+	if got := config.Paths["typescript"]; !sameStringSet(got, []string{"examples/chat-ts"}) {
+		t.Fatalf("expected TypeScript paths to be left unchanged, got %#v", got)
+	}
+	if got := config.Paths["go"]; !sameStringSet(got, []string{"."}) {
+		t.Fatalf("expected Go path to be refreshed, got %#v", got)
+	}
+}
+
+func TestRefreshDoctorConfigProfilesHandlesNoConfigNoProfilesAndScanErrors(t *testing.T) {
+	root := resolvedTempDir(t)
+	if err := refreshDoctorConfigProfiles(root, ""); err != nil {
+		t.Fatalf("expected missing config to be ignored, got %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["apps/web"]}
+}`)
+	if err := refreshDoctorConfigProfiles(root, ""); err != nil {
+		t.Fatalf("expected no detected profiles to be ignored, got %v", err)
+	}
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		t.Fatalf("loadDoctorConfig returned error: %v", err)
+	}
+	if config == nil || !sameStringSet(config.Paths["typescript"], []string{"apps/web"}) {
+		t.Fatalf("expected config to remain unchanged when no profiles are detected, got %#v", config)
+	}
+
+	originalWalk := walkDirFunc
+	t.Cleanup(func() {
+		walkDirFunc = originalWalk
+	})
+	walkDirFunc = func(root string, fn fs.WalkDirFunc) error {
+		return errors.New("scan failed")
+	}
+	if err := refreshDoctorConfigProfiles(root, ""); err == nil || !strings.Contains(err.Error(), "scan failed") {
+		t.Fatalf("expected scan error from refreshDoctorConfigProfiles, got %v", err)
+	}
+}
+
+func TestDoctorConfigDriftHelpersNormalizeAndOrderPaths(t *testing.T) {
+	if got := normalizedConfigPathMap(nil); len(got) != 0 {
+		t.Fatalf("expected nil config to produce no normalized paths, got %#v", got)
+	}
+	if got := configuredLanguageSet(nil); len(got) != 0 {
+		t.Fatalf("expected nil config to produce no configured languages, got %#v", got)
+	}
+	if got := orderedConfigPathLanguages(nil); len(got) != 0 {
+		t.Fatalf("expected nil config to produce no ordered path languages, got %#v", got)
+	}
+
+	config := &monorepoConfig{
+		Languages: []string{"ruby", "typescript", "typescript"},
+		Paths: map[string][]string{
+			"go":         {"."},
+			"ruby":       {"ignored"},
+			"typescript": {"", "apps//web", "apps/web"},
+		},
+	}
+
+	paths := normalizedConfigPathMap(config)
+	if got := paths[langTypeScript]; !sameStringSet(got, []string{"apps/web"}) {
+		t.Fatalf("expected TypeScript paths to be cleaned and deduplicated, got %#v", got)
+	}
+	if _, ok := paths[language("ruby")]; ok {
+		t.Fatalf("expected unsupported language paths to be ignored, got %#v", paths)
+	}
+
+	languages := configuredLanguageSet(config)
+	if !languages[langTypeScript] || !languages[langGo] || languages[language("ruby")] {
+		t.Fatalf("expected supported languages from both language list and paths, got %#v", languages)
+	}
+
+	ordered := orderedConfigPathLanguages(config)
+	if !reflect.DeepEqual(ordered, []language{langTypeScript, langGo}) {
+		t.Fatalf("expected configured languages first with remaining sorted, got %#v", ordered)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -702,6 +702,53 @@ func TestRunDoctorFixRefreshesConfigProfilesBeforeInstall(t *testing.T) {
 	}
 }
 
+func TestRunDoctorFixRestoresConfigWhenRefreshInstallFails(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.2"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 42, nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	configPath := filepath.Join(root, ".rulesrc.json")
+	originalConfig := `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["examples/chat-ts"]}
+}`
+	mustWriteFile(t, configPath, originalConfig)
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"doctor", "--fix"})
+		if exitCode != 42 {
+			t.Fatalf("expected backend refresh exit code 42, got %d", exitCode)
+		}
+	})
+
+	restoredConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(restoredConfig) != originalConfig {
+		t.Fatalf("expected failed doctor --fix to restore original config\nwant:\n%s\ngot:\n%s", originalConfig, restoredConfig)
+	}
+}
+
 func TestRefreshDoctorConfigProfilesSelectedLanguageOnly(t *testing.T) {
 	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/project\n\ngo 1.24\n")

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -757,8 +757,8 @@ func TestRefreshDoctorConfigProfilesSelectedLanguageOnly(t *testing.T) {
   "ballastVersion":"5.0.2",
   "targets":["codex"],
   "agents":["linting"],
-  "languages":["typescript"],
-  "paths":{"typescript":["examples/chat-ts"]}
+  "languages":[" TypeScript ","Go"],
+  "paths":{" TypeScript ":[" examples/chat-ts ","../outside"],"Go":["old-go"]}
 }`)
 
 	if err := refreshDoctorConfigProfiles(root, langGo); err != nil {
@@ -780,6 +780,9 @@ func TestRefreshDoctorConfigProfilesSelectedLanguageOnly(t *testing.T) {
 	}
 	if got := config.Paths["go"]; !sameStringSet(got, []string{"."}) {
 		t.Fatalf("expected Go path to be refreshed, got %#v", got)
+	}
+	if _, ok := config.Paths["Go"]; ok {
+		t.Fatalf("expected selected language refresh to normalize mixed-case path keys, got %#v", config.Paths)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -332,6 +332,53 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 }
 
+func TestRunDoctorReportsConfigProfileDrift(t *testing.T) {
+	originalCollect := collectDoctorBackendsFunc
+	t.Cleanup(func() {
+		collectDoctorBackendsFunc = originalCollect
+	})
+
+	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
+		return []doctorBackendStatus{
+			{Name: "ballast-typescript", Version: "5.0.2", Location: "/tmp/ts", Found: true},
+			{Name: "ballast-python", Version: "5.0.2", Location: "/tmp/py", Found: true},
+			{Name: "ballast-go", Version: "5.0.2", Location: "/tmp/go", Found: true},
+		}
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript"],
+  "paths":{"typescript":["examples/chat-ts"]}
+}`)
+
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"doctor"})
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d", exitCode)
+			}
+		})
+	})
+
+	for _, expected := range []string{
+		"Config drift:",
+		"- missing configured path: typescript=examples/chat-ts",
+		"- untracked detected profile: typescript=examples/web/ui",
+		"- untracked detected language: python=services/api",
+		"Run `ballast doctor --fix` to refresh saved languages and paths from current repository detection.",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in doctor output, got %q", expected, output)
+		}
+	}
+}
+
 func TestRunDoctorReportsMissingBallastState(t *testing.T) {
 	originalCollect := collectDoctorBackendsFunc
 	t.Cleanup(func() {
@@ -529,6 +576,64 @@ func TestRunDoctorFixInstallsBackendsAndRefreshesConfig(t *testing.T) {
 	}
 	if got := strings.Join(invocation.Args, " "); !strings.Contains(got, "install --yes") {
 		t.Fatalf("expected refresh-config install invocation, got %q", got)
+	}
+}
+
+func TestRunDoctorFixRefreshesConfigProfilesBeforeInstall(t *testing.T) {
+	originalRun := runCommandFunc
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+		version = originalVersion
+	})
+	version = "5.0.2"
+
+	runCommandFunc = func(name string, args []string) error { return nil }
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "go.mod"), "module example.com/project\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, "examples", "web", "ui", "tsconfig.json"), "{}")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "ballastVersion":"5.0.2",
+  "targets":["codex"],
+  "agents":["linting"],
+  "languages":["typescript","go"],
+  "paths":{
+    "typescript":["examples/chat-ts","examples/chat-web"],
+    "go":["."]
+  }
+}`)
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"doctor", "--fix"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		t.Fatalf("loadDoctorConfig returned error: %v", err)
+	}
+	if config == nil {
+		t.Fatal("expected .rulesrc.json to remain present")
+	}
+	if !sameStringSet(config.Languages, []string{"typescript", "go"}) {
+		t.Fatalf("expected languages to match detected profiles, got %#v", config.Languages)
+	}
+	if got := config.Paths["typescript"]; !sameStringSet(got, []string{"examples/web/ui"}) {
+		t.Fatalf("expected doctor --fix to replace stale TypeScript paths, got %#v", got)
+	}
+	if got := config.Paths["go"]; !sameStringSet(got, []string{"."}) {
+		t.Fatalf("expected doctor --fix to preserve detected Go path, got %#v", got)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -788,7 +788,7 @@ func TestDoctorConfigDriftHelpersNormalizeAndOrderPaths(t *testing.T) {
 		Paths: map[string][]string{
 			"go":         {"."},
 			"ruby":       {"ignored"},
-			"typescript": {"", "apps//web", "apps/web"},
+			"typescript": {"", "/tmp/outside", "../outside", "apps//web", "apps/web"},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add wrapper doctor config-drift reporting for missing configured paths, stale profile paths, untracked detected profiles, and newly detected languages.
- Refresh saved languages and paths during doctor --fix before reapplying the saved install config.
- Update PRD acceptance criteria and add wrapper regression tests for report and fix behavior.

## Validation

- [x] Tests or checks run: go test ./... -covermode=atomic -coverprofile=/tmp/ballast-wrapper-coverage.out in cli/ballast, go test ./... -covermode=atomic -coverprofile=/tmp/ballast-go-coverage.out in packages/ballast-go, go build -o /tmp/ballast-doctor-drift . in cli/ballast, /tmp/ballast-doctor-drift doctor in /home/marka/src/ai-agent-bridge
- [x] Docs updated or not needed: PRD.md updated
- [x] Generated files updated or not needed: not needed; no generated source changed

## Agent Notes

- Related issue/PRD: PRD.md Ballast Doctor Config Visibility
- Risk level: Medium
- Follow-up needed: none known

Coverage review: wrapper coverage is 79.3% overall. New drift functions are covered: analyzeDoctorConfigDrift 92.0%, refreshDoctorConfigProfiles 79.2%, printDoctorConfigDrift 88.2%. The Go backend package was unchanged and reports 72.7%, which appears to be an existing package-level gap outside this wrapper change.