### PR TITLE
Fix doctor backend reporting

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -325,6 +325,7 @@ Operators also need to know when saved language paths have drifted from the repo
 6. The wrapper `ballast doctor` report must identify configured language paths that are missing from disk or no longer match detected language profiles.
 7. The wrapper `ballast doctor` report must identify detected language profiles that are not saved in `.rulesrc.json`, including newly added directories and newly added languages.
 8. `ballast doctor --fix` must refresh saved `languages` and `paths` from current repository detection before reapplying the saved install configuration when current detection can produce a supported profile set.
+9. When `.rulesrc.json` contains configured `languages`, wrapper `ballast doctor` must check only the backend CLIs required by those languages; Ansible and Terraform configurations use the Go backend.
 
 ### Acceptance Criteria
 
@@ -337,6 +338,7 @@ Operators also need to know when saved language paths have drifted from the repo
 7. Given a repo where current detection finds a profile path not saved in `.rulesrc.json`, wrapper `ballast doctor` prints a config drift line that names the untracked detected profile.
 8. Given a repo where current detection finds a language not saved in `.rulesrc.json`, wrapper `ballast doctor` prints a config drift line that names the untracked detected language.
 9. Given stale saved TypeScript paths and a current detected TypeScript path, wrapper `ballast doctor --fix` rewrites `.rulesrc.json` to the detected path before refreshing generated outputs.
+10. Given a `.rulesrc.json` with only `go` configured and a globally installed `ballast-typescript` on `PATH`, wrapper `ballast doctor` does not report the TypeScript backend.
 
 ## JavaScript Detection Warning
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1745,6 +1745,9 @@ func configuredDoctorBackendLanguages(root string) []language {
 		languages = append(languages, lang)
 		seen[lang] = true
 	}
+	if len(languages) == 0 {
+		return slices.Clone(installableBackendLanguages)
+	}
 	return languages
 }
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -1719,13 +1719,44 @@ func resolveCommandVersionWithArgs(binary string, args []string, env map[string]
 }
 
 func collectDoctorBackends(root string) []doctorBackendStatus {
-	statuses := make([]doctorBackendStatus, 0, len(installableBackendLanguages))
-	for _, lang := range installableBackendLanguages {
+	languages := configuredDoctorBackendLanguages(root)
+	statuses := make([]doctorBackendStatus, 0, len(languages))
+	for _, lang := range languages {
 		tool := toolsByLanguage[lang]
 		resolved := resolveBackendCommand(lang, tool, nil, nil)
 		statuses = append(statuses, detectDoctorBackendStatus(resolved, tool))
 	}
 	return statuses
+}
+
+func configuredDoctorBackendLanguages(root string) []language {
+	config, err := loadDoctorConfig(root)
+	if err != nil || config == nil || len(config.Languages) == 0 {
+		return slices.Clone(installableBackendLanguages)
+	}
+
+	languages := make([]language, 0, len(config.Languages))
+	seen := map[language]bool{}
+	for _, configured := range config.Languages {
+		lang := backendLanguageForConfiguredLanguage(language(strings.ToLower(strings.TrimSpace(configured))))
+		if lang == "" || seen[lang] {
+			continue
+		}
+		languages = append(languages, lang)
+		seen[lang] = true
+	}
+	return languages
+}
+
+func backendLanguageForConfiguredLanguage(lang language) language {
+	switch lang {
+	case langTypeScript, langPython, langGo:
+		return lang
+	case langAnsible, langTerraform:
+		return langGo
+	default:
+		return ""
+	}
 }
 
 func detectDoctorBackendStatus(resolved resolvedBackendCommand, tool toolConfig) doctorBackendStatus {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -356,6 +356,18 @@ func TestConfiguredDoctorBackendLanguagesFallsBackWithoutConfig(t *testing.T) {
 	}
 }
 
+func TestConfiguredDoctorBackendLanguagesFallsBackForMalformedConfig(t *testing.T) {
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "languages":["","javascript","ruby"]
+}`)
+
+	got := configuredDoctorBackendLanguages(root)
+	if !slices.Equal(got, installableBackendLanguages) {
+		t.Fatalf("expected fallback backend languages %#v, got %#v", installableBackendLanguages, got)
+	}
+}
+
 func TestRunDoctorReportsConfigProfileDrift(t *testing.T) {
 	originalCollect := collectDoctorBackendsFunc
 	t.Cleanup(func() {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -270,7 +270,7 @@ func TestRunHelpAndVersionCommands(t *testing.T) {
 	})
 }
 
-func TestRunDoctorReportsAllBackends(t *testing.T) {
+func TestRunDoctorReportsConfiguredBackends(t *testing.T) {
 	originalCollect := collectDoctorBackendsFunc
 	t.Cleanup(func() {
 		collectDoctorBackendsFunc = originalCollect
@@ -279,7 +279,6 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	collectDoctorBackendsFunc = func(root string) []doctorBackendStatus {
 		return []doctorBackendStatus{
 			{Name: "ballast-typescript", Version: "5.0.2", Location: "/tmp/ts", Found: true},
-			{Name: "ballast-python", Version: "5.0.2", Location: "/tmp/py", Found: true},
 			{Name: "ballast-go", Version: "5.0.2", Location: "/tmp/go", Found: true},
 		}
 	}
@@ -310,10 +309,13 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	if !strings.Contains(output, "Ballast doctor") {
 		t.Fatalf("expected wrapper doctor output, got %q", output)
 	}
-	for _, name := range []string{"ballast-typescript", "ballast-python", "ballast-go"} {
+	for _, name := range []string{"ballast-typescript", "ballast-go"} {
 		if !strings.Contains(output, name) {
 			t.Fatalf("expected %s in doctor output, got %q", name, output)
 		}
+	}
+	if strings.Contains(output, "ballast-python") {
+		t.Fatalf("did not expect unconfigured python backend in doctor output, got %q", output)
 	}
 	if !strings.Contains(output, "ballastVersion: 5.0.2") {
 		t.Fatalf("expected config version in doctor output, got %q", output)
@@ -329,6 +331,28 @@ func TestRunDoctorReportsAllBackends(t *testing.T) {
 	}
 	if !strings.Contains(output, "deploymentModel: kubernetes") {
 		t.Fatalf("expected config deployment model in doctor output, got %q", output)
+	}
+}
+
+func TestConfiguredDoctorBackendLanguagesUsesConfig(t *testing.T) {
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "languages":["go","typescript","ansible","terraform","python","go"]
+}`)
+
+	got := configuredDoctorBackendLanguages(root)
+	want := []language{langGo, langTypeScript, langPython}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected configured backend languages %#v, got %#v", want, got)
+	}
+}
+
+func TestConfiguredDoctorBackendLanguagesFallsBackWithoutConfig(t *testing.T) {
+	root := resolvedTempDir(t)
+
+	got := configuredDoctorBackendLanguages(root)
+	if !slices.Equal(got, installableBackendLanguages) {
+		t.Fatalf("expected fallback backend languages %#v, got %#v", installableBackendLanguages, got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Filter wrapper doctor backend checks to the backends required by configured languages in .rulesrc.json.
- Map Ansible and Terraform configurations to the Go backend for doctor reporting.
- Update PRD requirements and wrapper tests for configured-backend behavior.

## Validation

- [x] Tests or checks run: `cd cli/ballast && go test ./...`; pre-push unit test hook passed
- [x] Docs updated or not needed: PRD.md updated
- [x] Generated files updated or not needed: not needed

## Agent Notes

- Related issue/PRD: PRD.md Ballast Doctor Config Visibility
- Risk level: Low
- Follow-up needed: None