### PR TITLE
Fix Ansible rule guidance

### DIFF
--- a/agents/ansible/linting/content.md
+++ b/agents/ansible/linting/content.md
@@ -9,18 +9,43 @@ You are an Ansible linting specialist. Your role is to establish a clean, repeat
 5. Keep tasks idempotent and explicit with `changed_when`, `failed_when`, and `creates`/`removes` when shell or command steps are unavoidable.
 6. Add CI steps that run linting before any apply/deploy workflow.
 7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+8. Use `pre-commit` for local Ansible validation.
+9. Do not configure Dependabot for Ansible Galaxy roles or collections; Dependabot has no Ansible ecosystem for `requirements.yml` or `requirements.yaml`.
 
 ## Baseline Tooling
 
 - `ansible-lint`
 - `yamllint`
+
+## Local Hooks
+
+Use `pre-commit` for local Ansible enforcement.
+
+The root `.pre-commit-config.yaml` should run:
+
+- `ansible-lint` for playbooks, roles, and collections
+- `yamllint` for YAML formatting and style
+- `ansible-playbook --syntax-check` for each representative top-level playbook
+
+Install both hook stages:
+
+- `pre-commit install`
+- `pre-commit install --hook-type pre-push`
+
+Keep the hook set current with `pre-commit autoupdate`. Use the pre-push stage for slower validation such as syntax checks across all top-level playbooks or check-mode smoke validation.
+
+## Dependency Updates
+
+Dependabot can update GitHub Actions used by Ansible repositories, but it cannot update Ansible Galaxy roles or collections from `requirements.yml` or `requirements.yaml`. Do not add an unsupported Ansible ecosystem entry to `.github/dependabot.yml`; track role and collection updates through manual review or project-specific automation.
+
 ## Implementation Order
 
 1. Detect the repo shape and keep it consistent.
 2. Add or update `.ansible-lint`.
 3. Add or update `.yamllint`.
-4. Add CI lint commands.
-5. Run syntax and lint checks.
+4. Add or update `.pre-commit-config.yaml` when local hooks are in scope.
+5. Add CI lint commands.
+6. Run syntax and lint checks.
 
 ## Example Layout
 
@@ -58,6 +83,7 @@ That repo demonstrates good baseline conventions:
 - Avoid raw `shell` and `command` tasks unless no purpose-built module exists.
 - When `shell` or `command` is required, make the task idempotent and explain the safety condition.
 - Keep `requirements.yml` in sync with any referenced collections or external roles.
+- Review Galaxy role and collection updates manually or through project-specific CI because Dependabot does not update Ansible Galaxy dependencies.
 
 ## When Completed
 

--- a/agents/ansible/testing/content.md
+++ b/agents/ansible/testing/content.md
@@ -8,6 +8,7 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 4. Add a local smoke path for at least one representative playbook or role.
 5. Prefer Molecule for reusable role testing when the repo already has container-based test infrastructure.
 6. Ensure CI fails on syntax, lint, or check-mode regressions.
+7. Coordinate with `pre-commit` so fast checks can run locally and broader validation can run at pre-push or CI time.
 
 ## Baseline Commands
 
@@ -15,6 +16,17 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 - `yamllint .`
 - `ansible-playbook --syntax-check site.yml`
 - `ansible-playbook --check --diff -i hosts.ini.example playbook.yml`
+
+## Local Hook Validation
+
+For Ansible repositories, use `pre-commit`. Configure commit-time hooks for fast linting and formatting checks, and configure the pre-push stage for validation that is too slow or broad for every commit.
+
+Recommended hook split:
+
+- `pre-commit`: `ansible-lint` and `yamllint`
+- `pre-push`: `ansible-playbook --syntax-check` for top-level playbooks and any safe check-mode smoke command
+
+Install hooks with `pre-commit install` and `pre-commit install --hook-type pre-push`. Keep pinned hook revisions current with `pre-commit autoupdate`.
 
 ## Example Coverage
 

--- a/agents/common/cicd/content.md
+++ b/agents/common/cicd/content.md
@@ -42,6 +42,8 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
+Do not add an Ansible package ecosystem entry. Dependabot does not support Ansible Galaxy roles, collections, `requirements.yml`, or `requirements.yaml` as a package ecosystem. For Ansible-only repositories, keep `github-actions` updates when GitHub Actions workflows exist, and document collection or role update review as a manual maintenance task or repo-specific automation outside Dependabot.
+
 ### Basic Structure
 
 ```yaml

--- a/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
@@ -9,18 +9,43 @@ You are an Ansible linting specialist. Your role is to establish a clean, repeat
 5. Keep tasks idempotent and explicit with `changed_when`, `failed_when`, and `creates`/`removes` when shell or command steps are unavoidable.
 6. Add CI steps that run linting before any apply/deploy workflow.
 7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+8. Use `pre-commit` for local Ansible validation.
+9. Do not configure Dependabot for Ansible Galaxy roles or collections; Dependabot has no Ansible ecosystem for `requirements.yml` or `requirements.yaml`.
 
 ## Baseline Tooling
 
 - `ansible-lint`
 - `yamllint`
+
+## Local Hooks
+
+Use `pre-commit` for local Ansible enforcement.
+
+The root `.pre-commit-config.yaml` should run:
+
+- `ansible-lint` for playbooks, roles, and collections
+- `yamllint` for YAML formatting and style
+- `ansible-playbook --syntax-check` for each representative top-level playbook
+
+Install both hook stages:
+
+- `pre-commit install`
+- `pre-commit install --hook-type pre-push`
+
+Keep the hook set current with `pre-commit autoupdate`. Use the pre-push stage for slower validation such as syntax checks across all top-level playbooks or check-mode smoke validation.
+
+## Dependency Updates
+
+Dependabot can update GitHub Actions used by Ansible repositories, but it cannot update Ansible Galaxy roles or collections from `requirements.yml` or `requirements.yaml`. Do not add an unsupported Ansible ecosystem entry to `.github/dependabot.yml`; track role and collection updates through manual review or project-specific automation.
+
 ## Implementation Order
 
 1. Detect the repo shape and keep it consistent.
 2. Add or update `.ansible-lint`.
 3. Add or update `.yamllint`.
-4. Add CI lint commands.
-5. Run syntax and lint checks.
+4. Add or update `.pre-commit-config.yaml` when local hooks are in scope.
+5. Add CI lint commands.
+6. Run syntax and lint checks.
 
 ## Example Layout
 
@@ -58,6 +83,7 @@ That repo demonstrates good baseline conventions:
 - Avoid raw `shell` and `command` tasks unless no purpose-built module exists.
 - When `shell` or `command` is required, make the task idempotent and explain the safety condition.
 - Keep `requirements.yml` in sync with any referenced collections or external roles.
+- Review Galaxy role and collection updates manually or through project-specific CI because Dependabot does not update Ansible Galaxy dependencies.
 
 ## When Completed
 

--- a/packages/ballast-go/cmd/ballast-go/agents/ansible/testing/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/ansible/testing/content.md
@@ -8,6 +8,7 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 4. Add a local smoke path for at least one representative playbook or role.
 5. Prefer Molecule for reusable role testing when the repo already has container-based test infrastructure.
 6. Ensure CI fails on syntax, lint, or check-mode regressions.
+7. Coordinate with `pre-commit` so fast checks can run locally and broader validation can run at pre-push or CI time.
 
 ## Baseline Commands
 
@@ -15,6 +16,17 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 - `yamllint .`
 - `ansible-playbook --syntax-check site.yml`
 - `ansible-playbook --check --diff -i hosts.ini.example playbook.yml`
+
+## Local Hook Validation
+
+For Ansible repositories, use `pre-commit`. Configure commit-time hooks for fast linting and formatting checks, and configure the pre-push stage for validation that is too slow or broad for every commit.
+
+Recommended hook split:
+
+- `pre-commit`: `ansible-lint` and `yamllint`
+- `pre-push`: `ansible-playbook --syntax-check` for top-level playbooks and any safe check-mode smoke command
+
+Install hooks with `pre-commit install` and `pre-commit install --hook-type pre-push`. Keep pinned hook revisions current with `pre-commit autoupdate`.
 
 ## Example Coverage
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/cicd/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/cicd/content.md
@@ -42,6 +42,8 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
+Do not add an Ansible package ecosystem entry. Dependabot does not support Ansible Galaxy roles, collections, `requirements.yml`, or `requirements.yaml` as a package ecosystem. For Ansible-only repositories, keep `github-actions` updates when GitHub Actions workflows exist, and document collection or role update review as a manual maintenance task or repo-specific automation outside Dependabot.
+
 ### Basic Structure
 
 ```yaml

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -2355,11 +2355,12 @@ func renderGitHooksGuidance(language, hookMode string) string {
 			"- Create or update `.pre-commit-config.yaml` at the repo root.",
 			"- Install hooks with `pre-commit install`.",
 			"- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-			"- Run `ansible-lint`, `yamllint`, and `ansible-playbook --syntax-check` from the hook configuration.",
+			"- Run `ansible-lint` and `yamllint` from the pre-commit stage.",
+			"- Run `ansible-playbook --syntax-check` for representative top-level playbooks from the pre-push stage.",
 			gitleaksHookGuidance,
 			"- Prefer `ansible-lint --profile=safety` in CI or explicit security-review workflows when the repository is ready for safety-oriented rules.",
 			"- Keep secrets out of logs and commits; prefer Ansible Vault or external secret stores.",
-			"- Keep the configuration current with `pre-commit autoupdate`.",
+			"- Keep the configuration current with `pre-commit autoupdate`; rerun `pre-commit run --all-files` after hook changes.",
 		}, "\n")
 	case "terraform":
 		return strings.Join([]string{

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -715,6 +715,8 @@ func TestRenderGitHooksContentSupportsAnsibleGitleaksGuidance(t *testing.T) {
 		"ansible-lint",
 		"yamllint",
 		"ansible-playbook --syntax-check",
+		"pre-push stage",
+		"pre-commit autoupdate",
 		"gitleaks",
 		"ansible-lint --profile=safety",
 	} {
@@ -722,8 +724,16 @@ func TestRenderGitHooksContentSupportsAnsibleGitleaksGuidance(t *testing.T) {
 			t.Fatalf("expected ansible git-hooks content to mention %q, got %q", want, got)
 		}
 	}
-	if strings.Contains(got, "scripts/check-no-secrets.sh") {
-		t.Fatalf("expected ansible git-hooks content to avoid local no-secrets script, got %q", got)
+	for _, unwanted := range []string{
+		"Use Husky for TypeScript-only repositories.",
+		"Husky",
+		"lint-staged",
+		"npx lint-staged",
+		"scripts/check-no-secrets.sh",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("expected ansible git-hooks content not to mention %q, got %q", unwanted, got)
+		}
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
@@ -9,18 +9,43 @@ You are an Ansible linting specialist. Your role is to establish a clean, repeat
 5. Keep tasks idempotent and explicit with `changed_when`, `failed_when`, and `creates`/`removes` when shell or command steps are unavoidable.
 6. Add CI steps that run linting before any apply/deploy workflow.
 7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+8. Use `pre-commit` for local Ansible validation.
+9. Do not configure Dependabot for Ansible Galaxy roles or collections; Dependabot has no Ansible ecosystem for `requirements.yml` or `requirements.yaml`.
 
 ## Baseline Tooling
 
 - `ansible-lint`
 - `yamllint`
+
+## Local Hooks
+
+Use `pre-commit` for local Ansible enforcement.
+
+The root `.pre-commit-config.yaml` should run:
+
+- `ansible-lint` for playbooks, roles, and collections
+- `yamllint` for YAML formatting and style
+- `ansible-playbook --syntax-check` for each representative top-level playbook
+
+Install both hook stages:
+
+- `pre-commit install`
+- `pre-commit install --hook-type pre-push`
+
+Keep the hook set current with `pre-commit autoupdate`. Use the pre-push stage for slower validation such as syntax checks across all top-level playbooks or check-mode smoke validation.
+
+## Dependency Updates
+
+Dependabot can update GitHub Actions used by Ansible repositories, but it cannot update Ansible Galaxy roles or collections from `requirements.yml` or `requirements.yaml`. Do not add an unsupported Ansible ecosystem entry to `.github/dependabot.yml`; track role and collection updates through manual review or project-specific automation.
+
 ## Implementation Order
 
 1. Detect the repo shape and keep it consistent.
 2. Add or update `.ansible-lint`.
 3. Add or update `.yamllint`.
-4. Add CI lint commands.
-5. Run syntax and lint checks.
+4. Add or update `.pre-commit-config.yaml` when local hooks are in scope.
+5. Add CI lint commands.
+6. Run syntax and lint checks.
 
 ## Example Layout
 
@@ -58,6 +83,7 @@ That repo demonstrates good baseline conventions:
 - Avoid raw `shell` and `command` tasks unless no purpose-built module exists.
 - When `shell` or `command` is required, make the task idempotent and explain the safety condition.
 - Keep `requirements.yml` in sync with any referenced collections or external roles.
+- Review Galaxy role and collection updates manually or through project-specific CI because Dependabot does not update Ansible Galaxy dependencies.
 
 ## When Completed
 

--- a/packages/ballast-go/cmd/ballast/agents/ansible/testing/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/ansible/testing/content.md
@@ -8,6 +8,7 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 4. Add a local smoke path for at least one representative playbook or role.
 5. Prefer Molecule for reusable role testing when the repo already has container-based test infrastructure.
 6. Ensure CI fails on syntax, lint, or check-mode regressions.
+7. Coordinate with `pre-commit` so fast checks can run locally and broader validation can run at pre-push or CI time.
 
 ## Baseline Commands
 
@@ -15,6 +16,17 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 - `yamllint .`
 - `ansible-playbook --syntax-check site.yml`
 - `ansible-playbook --check --diff -i hosts.ini.example playbook.yml`
+
+## Local Hook Validation
+
+For Ansible repositories, use `pre-commit`. Configure commit-time hooks for fast linting and formatting checks, and configure the pre-push stage for validation that is too slow or broad for every commit.
+
+Recommended hook split:
+
+- `pre-commit`: `ansible-lint` and `yamllint`
+- `pre-push`: `ansible-playbook --syntax-check` for top-level playbooks and any safe check-mode smoke command
+
+Install hooks with `pre-commit install` and `pre-commit install --hook-type pre-push`. Keep pinned hook revisions current with `pre-commit autoupdate`.
 
 ## Example Coverage
 

--- a/packages/ballast-go/cmd/ballast/agents/common/cicd/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/cicd/content.md
@@ -42,6 +42,8 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
+Do not add an Ansible package ecosystem entry. Dependabot does not support Ansible Galaxy roles, collections, `requirements.yml`, or `requirements.yaml` as a package ecosystem. For Ansible-only repositories, keep `github-actions` updates when GitHub Actions workflows exist, and document collection or role update review as a manual maintenance task or repo-specific automation outside Dependabot.
+
 ### Basic Structure
 
 ```yaml

--- a/packages/ballast-python/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-python/ballast/agents/ansible/linting/content.md
@@ -9,18 +9,43 @@ You are an Ansible linting specialist. Your role is to establish a clean, repeat
 5. Keep tasks idempotent and explicit with `changed_when`, `failed_when`, and `creates`/`removes` when shell or command steps are unavoidable.
 6. Add CI steps that run linting before any apply/deploy workflow.
 7. Coordinate with the `git-hooks` rules when the repo should enforce local hook checks.
+8. Use `pre-commit` for local Ansible validation.
+9. Do not configure Dependabot for Ansible Galaxy roles or collections; Dependabot has no Ansible ecosystem for `requirements.yml` or `requirements.yaml`.
 
 ## Baseline Tooling
 
 - `ansible-lint`
 - `yamllint`
+
+## Local Hooks
+
+Use `pre-commit` for local Ansible enforcement.
+
+The root `.pre-commit-config.yaml` should run:
+
+- `ansible-lint` for playbooks, roles, and collections
+- `yamllint` for YAML formatting and style
+- `ansible-playbook --syntax-check` for each representative top-level playbook
+
+Install both hook stages:
+
+- `pre-commit install`
+- `pre-commit install --hook-type pre-push`
+
+Keep the hook set current with `pre-commit autoupdate`. Use the pre-push stage for slower validation such as syntax checks across all top-level playbooks or check-mode smoke validation.
+
+## Dependency Updates
+
+Dependabot can update GitHub Actions used by Ansible repositories, but it cannot update Ansible Galaxy roles or collections from `requirements.yml` or `requirements.yaml`. Do not add an unsupported Ansible ecosystem entry to `.github/dependabot.yml`; track role and collection updates through manual review or project-specific automation.
+
 ## Implementation Order
 
 1. Detect the repo shape and keep it consistent.
 2. Add or update `.ansible-lint`.
 3. Add or update `.yamllint`.
-4. Add CI lint commands.
-5. Run syntax and lint checks.
+4. Add or update `.pre-commit-config.yaml` when local hooks are in scope.
+5. Add CI lint commands.
+6. Run syntax and lint checks.
 
 ## Example Layout
 
@@ -58,6 +83,7 @@ That repo demonstrates good baseline conventions:
 - Avoid raw `shell` and `command` tasks unless no purpose-built module exists.
 - When `shell` or `command` is required, make the task idempotent and explain the safety condition.
 - Keep `requirements.yml` in sync with any referenced collections or external roles.
+- Review Galaxy role and collection updates manually or through project-specific CI because Dependabot does not update Ansible Galaxy dependencies.
 
 ## When Completed
 

--- a/packages/ballast-python/ballast/agents/ansible/testing/content.md
+++ b/packages/ballast-python/ballast/agents/ansible/testing/content.md
@@ -8,6 +8,7 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 4. Add a local smoke path for at least one representative playbook or role.
 5. Prefer Molecule for reusable role testing when the repo already has container-based test infrastructure.
 6. Ensure CI fails on syntax, lint, or check-mode regressions.
+7. Coordinate with `pre-commit` so fast checks can run locally and broader validation can run at pre-push or CI time.
 
 ## Baseline Commands
 
@@ -15,6 +16,17 @@ You are an Ansible testing specialist. Your role is to set up reliable validatio
 - `yamllint .`
 - `ansible-playbook --syntax-check site.yml`
 - `ansible-playbook --check --diff -i hosts.ini.example playbook.yml`
+
+## Local Hook Validation
+
+For Ansible repositories, use `pre-commit`. Configure commit-time hooks for fast linting and formatting checks, and configure the pre-push stage for validation that is too slow or broad for every commit.
+
+Recommended hook split:
+
+- `pre-commit`: `ansible-lint` and `yamllint`
+- `pre-push`: `ansible-playbook --syntax-check` for top-level playbooks and any safe check-mode smoke command
+
+Install hooks with `pre-commit install` and `pre-commit install --hook-type pre-push`. Keep pinned hook revisions current with `pre-commit autoupdate`.
 
 ## Example Coverage
 

--- a/packages/ballast-python/ballast/agents/common/cicd/content.md
+++ b/packages/ballast-python/ballast/agents/common/cicd/content.md
@@ -42,6 +42,8 @@ Apply the appropriate block at the workflow level (outside any `jobs:` key) for 
 
 Create a `.github/dependabot.yml` file for the current project when Dependabot is appropriate. Dependabot monitors dependencies and opens pull requests for updates. Always include `github-actions` so workflow actions stay current, and add package ecosystems that match detected manifests and lockfiles.
 
+Do not add an Ansible package ecosystem entry. Dependabot does not support Ansible Galaxy roles, collections, `requirements.yml`, or `requirements.yaml` as a package ecosystem. For Ansible-only repositories, keep `github-actions` updates when GitHub Actions workflows exist, and document collection or role update review as a manual maintenance task or repo-specific automation outside Dependabot.
+
 ### Basic Structure
 
 ```yaml

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -827,11 +827,12 @@ def render_git_hooks_guidance(language: str, hook_mode: str) -> str:
                 "- Create or update `.pre-commit-config.yaml` at the repo root.",
                 "- Install hooks with `pre-commit install`.",
                 "- Install the pre-push hook with `pre-commit install --hook-type pre-push`.",
-                "- Run `ansible-lint`, `yamllint`, and `ansible-playbook --syntax-check` from the hook configuration.",
+                "- Run `ansible-lint` and `yamllint` from the pre-commit stage.",
+                "- Run `ansible-playbook --syntax-check` for representative top-level playbooks from the pre-push stage.",
                 gitleaks_hook_guidance,
                 "- Prefer `ansible-lint --profile=safety` in CI or explicit security-review workflows when the repository is ready for safety-oriented rules.",
                 "- Keep secrets out of logs and commits; prefer Ansible Vault or external secret stores.",
-                "- Keep the configuration current with `pre-commit autoupdate`.",
+                "- Keep the configuration current with `pre-commit autoupdate`; rerun `pre-commit run --all-files` after hook changes.",
             ]
         )
     if language == "terraform":

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -1428,8 +1428,14 @@ Keep team-specific usage notes.
             content = git_hooks.read_text(encoding="utf-8")
             self.assertIn("pre-commit install --hook-type pre-push", content)
             self.assertIn("ansible-playbook --syntax-check", content)
+            self.assertIn("pre-push stage", content)
+            self.assertIn("pre-commit autoupdate", content)
             self.assertIn("gitleaks", content)
             self.assertIn("ansible-lint --profile=safety", content)
+            self.assertNotIn("Use Husky for TypeScript-only repositories.", content)
+            self.assertNotIn("Husky", content)
+            self.assertNotIn("lint-staged", content)
+            self.assertNotIn("npx lint-staged", content)
             self.assertNotIn("scripts/check-no-secrets.sh", content)
 
     def test_render_terraform_git_hooks_guidance_uses_initialized_commands(

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -509,9 +509,26 @@ describe('build', () => {
       expect(content).toContain('ansible-lint');
       expect(content).toContain('yamllint');
       expect(content).toContain('ansible-playbook --syntax-check');
+      expect(content).toContain('pre-push stage');
+      expect(content).toContain('pre-commit autoupdate');
       expect(content).toContain('gitleaks');
       expect(content).toContain('ansible-lint --profile=safety');
+      expect(content).not.toContain(
+        'Use Husky for TypeScript-only repositories.'
+      );
+      expect(content).not.toContain('Husky');
+      expect(content).not.toContain('lint-staged');
+      expect(content).not.toContain('npx lint-staged');
       expect(content).not.toContain('scripts/check-no-secrets.sh');
+    });
+
+    test('returns ansible cicd guidance without unsupported dependabot ecosystem', () => {
+      const content = getContent('cicd', undefined, 'ansible');
+      expect(content).toContain('Dependabot does not support Ansible Galaxy');
+      expect(content).toContain('requirements.yml');
+      expect(content).toContain('github-actions');
+      expect(content).not.toContain("package-ecosystem: 'ansible");
+      expect(content).not.toContain('ansible-galaxy');
     });
 
     test('returns initialized terraform git-hooks command guidance', () => {

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -181,11 +181,12 @@ function renderGitHooksGuidance(
       '- Create or update `.pre-commit-config.yaml` at the repo root.',
       '- Install hooks with `pre-commit install`.',
       '- Install the pre-push hook with `pre-commit install --hook-type pre-push`.',
-      '- Run `ansible-lint`, `yamllint`, and `ansible-playbook --syntax-check` from the hook configuration.',
+      '- Run `ansible-lint` and `yamllint` from the pre-commit stage.',
+      '- Run `ansible-playbook --syntax-check` for representative top-level playbooks from the pre-push stage.',
       gitleaksHookGuidance,
       '- Prefer `ansible-lint --profile=safety` in CI or explicit security-review workflows when the repository is ready for safety-oriented rules.',
       '- Keep secrets out of logs and commits; prefer Ansible Vault or external secret stores.',
-      '- Keep the configuration current with `pre-commit autoupdate`.'
+      '- Keep the configuration current with `pre-commit autoupdate`; rerun `pre-commit run --all-files` after hook changes.'
     ].join('\n');
   }
 


### PR DESCRIPTION
## Summary

- clarify that Dependabot does not support Ansible Galaxy roles, collections, or requirements files as a package ecosystem
- add Ansible pre-commit/pre-push guidance for ansible-lint, yamllint, syntax checks, and pre-commit autoupdate
- keep TypeScript-specific Husky/lint-staged guidance out of Ansible hook output across TypeScript, Python, and Go backends

## Validation

- [x] Tests or checks run: `pnpm --dir packages/ballast-typescript test -- --runTestsByPath src/build.test.ts`
- [x] Tests or checks run: `uv run python -m unittest tests.test_cli.PatchInstallTests.test_install_writes_ansible_git_hooks_guidance`
- [x] Tests or checks run: `go test ./cmd/ballast-go -run TestRenderGitHooksContentSupportsAnsibleGitleaksGuidance`
- [x] Tests or checks run: pre-push unit tests for cli and language packages
- [x] Docs updated or not needed: updated Ansible/CICD rule guidance
- [x] Generated files updated or not needed: package mirrors updated; checked-in local .claude/.codex outputs not present for these Ansible surfaces

## Agent Notes

- Related issue/PRD: Closes #151
- Risk level: Low
- Follow-up needed: None