### PR TITLE
Use rulesrc version for install-cli

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -93,9 +93,11 @@ Ballast stores project-local backend CLIs under `.ballast/`, but the product con
 5. `ballast doctor` must report whether `.ballast/`, `.ballast/bin`, and `.ballast/tools` exist.
 6. `ballast doctor` must provide actionable remediation when `.ballast/` state is missing or incomplete.
 7. `ballast doctor --fix` must recreate missing `.ballast/` directories through the same local CLI install path.
-8. Agent guidance must explain how to check and repair Ballast local state.
-9. Ballast must ship a dedicated common skill for AI agents that covers Ballast-managed repository status, bootstrap, and repair workflows.
-10. Documentation must describe the dedicated Ballast skill and how to install it.
+8. When `ballast install-cli` runs without an explicit `--version`, it must install backend CLIs matching the saved `.rulesrc.json` `ballastVersion` when present, instead of defaulting to the running wrapper version.
+9. When the saved `.rulesrc.json` `ballastVersion` is newer than the running wrapper version, `ballast install-cli` must exit without installing backend CLIs and tell the operator to update Ballast.
+10. Agent guidance must explain how to check and repair Ballast local state.
+11. Ballast must ship a dedicated common skill for AI agents that covers Ballast-managed repository status, bootstrap, and repair workflows.
+12. Documentation must describe the dedicated Ballast skill and how to install it.
 
 ### Acceptance Criteria
 
@@ -103,9 +105,11 @@ Ballast stores project-local backend CLIs under `.ballast/`, but the product con
 2. Given a repository with `.ballast/` but missing `.ballast/bin` or `.ballast/tools`, `ballast doctor` reports the incomplete state and recommends repair.
 3. Given a repository without `.ballast/`, `ballast install-cli --language go --version <version>` creates `.ballast/bin` and `.ballast/tools` before running the install command.
 4. Given a repository without `.ballast/`, `ballast doctor --fix` creates `.ballast/bin` and `.ballast/tools` before running backend install commands.
-5. Generated local-dev guidance tells agents to use `ballast doctor` to inspect Ballast local state and `ballast doctor --fix` or `ballast install-cli` to repair it.
-6. The new Ballast skill is available through `--skill ballast-project-maintenance` and `--all-skills`.
-7. README and installation docs document `.ballast/` as generated local state and list the Ballast project maintenance skill.
+5. Given `.rulesrc.json` contains `ballastVersion: 5.12.0` and the running wrapper is newer, `ballast install-cli` installs backend CLIs at `5.12.0`.
+6. Given `.rulesrc.json` contains a `ballastVersion` newer than the running wrapper, `ballast install-cli` exits non-zero, runs no backend installer, and tells the operator to update Ballast.
+7. Generated local-dev guidance tells agents to use `ballast doctor` to inspect Ballast local state and `ballast doctor --fix` or `ballast install-cli` to repair it.
+8. The new Ballast skill is available through `--skill ballast-project-maintenance` and `--all-skills`.
+9. README and installation docs document `.ballast/` as generated local state and list the Ballast project maintenance skill.
 
 ## Agent Development Environment Bootstrap
 

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -599,7 +599,14 @@ func ensureInstalled(tool toolConfig) error {
 }
 
 func runInstallCLI(selectedLanguage language, args []string) int {
-	version, err := parseInstallCLIVersion(args)
+	requestedVersion, err := parseInstallCLIVersion(args)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+
+	root := findProjectRoot("")
+	version, err := resolveInstallCLIVersion(root, requestedVersion)
 	if err != nil {
 		fmt.Println(err)
 		return 1
@@ -643,6 +650,79 @@ func installCLIs(selectedLanguage language, version string) int {
 	}
 
 	return 0
+}
+
+func resolveInstallCLIVersion(root string, requestedVersion string) (string, error) {
+	if strings.TrimSpace(requestedVersion) != "" {
+		return requestedVersion, nil
+	}
+	config, err := loadDoctorConfig(root)
+	if err != nil {
+		return "", err
+	}
+	if config == nil {
+		return "", nil
+	}
+	requiredVersion := releaseVersion(config.BallastVersion)
+	if requiredVersion == "" {
+		return "", nil
+	}
+	currentVersion := releaseVersion(resolveVersion())
+	if currentVersion != "" && compareVersions(currentVersion, requiredVersion) < 0 {
+		return "", fmt.Errorf(".rulesrc.json requires Ballast %s but this ballast is %s. Update Ballast before running install-cli", requiredVersion, currentVersion)
+	}
+	return requiredVersion, nil
+}
+
+func compareVersions(left string, right string) int {
+	if left == right {
+		return 0
+	}
+	leftParts, leftOK := parseVersionParts(left)
+	rightParts, rightOK := parseVersionParts(right)
+	if leftOK && !rightOK {
+		return 1
+	}
+	if !leftOK && rightOK {
+		return -1
+	}
+	if !leftOK || !rightOK {
+		if left < right {
+			return -1
+		}
+		return 1
+	}
+	length := max(len(leftParts), len(rightParts))
+	for index := 0; index < length; index++ {
+		leftPart := 0
+		rightPart := 0
+		if index < len(leftParts) {
+			leftPart = leftParts[index]
+		}
+		if index < len(rightParts) {
+			rightPart = rightParts[index]
+		}
+		if leftPart < rightPart {
+			return -1
+		}
+		if leftPart > rightPart {
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseVersionParts(value string) ([]int, bool) {
+	parts := strings.Split(value, ".")
+	parsed := make([]int, 0, len(parts))
+	for _, part := range parts {
+		number := 0
+		if _, err := fmt.Sscanf(part, "%d", &number); err != nil {
+			return nil, false
+		}
+		parsed = append(parsed, number)
+	}
+	return parsed, true
 }
 
 type setupDevCommand struct {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -17,6 +17,7 @@ import (
 	"runtime/debug"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -716,8 +717,8 @@ func parseVersionParts(value string) ([]int, bool) {
 	parts := strings.Split(value, ".")
 	parsed := make([]int, 0, len(parts))
 	for _, part := range parts {
-		number := 0
-		if _, err := fmt.Sscanf(part, "%d", &number); err != nil {
+		number, err := strconv.Atoi(part)
+		if err != nil {
 			return nil, false
 		}
 		parsed = append(parsed, number)

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -2105,6 +2105,161 @@ func TestRunInstallCLICommandInstallsAllLanguagesByDefault(t *testing.T) {
 	}
 }
 
+func TestRunInstallCLIUsesRulesrcVersionByDefault(t *testing.T) {
+	originalRun := runCommandFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"5.0.5","languages":["python"]}`)
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install-cli", "--language", "python"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if len(commands) != 1 {
+		t.Fatalf("expected 1 install command, got %#v", commands)
+	}
+	got := strings.Join(commands[0], " ")
+	if !strings.Contains(got, "releases/download/v5.0.5/ballast_python-5.0.5-py3-none-any.whl") {
+		t.Fatalf("expected install-cli to use .rulesrc.json version 5.0.5, got %q", got)
+	}
+	if strings.Contains(got, "5.0.6") {
+		t.Fatalf("expected install-cli not to use running wrapper version, got %q", got)
+	}
+}
+
+func TestRunInstallCLIRequiresWrapperAtLeastRulesrcVersion(t *testing.T) {
+	originalRun := runCommandFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		version = originalVersion
+	})
+	version = "5.0.4"
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"5.0.5","languages":["python"]}`)
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"install-cli", "--language", "python"})
+			if exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d", exitCode)
+			}
+		})
+	})
+
+	if len(commands) != 0 {
+		t.Fatalf("expected no install commands, got %#v", commands)
+	}
+	if !strings.Contains(output, ".rulesrc.json requires Ballast 5.0.5 but this ballast is 5.0.4") {
+		t.Fatalf("expected update guidance, got %q", output)
+	}
+}
+
+func TestResolveInstallCLIVersion(t *testing.T) {
+	originalVersion := version
+	t.Cleanup(func() {
+		version = originalVersion
+	})
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"v5.0.5"}`)
+
+	version = "5.0.6"
+	got, err := resolveInstallCLIVersion(root, "5.0.4")
+	if err != nil {
+		t.Fatalf("explicit version returned error: %v", err)
+	}
+	if got != "5.0.4" {
+		t.Fatalf("expected explicit version to win, got %q", got)
+	}
+
+	got, err = resolveInstallCLIVersion(root, "")
+	if err != nil {
+		t.Fatalf("rulesrc version returned error: %v", err)
+	}
+	if got != "5.0.5" {
+		t.Fatalf("expected rulesrc version, got %q", got)
+	}
+
+	version = "dev"
+	got, err = resolveInstallCLIVersion(root, "")
+	if err != nil {
+		t.Fatalf("dev wrapper should allow rulesrc release target: %v", err)
+	}
+	if got != "5.0.5" {
+		t.Fatalf("expected rulesrc version for dev wrapper, got %q", got)
+	}
+
+	emptyRoot := resolvedTempDir(t)
+	got, err = resolveInstallCLIVersion(emptyRoot, "")
+	if err != nil {
+		t.Fatalf("missing config returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected no default version without config, got %q", got)
+	}
+
+	missingVersionRoot := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(missingVersionRoot, ".rulesrc.json"), `{"languages":["python"]}`)
+	got, err = resolveInstallCLIVersion(missingVersionRoot, "")
+	if err != nil {
+		t.Fatalf("missing rulesrc version returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected no default version without ballastVersion, got %q", got)
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name  string
+		left  string
+		right string
+		want  int
+	}{
+		{name: "equal", left: "5.0.5", right: "5.0.5", want: 0},
+		{name: "left older", left: "5.0.4", right: "5.0.5", want: -1},
+		{name: "left newer", left: "5.0.6", right: "5.0.5", want: 1},
+		{name: "missing patch equals zero", left: "5.0", right: "5.0.0", want: 0},
+		{name: "numeric not lexical", left: "5.10.0", right: "5.9.9", want: 1},
+		{name: "parseable beats unparseable", left: "5.0.0", right: "dev", want: 1},
+		{name: "unparseable loses to parseable", left: "dev", right: "5.0.0", want: -1},
+		{name: "lexical fallback older", left: "alpha", right: "beta", want: -1},
+		{name: "lexical fallback newer", left: "beta", right: "alpha", want: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareVersions(tt.left, tt.right)
+			if got != tt.want {
+				t.Fatalf("compareVersions(%q, %q) = %d, want %d", tt.left, tt.right, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRunInstallCLICommandInstallsGoBackendForAnsibleLanguage(t *testing.T) {
 	originalRun := runCommandFunc
 	originalVersion := version

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -2105,6 +2105,78 @@ func TestRunInstallCLICommandInstallsAllLanguagesByDefault(t *testing.T) {
 	}
 }
 
+func TestRunInstallCLIUsesRulesrcVersionByDefault(t *testing.T) {
+	originalRun := runCommandFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		version = originalVersion
+	})
+	version = "5.0.6"
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"5.0.5","languages":["python"]}`)
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install-cli", "--language", "python"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if len(commands) != 1 {
+		t.Fatalf("expected 1 install command, got %#v", commands)
+	}
+	got := strings.Join(commands[0], " ")
+	if !strings.Contains(got, "releases/download/v5.0.5/ballast_python-5.0.5-py3-none-any.whl") {
+		t.Fatalf("expected install-cli to use .rulesrc.json version 5.0.5, got %q", got)
+	}
+	if strings.Contains(got, "5.0.6") {
+		t.Fatalf("expected install-cli not to use running wrapper version, got %q", got)
+	}
+}
+
+func TestRunInstallCLIRequiresWrapperAtLeastRulesrcVersion(t *testing.T) {
+	originalRun := runCommandFunc
+	originalVersion := version
+	t.Cleanup(func() {
+		runCommandFunc = originalRun
+		version = originalVersion
+	})
+	version = "5.0.4"
+
+	var commands [][]string
+	runCommandFunc = func(name string, args []string) error {
+		commands = append(commands, append([]string{name}, args...))
+		return nil
+	}
+
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{"ballastVersion":"5.0.5","languages":["python"]}`)
+	output := captureStdout(t, func() {
+		withWorkingDir(t, root, func() {
+			exitCode := run([]string{"install-cli", "--language", "python"})
+			if exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d", exitCode)
+			}
+		})
+	})
+
+	if len(commands) != 0 {
+		t.Fatalf("expected no install commands, got %#v", commands)
+	}
+	if !strings.Contains(output, ".rulesrc.json requires Ballast 5.0.5 but this ballast is 5.0.4") {
+		t.Fatalf("expected update guidance, got %q", output)
+	}
+}
+
 func TestRunInstallCLICommandInstallsGoBackendForAnsibleLanguage(t *testing.T) {
 	originalRun := runCommandFunc
 	originalVersion := version

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -2246,6 +2246,7 @@ func TestCompareVersions(t *testing.T) {
 		{name: "numeric not lexical", left: "5.10.0", right: "5.9.9", want: 1},
 		{name: "parseable beats unparseable", left: "5.0.0", right: "dev", want: 1},
 		{name: "unparseable loses to parseable", left: "dev", right: "5.0.0", want: -1},
+		{name: "partial numeric part is unparseable", left: "5-rc1.0.0", right: "5.0.0", want: -1},
 		{name: "lexical fallback older", left: "alpha", right: "beta", want: -1},
 		{name: "lexical fallback newer", left: "beta", right: "alpha", want: 1},
 	}


### PR DESCRIPTION
## Summary
- make wrapper install-cli default to the saved .rulesrc.json ballastVersion when --version is omitted
- fail before installing backend CLIs when the saved required version is newer than the running wrapper
- document the version-selection contract in PRD.md and add wrapper regression tests

## Tests
- go test . -run 'TestRunInstallCLI(Command|UsesRulesrcVersionByDefault|RequiresWrapperAtLeastRulesrcVersion)' from cli/ballast
- go test . from cli/ballast
- pre-commit hooks during commit
- pre-push unit tests for cli and language packages