### PR TITLE
Align Kubernetes publishing rules with GitOps releases

### DIFF
--- a/.claude/rules/publishing-api.md
+++ b/.claude/rules/publishing-api.md
@@ -21,20 +21,23 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -118,8 +121,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -146,7 +149,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -155,10 +158,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.claude/rules/publishing-web.md
+++ b/.claude/rules/publishing-web.md
@@ -67,10 +67,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -101,7 +101,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -137,7 +137,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/.claude/rules/publishing-web.md
+++ b/.claude/rules/publishing-web.md
@@ -10,10 +10,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -21,50 +22,228 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -88,8 +267,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -102,44 +285,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -147,13 +415,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -161,40 +429,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/.codex/rules/common/publishing-api.md
+++ b/.codex/rules/common/publishing-api.md
@@ -23,20 +23,23 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -120,8 +123,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -148,7 +151,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -157,10 +160,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/common/publishing-web.md
+++ b/.codex/rules/common/publishing-web.md
@@ -12,10 +12,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -23,50 +24,228 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,8 +269,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -104,44 +287,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -149,13 +417,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -163,40 +431,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/.codex/rules/common/publishing-web.md
+++ b/.codex/rules/common/publishing-web.md
@@ -69,10 +69,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -103,7 +103,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -139,7 +139,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/.codex/rules/publishing-api.md
+++ b/.codex/rules/publishing-api.md
@@ -23,20 +23,23 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -120,8 +123,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -148,7 +151,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -157,10 +160,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/publishing-web.md
+++ b/.codex/rules/publishing-web.md
@@ -12,10 +12,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -23,50 +24,228 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,8 +269,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -104,44 +287,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -149,13 +417,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -163,40 +431,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/.codex/rules/publishing-web.md
+++ b/.codex/rules/publishing-web.md
@@ -69,10 +69,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -103,7 +103,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -139,7 +139,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/.codex/rules/typescript/typescript-publishing-api.md
+++ b/.codex/rules/typescript/typescript-publishing-api.md
@@ -23,20 +23,23 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -120,8 +123,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -148,7 +151,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -157,10 +160,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/.codex/rules/typescript/typescript-publishing-web.md
+++ b/.codex/rules/typescript/typescript-publishing-web.md
@@ -12,10 +12,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -23,50 +24,228 @@ No app deployment model is configured (`deploymentModel: none`). Deployment guid
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,8 +269,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -104,44 +287,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -149,13 +417,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -163,40 +431,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/.codex/rules/typescript/typescript-publishing-web.md
+++ b/.codex/rules/typescript/typescript-publishing-web.md
@@ -69,10 +69,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -103,7 +103,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -139,7 +139,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/agents/common/publishing/content-api.md
+++ b/agents/common/publishing/content-api.md
@@ -15,20 +15,23 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -112,8 +115,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -140,7 +143,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -149,10 +152,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/agents/common/publishing/content-web.md
+++ b/agents/common/publishing/content-web.md
@@ -61,10 +61,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -95,7 +95,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -131,7 +131,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/agents/common/publishing/content-web.md
+++ b/agents/common/publishing/content-web.md
@@ -4,10 +4,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -15,50 +16,228 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,8 +261,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -96,44 +279,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -141,13 +409,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -155,40 +423,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-api.md
@@ -15,20 +15,23 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -112,8 +115,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -140,7 +143,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -149,10 +152,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
@@ -61,10 +61,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -95,7 +95,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -131,7 +131,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/publishing/content-web.md
@@ -4,10 +4,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -15,50 +16,228 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,8 +261,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -96,44 +279,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -141,13 +409,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -155,40 +423,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-api.md
@@ -15,20 +15,23 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -112,8 +115,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -140,7 +143,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -149,10 +152,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
@@ -61,10 +61,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -95,7 +95,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -131,7 +131,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/publishing/content-web.md
@@ -4,10 +4,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -15,50 +16,228 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,8 +261,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -96,44 +279,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -141,13 +409,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -155,40 +423,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/packages/ballast-python/ballast/agents/common/publishing/content-api.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-api.md
@@ -15,20 +15,23 @@ You are a publishing specialist for REST API services deployed as Docker contain
 
 ## Release Model
 
-When an API deployment model is configured, REST API apps usually use **continuous deployment**: every merge to `main` deploys. See the web app publishing rule for the full `deploy-web.yml` workflow template; the same workflow applies here. The only differences are API health endpoint requirements and any deployment-model-specific runtime configuration.
+REST API Docker publishing uses the same versioned release model as web app Docker publishing. For Kubernetes, use the web app publishing rule's quality, `bump_and_tag`, image publish, and GitOps deploy workflow. The API-specific differences are health endpoint requirements and any deployment-model-specific runtime configuration.
 
-## CI Workflow
+## Docker Publish Workflow
 
-Use the same `deploy-web.yml` workflow template as the web app publishing rule only when this repository owns an active API deployment:
+Use the same Kubernetes `deploy.yml` and `gitops-deploy.yml` templates as the web app publishing rule when this repository publishes an API Docker image:
 
-- Trigger on `push` to `main`.
-- `concurrency: cancel-in-progress: true`.
-- Build and push the Docker image tagged with `sha-<short-sha>` and `latest`.
-- Update deployment state according to the configured deployment model.
+- Pull requests run quality checks only.
+- Pushes to `main` and `workflow_dispatch` runs create only `v`-prefixed Git tags such as `v1.8.0`; never create unprefixed tags.
+- Use `concurrency: cancel-in-progress: false` for release, image publish, and GitOps update workflows so an in-flight publish can complete.
+- Check out `refs/tags/v<version>` before building the image.
+- Build and push the Docker image tagged with `v<version>`, optional semver aliases, and the git SHA.
+- Add `latest` only when the team explicitly wants a mutable tag.
+- Update the GitOps repository only after the tagged image is pushed, and include the image digest when the chart supports digest pinning.
 
-Name the workflow file `deploy-api.yml` (or keep `deploy-web.yml` if there is only one service).
+Name the workflow file `deploy-api.yml` (or keep `deploy.yml` if there is only one service).
 
-If `deploymentModel` is `none`, do not add `deploy-api.yml` unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
+If `deploymentModel` is `none`, do not add deployment-state update jobs unless the user explicitly asks to introduce API deployment ownership. Container publishing may still be valid for installable or local runtime images, but deployment-state updates are inactive.
 
 ## Health Endpoint Requirements
 
@@ -112,8 +115,8 @@ And in `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/OWNER/IMAGE
-  tag: latest
-  digest: ""          # filled in by the CD workflow
+  tag: v1.2.3
+  digest: ""          # filled in by the publish workflow
 
 service:
   port: 8080
@@ -140,7 +143,7 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 ## README Badge
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
+[![Deploy API](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-api.yml)
 ```
 
 ## Important Notes
@@ -149,10 +152,11 @@ Grant `packages: write` to the build job for GHCR. Remove it for Docker Hub.
 - For Kubernetes, set `initialDelaySeconds` long enough that the API finishes startup before the first probe fires; misconfigured probes cause restart loops.
 - For Kubernetes HTTP services, prefer `httpGet` probes over `exec` probes.
 - Readiness checks should cover critical dependencies; liveness checks should only verify process health.
-- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if the `latest` tag is updated.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- For Kubernetes, use `digest` not `tag` in the container spec so the cluster pulls the exact image version, even if a mutable tag is updated.
 
 ## When to Apply
 
 - When a REST API service is deployed from a container image or platform-native service artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys the API from a GitOps repository.
 - When the API needs health and readiness checks for safe runtime lifecycle management.

--- a/packages/ballast-python/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-web.md
@@ -61,10 +61,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 ```
 
-Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
+Cancel superseded pull request checks, but do not cancel in-progress release, image publish, or GitOps deployment runs.
 
 ## Kubernetes Workflow Template (`deploy.yml`)
 
@@ -95,7 +95,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   quality:
@@ -131,7 +131,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          existing_tag="$(
+            git tag --points-at HEAD --list 'v*' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V \
+              | tail -n 1 \
+              || true
+          )"
           echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag

--- a/packages/ballast-python/ballast/agents/common/publishing/content-web.md
+++ b/packages/ballast-python/ballast/agents/common/publishing/content-web.md
@@ -4,10 +4,11 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Goals
 
-- When this repository owns an active web deployment, build and publish a Docker image to GHCR or Docker Hub on every merge to `main`.
-- Tag images with the git SHA and `latest`; capture the digest for immutable deploys.
-- Update deployment state according to the configured deployment model after the image is pushed.
-- Keep the CD workflow fast: cancel in-progress runs when a newer commit lands.
+- Publish Docker images to GHCR or Docker Hub only after tests and build verification pass.
+- For `deploymentModel: kubernetes`, use a versioned GitOps release flow: quality gates, `bump_and_tag`, image publish, then GitOps values update for Argo CD.
+- Create only `v`-prefixed Git release tags such as `v1.8.0`; never create unprefixed release tags.
+- Build images from the created release tag, tag images with the release tag and git SHA, and expose the pushed digest for immutable deployments.
+- Update deployment state according to the configured deployment model only after the tagged image is pushed.
 
 ## Activation
 
@@ -15,50 +16,228 @@ You are a publishing specialist for web applications deployed as Docker containe
 
 ## Release Model
 
-When a web app deployment model is configured, web apps usually use **continuous deployment**: every merge to `main` deploys. There is no manual version bump or `workflow_dispatch` trigger. If a named semver release is also needed (e.g. for a public API), create a separate `release.yml` workflow that responds to `v*` tags.
+Web Docker publishing is a release flow. For Kubernetes deployments, model it after this sequence:
+
+1. Pull requests run quality checks only.
+2. Pushes to `main` and manual `workflow_dispatch` runs execute quality checks, compute the next semver version, create a `v<version>` Git tag, publish the image, then update the GitOps repository watched by Argo CD.
+3. `workflow_dispatch` must use a required `release_type` choice input of `patch`, `minor`, or `major`.
+4. The `bump_and_tag` job must:
+   - fetch full git history
+   - detect an existing `v<version>` tag already pointing at `HEAD`
+   - fetch the previous tag with `WyriHaximus/github-action-get-previous-tag@v2`
+   - calculate the next patch, minor, and major versions with `WyriHaximus/github-action-next-semvers`
+   - normalize the computed version to an unprefixed semver output and a separate `v`-prefixed `release_tag` output
+   - update app version files when the app has them
+   - create and push only `v<version>`, never `<version>`
+5. The Docker publish job must check out `refs/tags/v<version>`, not the branch head.
+6. Image tags should include:
+   - `v<version>` as the primary deployment tag
+   - `<version>` and `<major>.<minor>` aliases when useful for operators
+   - `sha-<short-sha>` for source traceability
+   - `latest` only when the team explicitly wants a mutable tag
+7. Kubernetes GitOps updates should write the image tag and, when the chart supports it, the image digest.
 
 ## Workflow Trigger and Concurrency
 
-Use this workflow trigger only when this repository owns an active web deployment. If `deploymentModel` is `none`, do not add this workflow unless the user explicitly asks to introduce web deployment ownership.
+Use this workflow trigger when this repository publishes and deploys a Kubernetes web image. If `deploymentModel` is `none`, keep deployment-state update jobs inactive unless the user explicitly asks to introduce deployment ownership.
 
 ```yaml
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 ```
 
-`cancel-in-progress: true` ensures the newest commit's deploy always wins.
+Do not cancel in-progress release, image publish, or GitOps deployment runs. If the project needs aggressively cancellable pull request checks, put PR-only CI in a separate workflow with `cancel-in-progress: true`.
 
-## CI Workflow Template (`deploy-web.yml`)
+## Kubernetes Workflow Template (`deploy.yml`)
 
-This template is conditional. Apply it only when a web deployment model is configured or an existing web deployment workflow is being maintained.
+This template is conditional. Apply it when `deploymentModel` is `kubernetes` and this repository owns the application image while a separate GitOps repository owns environment state.
 
 ```yaml
-name: Deploy Web
+name: CI, Image, and GitOps Deploy
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type (patch/minor/major)'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+        required: true
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
-  build_and_push:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      # Set up the project runtime and package manager here.
+      - run: make test
+      - run: make build
+
+  bump_and_tag:
+    needs:
+      - quality
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      major_minor: ${{ steps.version_parts.outputs.major_minor }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Find existing version tag on HEAD
+        id: existing_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing_tag="$(git tag --points-at HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)"
+          echo "tag=${existing_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Get previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get next version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previoustag.outputs.tag }}
+
+      - name: Set version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -n "${{ steps.existing_tag.outputs.tag }}" ]; then
+            release_tag="${{ steps.existing_tag.outputs.tag }}"
+            version="${release_tag#v}"
+          else
+            case "${{ github.event.inputs.release_type || 'patch' }}" in
+              major) version="${{ steps.semvers.outputs.major }}" ;;
+              minor) version="${{ steps.semvers.outputs.minor }}" ;;
+              patch) version="${{ steps.semvers.outputs.patch }}" ;;
+              *) echo "Unsupported release_type: ${{ github.event.inputs.release_type }}" >&2; exit 1 ;;
+            esac
+            version="${version#v}"
+            release_tag="v${version}"
+          fi
+
+          if ! [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must be v-prefixed semver: ${release_tag}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Set version parts
+        id: version_parts
+        shell: bash
+        run: |
+          set -euo pipefail
+          major_minor="$(cut -d. -f1,2 <<< "${{ steps.version.outputs.version }}")"
+          echo "major_minor=${major_minor}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump app version
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          # Update package.json, pyproject.toml, Chart.yaml, or another app-owned
+          # version file here when the application stores a release version.
+          echo "Set application version to ${VERSION}"
+
+      - name: Commit version changes and create tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.version.outputs.release_tag }}"
+
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "${release_tag}")"
+            head_commit="$(git rev-parse HEAD)"
+            if [ "${tagged_commit}" != "${head_commit}" ]; then
+              echo "Tag ${release_tag} already exists but does not point at HEAD." >&2
+              exit 1
+            fi
+            echo "Tag ${release_tag} already exists on HEAD; skipping creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if ! git diff --quiet; then
+            # Replace this list with the exact version files changed above.
+            git add package.json package-lock.json pnpm-lock.yaml pyproject.toml uv.lock Chart.yaml charts/*/Chart.yaml 2>/dev/null || true
+            git commit -m "chore(release): bump version to ${release_tag} [skip ci]"
+          fi
+
+          git tag -a "${release_tag}" -m "Release ${release_tag}"
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "refs/tags/${release_tag}"
+
+  image:
+    needs:
+      - quality
+      - bump_and_tag
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write        # required for GHCR; remove for Docker Hub
     outputs:
-      image_tag: sha-${{ github.sha }}
+      image_tag: ${{ needs.bump_and_tag.outputs.release_tag }}
       image_digest: ${{ steps.push.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -82,8 +261,12 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           # For Docker Hub: images: docker.io/NAMESPACE/IMAGE
           tags: |
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.bump_and_tag.outputs.release_tag }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.version }}
+            type=raw,value=${{ needs.bump_and_tag.outputs.major_minor }}
+            type=sha,prefix=sha-,format=short
+            # Add latest only when the team explicitly wants a mutable tag:
+            # type=raw,value=latest
 
       - name: Build and push
         id: push
@@ -96,44 +279,129 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  update_deployment_state:
-    needs: build_and_push
+      - name: Report image digest
+        run: echo "Published image digest ${{ steps.push.outputs.digest }}"
+
+  deploy:
+    needs:
+      - image
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/gitops-deploy.yml
+    with:
+      tag: ${{ needs.image.outputs.image_tag }}
+      digest: ${{ needs.image.outputs.image_digest }}
+    secrets:
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+```
+
+## GitOps Deploy Workflow Template (`gitops-deploy.yml`)
+
+Use a separate reusable workflow for GitOps updates. It should be callable by the image workflow and manually runnable for an operator-provided image tag.
+
+```yaml
+name: GitOps Deploy
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Image digest produced by the image publish job.
+        required: false
+        type: string
+    secrets:
+      GITOPS_TOKEN:
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag to deploy. Must be v-prefixed semver.
+        required: true
+        type: string
+      digest:
+        description: Optional image digest to pin.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
     runs-on: ubuntu-latest
-    # Include this job only when the configured deployment model has external
-    # state to update. Hosted, serverless, server, or none models may replace
-    # or omit this job entirely.
     steps:
-      - name: Checkout deployment state repo
+      - name: Validate image tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ inputs.tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Image tag must be v-prefixed semver: ${{ inputs.tag }}" >&2
+            exit 1
+          fi
+
+      - name: Checkout GitOps repository
         uses: actions/checkout@v4
         with:
-          repository: OWNER/deployment-state
-          token: ${{ secrets.DEPLOYMENT_STATE_REPO_TOKEN }}
-          path: deployment-state
+          repository: OWNER/GITOPS_REPO
+          ref: main
+          path: gitops
+          token: ${{ secrets.GITOPS_TOKEN }}
 
       - name: Install yq
         uses: mikefarah/yq@v4
 
-      - name: Update image digest in deployment state
+      - name: Update GitOps image reference
+        shell: bash
         run: |
-          cd deployment-state
-          # Prefer digest pinning for immutable deploys
-          IMAGE_DIGEST="${{ needs.build_and_push.outputs.image_digest }}"
-          IMAGE_TAG="sha-$(echo '${{ github.sha }}' | head -c 7)"
-          # Kubernetes model: update the environment values referenced by ArgoCD.
-          # Hosted/serverless/server models: replace or remove this block.
-          yq -i '.image.digest = strenv(IMAGE_DIGEST)' path/to/deployment-state.yaml
-          yq -i '.image.tag = strenv(IMAGE_TAG)' path/to/deployment-state.yaml
+          set -euo pipefail
+          export IMAGE_REPOSITORY="ghcr.io/${{ github.repository }}"
+          export IMAGE_TAG="${{ inputs.tag }}"
+          export IMAGE_DIGEST="${{ inputs.digest }}"
+          values_file="gitops/path/to/app/values.yaml"
 
-      - name: Commit and push deployment state update
+          yq -i '.image.repository = strenv(IMAGE_REPOSITORY) | .image.tag = strenv(IMAGE_TAG)' "${values_file}"
+          if [ -n "${IMAGE_DIGEST}" ]; then
+            yq -i '.image.digest = strenv(IMAGE_DIGEST)' "${values_file}"
+          fi
+
+      - name: Commit GitOps deployment update
+        shell: bash
         run: |
-          cd deployment-state
+          set -euo pipefail
+          cd gitops
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet && echo "No changes" && exit 0
-          git commit -m "chore: update <your-app> image to sha-$(echo '${{ github.sha }}' | head -c 7)"
+          git add path/to/app/values.yaml
+          git diff --staged --quiet && echo "No deployment update needed." && exit 0
+          git commit -m "chore: deploy <app> ${{ inputs.tag }}"
           git push
 ```
+
+## Kubernetes Chart Rules
+
+For Kubernetes, keep the Helm chart in the application repository and keep Argo CD `Application` or environment values in the GitOps repository.
+
+If digest pinning is enabled, render the image by digest when `.Values.image.digest` is set, while keeping `.Values.image.tag` for readability:
+
+```yaml
+image:
+  repository: ghcr.io/OWNER/IMAGE
+  tag: v1.2.3
+  digest: ""
+```
+
+```yaml
+image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag }}{{ end }}"
+```
+
+If the platform cannot use digest pinning, deploy `v<version>` tags rather than `latest`.
 
 ## Container Registry Targets
 
@@ -141,13 +409,13 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 ### GHCR (`ghcr.io`)
 
-- Authenticate with `GITHUB_TOKEN` (no extra secret needed for same-repo images).
-- Grant `packages: write` permission to the job.
+- Authenticate with `GITHUB_TOKEN` for same-repository images.
+- Grant `packages: write` permission only to the image publish job.
 - Image URL: `ghcr.io/<owner>/<repo>` or `ghcr.io/<owner>/<image-name>`.
 
 ### Docker Hub (`docker.io`)
 
-- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (access token, not password) as repository secrets.
+- Add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as repository secrets.
 - Remove the `packages: write` permission from the job.
 - Image URL: `docker.io/<namespace>/<image>`.
 
@@ -155,40 +423,44 @@ Choose one registry per deployment. Use GHCR for private or org-internal images;
 
 These rules apply only when the configured deployment model has deployment state to update. With `deploymentModel: none`, omit deployment-state update jobs.
 
-- Prefer digest pinning (`image.digest`) over tag pinning for production deploys.
+- Prefer digest pinning (`image.digest`) over tag pinning for production deploys when the chart and platform support it.
 - Keep the `image.tag` field for human readability alongside the digest.
 - Do not overwrite unrelated environment values in the automation step.
-- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential (`DEPLOYMENT_STATE_REPO_TOKEN`) scoped to Contents: Read and write on that repo only.
+- If a deployment state repo is private, use a fine-grained PAT or GitHub App credential scoped to Contents: Read and write on that repo only.
 - For Kubernetes, bump the chart `version` field when chart templates in `charts/<app>/` change, not on every image update.
+- Operators may manually run the GitOps deploy workflow with a previously published `v<version>` image tag to redeploy or roll forward without rebuilding an image.
 
 ## Required Secrets and Permissions
 
 | Secret | Required for |
 |--------|-------------|
-| `GITHUB_TOKEN` | GHCR push (automatic) |
+| `GITHUB_TOKEN` | GHCR push (automatic) and release tag creation |
 | `DOCKERHUB_USERNAME` | Docker Hub push |
 | `DOCKERHUB_TOKEN` | Docker Hub push |
-| `DEPLOYMENT_STATE_REPO_TOKEN` | External deployment state or GitOps repo write access |
+| `GITOPS_TOKEN` | External GitOps repo write access |
 
 ## README Badge
 
-Add a badge for the deploy workflow:
+Add a badge for the deployment workflow:
 
 ```markdown
-[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy-web.yml)
+[![Deploy](https://github.com/OWNER/REPO/actions/workflows/deploy.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/deploy.yml)
 ```
 
 ## Important Notes
 
-- Do not push mutable `latest` tags as the only tag; always include the SHA tag so deploys are traceable.
+- Never create unprefixed Git release tags. Normalize action outputs to `version=<major>.<minor>.<patch>` and `release_tag=v<major>.<minor>.<patch>`.
+- Check out the release tag, not the branch head, before building the Docker image.
+- Run tests and build verification before pushing the image.
+- Do not cancel in-progress release, image publish, or GitOps update jobs.
+- Do not push mutable `latest` tags by default; always include the `v<version>` tag and SHA tag.
 - Use `docker/setup-buildx-action` and `cache-from: type=gha` to speed up repeated builds.
 - The deployment state update job should be omitted when the deployment model does not use an external state repository.
-- When present, the deployment state update job should be a no-op (early exit) when there are no changes, to avoid empty commits.
-- For Kubernetes, keep the Helm chart in `charts/<app>/` in the application repo and keep ArgoCD environment configuration in the separate GitOps repo.
-- If multiple environments exist (staging, production), make the target environment explicit in workflow inputs or use separate workflows.
+- When present, the deployment state update job should be a no-op when there are no changes, to avoid empty commits.
+- If multiple environments exist, make the target environment explicit in workflow inputs or use separate workflows.
 
 ## When to Apply
 
 - When a web application is deployed from a container image or platform-native app artifact.
-- When a configured deployment model or existing workflow says every merge to `main` should trigger a new deployment.
-- When the team wants immutable image references or artifact identifiers in deployment state.
+- When `deploymentModel` is `kubernetes` and Argo CD deploys from a GitOps repository.
+- When the team wants versioned image releases with auditable deployment-state changes.

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -313,19 +313,24 @@ describe('build', () => {
       expect(content).toContain('preview deployments');
     });
 
-    test('returns platform-neutral web deployment state placeholders', () => {
+    test('returns Kubernetes GitOps web deployment placeholders', () => {
       const content = getContent('publishing', 'web', 'typescript');
       expect(content).toContain('deploymentModel: none');
       expect(content).toContain('Deployment is inactive');
       expect(content).toContain('Deployment guidance is reference-only');
       expect(content).toContain('do not create deploy-on-main workflows');
-      expect(content).toContain('repository: OWNER/deployment-state');
+      expect(content).toContain('Kubernetes Workflow Template (`deploy.yml`)');
       expect(content).toContain(
-        'Hosted, serverless, server, or none models may replace'
+        'GitOps Deploy Workflow Template (`gitops-deploy.yml`)'
       );
-      expect(content).toContain('path/to/deployment-state.yaml');
-      expect(content).not.toContain('OWNER/gitops');
-      expect(content).not.toContain('environments/prod/<app>/values.yaml');
+      expect(content).toContain('release_tag');
+      expect(content).toContain(
+        'refs/tags/${{ needs.bump_and_tag.outputs.release_tag }}'
+      );
+      expect(content).toContain('repository: OWNER/GITOPS_REPO');
+      expect(content).toContain('GITOPS_TOKEN');
+      expect(content).toContain('image_digest');
+      expect(content).toContain('Never create unprefixed Git release tags');
     });
 
     test('keeps REST API baseline goals platform neutral', () => {


### PR DESCRIPTION
## Summary

- Replace deploy-on-main container guidance with a Kubernetes GitOps release pattern modeled on BuildFabric.
- Require v-prefixed Git release tags, explicit release_tag outputs, release-tag checkout for image builds, non-cancelling release/GitOps concurrency, and optional digest propagation.
- Regenerate Codex/Claude publishing rule outputs and update TypeScript assertions for the new guidance.

## Validation

- [x] Tests or checks run: pnpm --filter @everydaydevopsio/ballast run test; go test ./cmd/ballast-go; git diff --check; pre-push unit tests for cli and language packages
- [x] Docs updated or not needed: rule documentation updated
- [x] Generated files updated or not needed: Codex/Claude generated publishing outputs updated

## Agent Notes

- Related issue/PRD: Kubernetes publishing workflow review based on buildfabric-landing workflows
- Risk level: Medium
- Follow-up needed: none