### PR TITLE
Fix OpenCode target removal cleanup

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,5 +1,27 @@
 # Product Requirements
 
+## OpenCode First-Class Target Support
+
+### Problem
+
+OpenCode must remain a first-class Ballast target with parity across CLI target selection, saved configuration, generated artifacts, cleanup flows, documentation, and CI validation. Regressions in target-specific paths can leave stale `.opencode/` rules or make OpenCode behave differently from Cursor, Claude Code, Codex, and Gemini.
+
+### Requirements
+
+1. Ballast must accept `opencode` anywhere targets are listed or validated, including install commands, saved `.rulesrc.json` configuration, add/remove target flows, help text, and error messaging.
+2. `ballast install --target opencode` must generate OpenCode rules and skills in canonical `.opencode/` locations using the same source `agents/` and `skills/` content as other supported targets.
+3. OpenCode cleanup and refresh flows must remove only Ballast-managed `.opencode/` rules and skills for removed selections while preserving unrelated targets.
+4. Automated tests and smoke checks must cover OpenCode install, config persistence, idempotent reinstall behavior, remove-target cleanup, and cross-language target parity.
+5. Documentation and examples must list OpenCode consistently as a supported target.
+
+### Acceptance Criteria
+
+1. `opencode` is included in wrapper, TypeScript, Python, and Go target allowlists and target-related help text.
+2. OpenCode installs write rules under `.opencode/` and skills under `.opencode/skills/`.
+3. Removing `opencode` from an existing install deletes managed `.opencode/` language rules and skills while leaving other target artifacts intact.
+4. CI smoke coverage includes OpenCode in examples, config persistence, monorepo target parity, and cross-language validation paths.
+5. README and reference docs list OpenCode as a supported first-class target and document its output paths.
+
 ## GitHub PR Copilot Review Cycle Skill
 
 ### Problem

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -3971,7 +3971,7 @@ func targetRulesRoot(root string, target string) string {
 	case "gemini":
 		return filepath.Join(root, ".gemini", "rules")
 	case "opencode":
-		return filepath.Join(root, ".opencode", "rules")
+		return filepath.Join(root, ".opencode")
 	case "codex":
 		return filepath.Join(root, ".codex", "rules")
 	default:

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -4601,6 +4601,72 @@ func TestRunMonorepoRemoveTargetCleansManagedRulesAndSupportFiles(t *testing.T) 
 	}
 }
 
+func TestRunMonorepoRemoveTargetCleansOpencodeManagedRulesAndSkills(t *testing.T) {
+	root := resolvedTempDir(t)
+	mustWriteFile(t, filepath.Join(root, "services", "api", "pyproject.toml"), "[project]\nname='api'\n")
+	mustWriteFile(t, filepath.Join(root, "tools", "worker", "go.mod"), "module example.com/worker\n\ngo 1.24\n")
+	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
+  "targets": ["claude", "opencode"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  }
+}`)
+
+	mustWriteFile(t, filepath.Join(root, ".opencode", "python", "python-linting.md"), "managed")
+	mustWriteFile(t, filepath.Join(root, ".opencode", "go", "go-linting.md"), "managed")
+	mustWriteFile(t, filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md"), "managed")
+	mustWriteFile(t, filepath.Join(root, ".claude", "rules", "python", "python-linting.md"), "managed")
+	mustWriteFile(t, filepath.Join(root, ".claude", "skills", "owasp-security-scan.skill"), "managed")
+
+	originalEnsure := ensureInstalledFunc
+	originalExec := execToolFunc
+	t.Cleanup(func() {
+		ensureInstalledFunc = originalEnsure
+		execToolFunc = originalExec
+	})
+
+	ensureInstalledFunc = func(tool toolConfig) error { return nil }
+	execToolFunc = func(binary string, args []string, dir string, env map[string]string) (int, error) {
+		return 0, nil
+	}
+
+	withWorkingDir(t, root, func() {
+		exitCode := run([]string{"install", "--remove-target", "opencode", "--yes"})
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "python", "python-linting.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected opencode python rule to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "go", "go-linting.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected opencode go rule to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected opencode skill to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "rules", "python", "python-linting.md")); err != nil {
+		t.Fatalf("expected claude rule to remain, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "skills", "owasp-security-scan.skill")); err != nil {
+		t.Fatalf("expected claude skill to remain, got %v", err)
+	}
+
+	config, err := os.ReadFile(filepath.Join(root, ".rulesrc.json"))
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	text := string(config)
+	if strings.Contains(text, `"opencode"`) || !strings.Contains(text, `"claude"`) {
+		t.Fatalf("expected saved config targets to drop opencode and keep claude, got %q", text)
+	}
+}
+
 func TestRunMonorepoRemoveTargetDoesNotPersistConfigWhenCleanupFails(t *testing.T) {
 	root := resolvedTempDir(t)
 	mustWriteFile(t, filepath.Join(root, "apps", "frontend", "tsconfig.json"), "{}")

--- a/scripts/e2e-remove-target-existing-install.sh
+++ b/scripts/e2e-remove-target-existing-install.sh
@@ -9,10 +9,11 @@ trap 'rm -rf "${WORKDIR}"' EXIT
 source "${REPO_ROOT}/scripts/e2e/helpers.sh"
 setup_ballast_e2e
 
-PROJECT="${WORKDIR}/remove-target-existing-install"
-create_monorepo_fixture "${PROJECT}"
+run_codex_case() {
+  local project="${WORKDIR}/remove-target-existing-install-codex"
+  create_monorepo_fixture "${project}"
 
-cat > "${PROJECT}/.rulesrc.json" <<'EOF'
+  cat > "${project}/.rulesrc.json" <<'EOF'
 {
   "targets": ["claude", "codex"],
   "agents": ["linting"],
@@ -26,20 +27,58 @@ cat > "${PROJECT}/.rulesrc.json" <<'EOF'
 }
 EOF
 
-materialize_saved_install "${PROJECT}"
+  materialize_saved_install "${project}"
 
-(
-  cd "${PROJECT}"
-  ballast install --remove-target codex --yes >/dev/null
-)
+  (
+    cd "${project}"
+    ballast install --remove-target codex --yes >/dev/null
+  )
 
-assert_not_contains '"codex"' "${PROJECT}/.rulesrc.json"
-assert_contains '"claude"' "${PROJECT}/.rulesrc.json"
-assert_file_absent "${PROJECT}/.codex/rules/python/python-linting.md"
-assert_file_absent "${PROJECT}/.codex/rules/go/go-linting.md"
-assert_file_absent "${PROJECT}/.codex/skills/owasp-security-scan"
-assert_not_contains '`.codex/rules/' "${PROJECT}/AGENTS.md"
-assert_contains '`.claude/rules/python/python-linting.md`' "${PROJECT}/CLAUDE.md"
-assert_file_exists "${PROJECT}/.claude/skills/owasp-security-scan.skill"
+  assert_not_contains '"codex"' "${project}/.rulesrc.json"
+  assert_contains '"claude"' "${project}/.rulesrc.json"
+  assert_file_absent "${project}/.codex/rules/python/python-linting.md"
+  assert_file_absent "${project}/.codex/rules/go/go-linting.md"
+  assert_file_absent "${project}/.codex/skills/owasp-security-scan"
+  assert_not_contains '`.codex/rules/' "${project}/AGENTS.md"
+  assert_contains '`.claude/rules/python/python-linting.md`' "${project}/CLAUDE.md"
+  assert_file_exists "${project}/.claude/skills/owasp-security-scan.skill"
+}
+
+run_opencode_case() {
+  local project="${WORKDIR}/remove-target-existing-install-opencode"
+  create_monorepo_fixture "${project}"
+
+  cat > "${project}/.rulesrc.json" <<'EOF'
+{
+  "targets": ["claude", "opencode"],
+  "agents": ["linting"],
+  "skills": ["owasp-security-scan"],
+  "languages": ["python", "go"],
+  "paths": {
+    "python": ["services/api"],
+    "go": ["tools/worker"]
+  },
+  "ballastVersion": "5.10.2"
+}
+EOF
+
+  materialize_saved_install "${project}"
+
+  (
+    cd "${project}"
+    ballast install --remove-target opencode --yes >/dev/null
+  )
+
+  assert_not_contains '"opencode"' "${project}/.rulesrc.json"
+  assert_contains '"claude"' "${project}/.rulesrc.json"
+  assert_file_absent "${project}/.opencode/python/python-linting.md"
+  assert_file_absent "${project}/.opencode/go/go-linting.md"
+  assert_file_absent "${project}/.opencode/skills/owasp-security-scan.md"
+  assert_file_exists "${project}/.claude/rules/python/python-linting.md"
+  assert_file_exists "${project}/.claude/skills/owasp-security-scan.skill"
+}
+
+run_codex_case
+run_opencode_case
 
 echo "PASS: remove-target-existing-install-e2e"


### PR DESCRIPTION
## Summary
- documents the OpenCode first-class target contract in PRD.md for issue #188
- fixes wrapper cleanup to remove managed OpenCode rules from canonical .opencode/<language>/ paths
- adds unit and E2E coverage for removing OpenCode from an existing multi-target install while preserving Claude artifacts

Fixes #188.

## Verification
- go test ./... (cli/ballast)
- scripts/e2e-remove-target-existing-install.sh /home/marka/src/ballast-issue-188-opencode
- scripts/smoke-wrapper-monorepo.sh ../ballast-examples
- git diff --check
- pre-push hook: ballast-unit-tests-pre-push, whitespace, secrets, yamllint, cli/ballast pre-commit

## #188 Evidence
- target allowlists/help already include opencode in wrapper, TypeScript, Python, and Go CLIs
- OpenCode generation writes rules under .opencode/ and skills under .opencode/skills/
- CI smoke coverage includes OpenCode in examples-smoke, config-persistence-smoke, monorepo smokes, tasks/skills smokes, and cross-language validation
- docs list OpenCode in README, installation docs, architecture docs, and skill docs