### PR TITLE
feat(doctor): detect managed rule drift

### DIFF
--- a/.claude/rules/common/git-hooks.md
+++ b/.claude/rules/common/git-hooks.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/git-hooks" version="5.16.5" checksum="2c54b13a8666bf8340b95c46d939b33e9161c7cdc41246e69610ecf28daf4a73" -->
 # Git Hooks Rules
 
 These rules are intended for Claude Code.

--- a/.claude/rules/go/go-linting.md
+++ b/.claude/rules/go/go-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/linting" version="5.16.5" checksum="488db029ad98d9aaa1f7c4b098eb19bce3c9f686b3e8e2751715e832d6374897" -->
 # Go Linting Rules
 
 These rules provide Go Linting Rules guidance for projects in this repository.

--- a/.claude/rules/go/go-logging.md
+++ b/.claude/rules/go/go-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/logging" version="5.16.5" checksum="20cce8e48d72f688d52c8a3179ad414189e005ed5a1275714c8add91e8b3ca4d" -->
 # Go Logging Rules
 
 These rules provide Go Logging Rules guidance for projects in this repository.

--- a/.claude/rules/go/go-testing.md
+++ b/.claude/rules/go/go-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/testing" version="5.16.5" checksum="d41e060516206ed4749ad7a825cc10ac7b185f5f1f3174ff9fc72320cd68eee6" -->
 # Go Testing Rules
 
 These rules provide Go Testing Rules guidance for projects in this repository.

--- a/.claude/rules/python/python-linting.md
+++ b/.claude/rules/python/python-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/linting" version="5.16.5" checksum="41ca738ba52efd2b12d8bb2e73e1b100aad63edfb7b5e47f436a0ba8c6061f62" -->
 # Python Linting Rules
 
 These rules provide Python Linting Rules guidance for projects in this repository.

--- a/.claude/rules/python/python-logging.md
+++ b/.claude/rules/python/python-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/logging" version="5.16.5" checksum="31cbe4f167fb94530b4612f85cd02c89aa8d6c9978e9664ca5721aec635e6654" -->
 # Python Logging Rules
 
 These rules provide Python Logging Rules guidance for projects in this repository.

--- a/.claude/rules/python/python-testing.md
+++ b/.claude/rules/python/python-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/testing" version="5.16.5" checksum="12b0a03707c933dcef8e54d49b7ae9de5d92415e227df4ec4b75e3eea805edbd" -->
 # Python Testing Rules
 
 These rules provide Python Testing Rules guidance for projects in this repository.

--- a/.claude/rules/typescript/typescript-linting.md
+++ b/.claude/rules/typescript/typescript-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/linting" version="5.16.5" checksum="0bdc4f69d8f918e805e97b4755450daa19ba51dffb81e5b3473b00d9f8781b06" -->
 # TypeScript Linting Rules
 
 These rules provide TypeScript linting setup instructions following Everyday DevOps best practices from https://www.markcallen.com/typescript-linting/

--- a/.claude/rules/typescript/typescript-logging.md
+++ b/.claude/rules/typescript/typescript-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/logging" version="5.16.5" checksum="edc1d479f376578af29ef07ec0956c834fb314b0e88709678d1feccb7d38d375" -->
 # Centralized Logging Rules
 
 These rules provide instructions for configuring Pino with Fluentd (Node.js, Next.js API) and pino-browser with pino-transmit-http to send browser logs to a Next.js /api/logs endpoint.

--- a/.claude/rules/typescript/typescript-testing.md
+++ b/.claude/rules/typescript/typescript-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/testing" version="5.16.5" checksum="4d154aa4218a2c8f3effff95547680b26d1e17e515bb45aa2e0bf49b2f255d84" -->
 # Testing Rules
 
 These rules provide testing setup for TypeScript/JavaScript projects: Jest by default, Vitest for Vite projects, 50% coverage default, and a test step in the build GitHub Action.

--- a/.codex/rules/common/git-hooks.md
+++ b/.codex/rules/common/git-hooks.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/git-hooks" version="5.16.5" checksum="311cd62d8ef40005084e9ab817062bb805dd30e12214a89d68c40d2b499a60de" -->
 # Git Hooks Rules
 
 These rules are intended for Codex (CLI and app).

--- a/.codex/rules/go/go-linting.md
+++ b/.codex/rules/go/go-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/linting" version="5.16.5" checksum="488db029ad98d9aaa1f7c4b098eb19bce3c9f686b3e8e2751715e832d6374897" -->
 # Go Linting Rules
 
 These rules provide Go Linting Rules guidance for projects in this repository.

--- a/.codex/rules/go/go-logging.md
+++ b/.codex/rules/go/go-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/logging" version="5.16.5" checksum="20cce8e48d72f688d52c8a3179ad414189e005ed5a1275714c8add91e8b3ca4d" -->
 # Go Logging Rules
 
 These rules provide Go Logging Rules guidance for projects in this repository.

--- a/.codex/rules/go/go-testing.md
+++ b/.codex/rules/go/go-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="go/testing" version="5.16.5" checksum="d41e060516206ed4749ad7a825cc10ac7b185f5f1f3174ff9fc72320cd68eee6" -->
 # Go Testing Rules
 
 These rules provide Go Testing Rules guidance for projects in this repository.

--- a/.codex/rules/python/python-linting.md
+++ b/.codex/rules/python/python-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/linting" version="5.16.5" checksum="41ca738ba52efd2b12d8bb2e73e1b100aad63edfb7b5e47f436a0ba8c6061f62" -->
 # Python Linting Rules
 
 These rules provide Python Linting Rules guidance for projects in this repository.

--- a/.codex/rules/python/python-logging.md
+++ b/.codex/rules/python/python-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/logging" version="5.16.5" checksum="31cbe4f167fb94530b4612f85cd02c89aa8d6c9978e9664ca5721aec635e6654" -->
 # Python Logging Rules
 
 These rules provide Python Logging Rules guidance for projects in this repository.

--- a/.codex/rules/python/python-testing.md
+++ b/.codex/rules/python/python-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="python/testing" version="5.16.5" checksum="12b0a03707c933dcef8e54d49b7ae9de5d92415e227df4ec4b75e3eea805edbd" -->
 # Python Testing Rules
 
 These rules provide Python Testing Rules guidance for projects in this repository.

--- a/.codex/rules/typescript/typescript-linting.md
+++ b/.codex/rules/typescript/typescript-linting.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/linting" version="5.16.5" checksum="65d16fdc748fcafc789128d133433d6f31b7ab25cb52b5e5a64d3519bc1040ff" -->
 # TypeScript Linting Rules
 
 These rules are intended for Codex (CLI and app).

--- a/.codex/rules/typescript/typescript-logging.md
+++ b/.codex/rules/typescript/typescript-logging.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/logging" version="5.16.5" checksum="4eb1c4f956b6f3f55b3c7f6f441ef5b0fe3283ec0ca9e55b050d8fcb6e47a1ea" -->
 # Centralized Logging Rules
 
 These rules are intended for Codex (CLI and app).

--- a/.codex/rules/typescript/typescript-testing.md
+++ b/.codex/rules/typescript/typescript-testing.md
@@ -1,3 +1,4 @@
+<!-- ballast:rule id="typescript/testing" version="5.16.5" checksum="94c40698e162d97039f3fd50ec809e064746b46f6996a5f49f2a2ec8f4ad3da2" -->
 # Testing Rules
 
 These rules are intended for Codex (CLI and app).

--- a/PRD.md
+++ b/PRD.md
@@ -425,6 +425,33 @@ Operators also need to know when saved language paths have drifted from the repo
 9. Given stale saved TypeScript paths and a current detected TypeScript path, wrapper `ballast doctor --fix` rewrites `.rulesrc.json` to the detected path before refreshing generated outputs.
 10. Given a `.rulesrc.json` with only `go` configured and a globally installed `ballast-typescript` on `PATH`, wrapper `ballast doctor` does not report the TypeScript backend.
 
+## Ballast Doctor Rule Drift Detection
+
+### Problem
+
+Ballast-generated rule files can diverge from current source templates when users edit generated files, merge conflicts leave noise behind, or saved `.rulesrc.json` targets and agents change while old managed files remain on disk. Without a machine-readable ownership marker, `ballast doctor` cannot reliably distinguish current managed files from stale managed files or user-authored files.
+
+### Requirements
+
+1. Every generated Ballast-managed rule file must include a machine-readable marker with `id`, `version`, and `checksum`.
+2. The marker checksum must be computed from generated rule content with the marker excluded so the checksum is stable and non-self-referential.
+3. `ballast doctor` must enumerate generated rule destinations for configured targets and known rule directories, parse rule markers, and categorize files as `ok`, `drifted`, `stale`, or `unowned`.
+4. `ballast doctor` must compare marked rule files against the canonical content Ballast would generate for the marked rule ID.
+5. `ballast doctor` must add recommendations for drifted and stale managed rule files while making unowned files explicitly skipped.
+6. `ballast doctor --fix` must delete stale managed rule files and print each deleted path.
+7. `ballast doctor --fix` must never delete unowned files and must never overwrite drifted files.
+8. The behavior must be covered across the TypeScript backend and mirrored rule-generation surfaces in Python and Go where applicable.
+
+### Acceptance Criteria
+
+1. Given a Ballast-generated rule file, the file contains `<!-- ballast:rule id="..." version="..." checksum="..." -->`.
+2. Given a marked file whose body still matches current generated content and remains in `.rulesrc.json`, `ballast doctor` reports it as `ok`.
+3. Given a marked active file whose content differs from its marker checksum or current generated content, `ballast doctor` reports it as `drifted` and recommends `ballast install --refresh-config`.
+4. Given a marked file that is no longer part of the current saved config, `ballast doctor` reports it as `stale` and recommends `ballast doctor --fix`.
+5. Given a file without a Ballast rule marker, `ballast doctor` reports it as `unowned` and skips remediation.
+6. Given stale, drifted, and unowned rule files, `ballast doctor --fix` removes only the stale managed files, prints removed paths, leaves drifted and unowned files untouched, and keeps recommending refresh for drifted files.
+7. Automated tests cover marker parsing, checksum comparison, report formatting, stale cleanup, and safety behavior.
+
 ## JavaScript Detection Warning
 
 ### Problem

--- a/agents/common/local-dev/content-env.md
+++ b/agents/common/local-dev/content-env.md
@@ -2,7 +2,7 @@
 
 You are a local development environment specialist for the repository's configured languages and runtimes.
 
-Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+Use this rule to set direction, then read implementation files or docs for details.
 
 For the full playbook and examples, use `docs/agents/local-dev.md`.
 
@@ -28,7 +28,7 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Branch Before Code
 
-Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix. If both default-branch detection methods fail, create or switch to a task branch before editing files.
 
 - If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
 - If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -3724,9 +3724,8 @@ func removeStaleManagedFiles(root string, target string, previous *monorepoConfi
 		return nil
 	}
 	trackedPaths := ballastManagedPathsFromSupportFile(root, target)
-	configBackedStaleRulePaths := configBackedStaleRulePathSet(root, target, previous)
 	for _, file := range stringDifference(allManagedRulePaths(root, target), managedRulePaths(root, target, next)) {
-		if !ballastOwnsManagedFile(file) && !trackedPaths[file] && !configBackedStaleRulePaths[file] && !looksLikeLegacyGeneratedRule(file) {
+		if !ballastOwnsManagedFile(file) && !trackedPaths[file] {
 			continue
 		}
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -3774,7 +3773,7 @@ func removeUnlistedManagedRuleFiles(root string, target string, next *monorepoCo
 		if expected[cleaned] {
 			return nil
 		}
-		if !ballastOwnsManagedFile(cleaned) && !looksLikeLegacyGeneratedRule(cleaned) {
+		if !ballastOwnsManagedFile(cleaned) {
 			return nil
 		}
 		if err := os.Remove(cleaned); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -4211,9 +4210,12 @@ func patchInstalledRulesSection(existing string, canonical string) string {
 const rootPlaceholder = "__BALLAST_ROOT__"
 const ballastManagedMarker = "Created by [Ballast]"
 const ballastManagedSectionNotice = "Created by Ballast. Do not edit this section."
+const ballastRuleMarker = "ballast:rule"
 
 func containsBallastManagedMarker(content string) bool {
-	return strings.Contains(content, ballastManagedMarker) || strings.Contains(content, ballastManagedSectionNotice)
+	return strings.Contains(content, ballastManagedMarker) ||
+		strings.Contains(content, ballastManagedSectionNotice) ||
+		strings.Contains(content, ballastRuleMarker)
 }
 
 func patchManagedSupportSections(existing string, canonical string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -4210,12 +4210,12 @@ func patchInstalledRulesSection(existing string, canonical string) string {
 const rootPlaceholder = "__BALLAST_ROOT__"
 const ballastManagedMarker = "Created by [Ballast]"
 const ballastManagedSectionNotice = "Created by Ballast. Do not edit this section."
-const ballastRuleMarker = "ballast:rule"
+const ballastRuleMarkerPrefix = "<!-- ballast:rule "
 
 func containsBallastManagedMarker(content string) bool {
 	return strings.Contains(content, ballastManagedMarker) ||
 		strings.Contains(content, ballastManagedSectionNotice) ||
-		strings.Contains(content, ballastRuleMarker)
+		strings.Contains(content, ballastRuleMarkerPrefix)
 }
 
 func patchManagedSupportSections(existing string, canonical string) string {

--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -4215,7 +4215,17 @@ const ballastRuleMarkerPrefix = "<!-- ballast:rule "
 func containsBallastManagedMarker(content string) bool {
 	return strings.Contains(content, ballastManagedMarker) ||
 		strings.Contains(content, ballastManagedSectionNotice) ||
-		strings.Contains(content, ballastRuleMarkerPrefix)
+		hasRuleMarkerAtGeneratedHeader(content)
+}
+
+func hasRuleMarkerAtGeneratedHeader(content string) bool {
+	if strings.HasPrefix(content, ballastRuleMarkerPrefix) {
+		return true
+	}
+	if match := regexp.MustCompile(`(?s)^---\r?\n.*?\r?\n---\r?\n?`).FindStringIndex(content); match != nil && match[0] == 0 {
+		return strings.HasPrefix(content[match[1]:], ballastRuleMarkerPrefix)
+	}
+	return false
 }
 
 func patchManagedSupportSections(existing string, canonical string) string {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -4470,6 +4470,40 @@ func TestRemoveStaleManagedFilesPreservesCursorSkillsUnderRules(t *testing.T) {
 	}
 }
 
+func TestRemoveStaleManagedFilesOnlyOwnsLiteralRuleMarkerPrefix(t *testing.T) {
+	root := resolvedTempDir(t)
+	mentioned := filepath.Join(root, ".codex", "rules", "common", "docs.md")
+	marked := filepath.Join(root, ".codex", "rules", "common", "observability.md")
+	legacy := filepath.Join(root, ".codex", "rules", "common", "cicd.md")
+	mustWriteFile(t, mentioned, "# Docs\n\nThis example mentions ballast:rule but is user-authored.\n")
+	mustWriteFile(t, marked, "<!-- ballast:rule id=\"common/observability\" version=\"dev\" checksum=\"0123456789abcdef\" -->\n# Observability\n")
+	mustWriteFile(t, legacy, "<!-- Created by Ballast. Do not edit this section. -->\n# CI/CD\n")
+
+	previous := &monorepoConfig{
+		Targets:   []string{"codex"},
+		Agents:    []string{"docs", "observability", "cicd"},
+		Languages: []string{"typescript"},
+	}
+	next := &monorepoConfig{
+		Targets:   []string{"codex"},
+		Agents:    []string{"local-dev"},
+		Languages: []string{"typescript"},
+	}
+
+	if err := removeStaleManagedFiles(root, "codex", previous, next); err != nil {
+		t.Fatalf("removeStaleManagedFiles(codex): %v", err)
+	}
+	if _, err := os.Stat(mentioned); err != nil {
+		t.Fatalf("expected user-authored ballast:rule mention to remain, got %v", err)
+	}
+	if fileExists(marked) {
+		t.Fatalf("expected literal generated rule marker file to be removed: %s", marked)
+	}
+	if fileExists(legacy) {
+		t.Fatalf("expected legacy Ballast notice file to be removed: %s", legacy)
+	}
+}
+
 func TestRemoveStaleManagedFilesDeletesConfigBackedOpencodeSkill(t *testing.T) {
 	root := resolvedTempDir(t)
 	skillPath := filepath.Join(root, ".opencode", "skills", "github-health-check.md")

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -5363,6 +5363,15 @@ func TestRemoveStaleManagedFilesPreservesUnownedGeneratedLookingRules(t *testing
 	}
 }
 
+func TestContainsBallastManagedMarkerRequiresLiteralRuleMarkerPrefix(t *testing.T) {
+	if !containsBallastManagedMarker(`<!-- ballast:rule id="typescript/linting" version="5.0.0" checksum="abc123" -->`) {
+		t.Fatal("expected literal rule marker prefix to be treated as managed")
+	}
+	if containsBallastManagedMarker("Manual notes that mention ballast:rule without a marker comment") {
+		t.Fatal("did not expect prose mentioning ballast:rule to be treated as managed")
+	}
+}
+
 // resolvedTempDir wraps t.TempDir and resolves symlinks so that path
 // comparisons work on macOS where /tmp is a symlink to /private/tmp.
 func resolvedTempDir(t *testing.T) string {

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -4755,7 +4755,7 @@ func TestRunMonorepoRemoveLanguageCleansManagedRulesAndConfig(t *testing.T) {
 	}
 }
 
-func TestRunMonorepoRemoveLanguageCleansConfigBackedRuleWithoutMarker(t *testing.T) {
+func TestRunMonorepoRemoveLanguagePreservesConfigBackedRuleWithoutMarker(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, ".rulesrc.json"), `{
   "targets": ["codex"],
@@ -4792,8 +4792,8 @@ func TestRunMonorepoRemoveLanguageCleansConfigBackedRuleWithoutMarker(t *testing
 		}
 	})
 
-	if _, err := os.Stat(filepath.Join(root, ".codex", "rules", "typescript", "typescript-linting.md")); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("expected config-backed markerless typescript rule to be removed, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(root, ".codex", "rules", "typescript", "typescript-linting.md")); err != nil {
+		t.Fatalf("expected config-backed markerless typescript rule to be preserved, got err=%v", err)
 	}
 }
 
@@ -5309,11 +5309,12 @@ func TestRemoveStaleManagedFilesRemovesLegacyRootRules(t *testing.T) {
 	commonLanguageRule := filepath.Join(root, ".claude", "rules", "common", "go-testing.md")
 	languageLocalDevRule := filepath.Join(root, ".claude", "rules", "go", "go-local-dev-badges.md")
 	current := filepath.Join(root, ".claude", "rules", "common", "publishing-web.md")
-	mustWriteFile(t, legacy, "---\n# Publishing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
-	mustWriteFile(t, removedLanguageGitHooks, "# Git Hooks Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
-	mustWriteFile(t, crossLanguageRule, "# Testing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
-	mustWriteFile(t, commonLanguageRule, "# Go Testing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
-	mustWriteFile(t, languageLocalDevRule, "# Local Development: README Badges\n\nThese rules are intended for Claude Code.\n\n---\n")
+	legacyNotice := "<!-- Created by [Ballast](https://github.com/everydaydevopsio/ballast) v1.0.0. Do not edit this section. -->\n"
+	mustWriteFile(t, legacy, legacyNotice+"---\n# Publishing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
+	mustWriteFile(t, removedLanguageGitHooks, legacyNotice+"# Git Hooks Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
+	mustWriteFile(t, crossLanguageRule, legacyNotice+"# Testing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
+	mustWriteFile(t, commonLanguageRule, legacyNotice+"# Go Testing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
+	mustWriteFile(t, languageLocalDevRule, legacyNotice+"# Local Development: README Badges\n\nThese rules are intended for Claude Code.\n\n---\n")
 	mustWriteFile(t, current, "<!-- Created by [Ballast](https://github.com/everydaydevopsio/ballast) v1.0.0. Do not edit this section. -->\n")
 
 	next := &monorepoConfig{
@@ -5341,6 +5342,24 @@ func TestRemoveStaleManagedFilesRemovesLegacyRootRules(t *testing.T) {
 	}
 	if !fileExists(current) {
 		t.Fatalf("expected current common rule to remain: %s", current)
+	}
+}
+
+func TestRemoveStaleManagedFilesPreservesUnownedGeneratedLookingRules(t *testing.T) {
+	root := resolvedTempDir(t)
+	unowned := filepath.Join(root, ".claude", "rules", "publishing-web.md")
+	mustWriteFile(t, unowned, "---\n# Publishing Rules\n\nThese rules are intended for Claude Code.\n\n---\n")
+
+	next := &monorepoConfig{
+		Agents:    []string{"linting"},
+		Languages: []string{"typescript"},
+	}
+
+	if err := removeStaleManagedFiles(root, "claude", nil, next); err != nil {
+		t.Fatalf("removeStaleManagedFiles returned error: %v", err)
+	}
+	if !fileExists(unowned) {
+		t.Fatalf("expected unowned generated-looking rule to remain: %s", unowned)
 	}
 }
 

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -5401,8 +5401,14 @@ func TestContainsBallastManagedMarkerRequiresLiteralRuleMarkerPrefix(t *testing.
 	if !containsBallastManagedMarker(`<!-- ballast:rule id="typescript/linting" version="5.0.0" checksum="abc123" -->`) {
 		t.Fatal("expected literal rule marker prefix to be treated as managed")
 	}
+	if !containsBallastManagedMarker("---\ntitle: Rule\n---\n<!-- ballast:rule id=\"typescript/linting\" version=\"5.0.0\" checksum=\"abc123\" -->") {
+		t.Fatal("expected rule marker after frontmatter to be treated as managed")
+	}
 	if containsBallastManagedMarker("Manual notes that mention ballast:rule without a marker comment") {
 		t.Fatal("did not expect prose mentioning ballast:rule to be treated as managed")
+	}
+	if containsBallastManagedMarker("# Docs\n\n```md\n<!-- ballast:rule id=\"typescript/linting\" version=\"5.0.0\" checksum=\"abc123\" -->\n```") {
+		t.Fatal("did not expect copied rule marker in body to be treated as managed")
 	}
 }
 

--- a/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/common/local-dev/content-env.md
@@ -2,7 +2,7 @@
 
 You are a local development environment specialist for the repository's configured languages and runtimes.
 
-Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+Use this rule to set direction, then read implementation files or docs for details.
 
 For the full playbook and examples, use `docs/agents/local-dev.md`.
 
@@ -28,7 +28,7 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Branch Before Code
 
-Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix. If both default-branch detection methods fail, create or switch to a task branch before editing files.
 
 - If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
 - If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -58,7 +58,7 @@ var publishingProfileAliases = map[string]string{
 	"sdk":     "sdks",
 }
 
-var ruleMarkerRegex = regexp.MustCompile(`<!-- ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?`)
+var ruleMarkerRegex = regexp.MustCompile(`^<!-- ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]{64})"\s*-->\r?\n?`)
 
 type ruleMarker struct {
 	ruleID   string
@@ -2141,7 +2141,7 @@ func ruleMarkerID(agentID, language, suffix string) string {
 }
 
 func parseRuleMarker(content string) (*ruleMarker, bool) {
-	matches := ruleMarkerRegex.FindStringSubmatch(content)
+	matches := ruleMarkerRegex.FindStringSubmatch(content[ruleMarkerHeaderStart(content):])
 	if len(matches) != 4 {
 		return nil, false
 	}
@@ -2153,7 +2153,20 @@ func parseRuleMarker(content string) (*ruleMarker, bool) {
 }
 
 func stripRuleMarker(content string) string {
-	return ruleMarkerRegex.ReplaceAllString(content, "")
+	start := ruleMarkerHeaderStart(content)
+	match := ruleMarkerRegex.FindStringIndex(content[start:])
+	if match == nil || match[0] != 0 {
+		return content
+	}
+	return content[:start] + content[start+match[1]:]
+}
+
+func ruleMarkerHeaderStart(content string) int {
+	frontmatterRegex := regexp.MustCompile(`(?s)^---\r?\n.*?\r?\n---\r?\n?`)
+	if match := frontmatterRegex.FindStringIndex(content); match != nil && match[0] == 0 {
+		return match[1]
+	}
+	return 0
 }
 
 func calculateRuleChecksum(content string) string {

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -58,7 +58,7 @@ var publishingProfileAliases = map[string]string{
 	"sdk":     "sdks",
 }
 
-var ruleMarkerRegex = regexp.MustCompile(`<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?`)
+var ruleMarkerRegex = regexp.MustCompile(`<!-- ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?`)
 
 type ruleMarker struct {
 	ruleID   string

--- a/packages/ballast-go/cmd/ballast-go/main.go
+++ b/packages/ballast-go/cmd/ballast-go/main.go
@@ -4,7 +4,9 @@ import (
 	"archive/zip"
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -55,6 +57,15 @@ var publishingProfileAliases = map[string]string{
 	"library": "libraries",
 	"sdk":     "sdks",
 }
+
+var ruleMarkerRegex = regexp.MustCompile(`<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?`)
+
+type ruleMarker struct {
+	ruleID   string
+	version  string
+	checksum string
+}
+
 var defaultLanguageTools = map[string][]string{
 	"python":     {"uv", "pyenv"},
 	"typescript": {"pnpm", "corepack"},
@@ -2078,14 +2089,14 @@ func buildContent(agentID, target, language, suffix, hookMode, taskSystem, deplo
 		}
 		front = applyHookTemplateVariables(front, agentID, language, hookMode)
 		front = applyTaskSystemVariables(front, agentID, taskSystem)
-		return front + "\n" + content, nil
+		return addRuleMarker(front+"\n"+content, ruleMarkerID(agentID, language, suffix)), nil
 	case "claude":
 		header, err := readTemplate(agentID, language, "claude-header.md", suffix)
 		if err != nil {
 			return "", err
 		}
 		header = applyTaskSystemVariables(header, agentID, taskSystem)
-		return header + content, nil
+		return addRuleMarker(header+content, ruleMarkerID(agentID, language, suffix)), nil
 	case "gemini":
 		header, err := readTemplate(agentID, language, "gemini-header.md", suffix)
 		if err != nil {
@@ -2098,14 +2109,14 @@ func buildContent(agentID, target, language, suffix, hookMode, taskSystem, deplo
 			}
 		}
 		header = applyTaskSystemVariables(header, agentID, taskSystem)
-		return header + "\n---\n\n" + renderGeminiMandates() + content, nil
+		return addRuleMarker(header+"\n---\n\n"+renderGeminiMandates()+content, ruleMarkerID(agentID, language, suffix)), nil
 	case "opencode":
 		front, err := readTemplate(agentID, language, "opencode-frontmatter.yaml", suffix)
 		if err != nil {
 			return "", err
 		}
 		front = applyTaskSystemVariables(front, agentID, taskSystem)
-		return front + "\n" + content, nil
+		return addRuleMarker(front+"\n"+content, ruleMarkerID(agentID, language, suffix)), nil
 	case "codex":
 		header, err := readTemplate(agentID, language, "codex-header.md", suffix)
 		if err != nil {
@@ -2115,10 +2126,59 @@ func buildContent(agentID, target, language, suffix, hookMode, taskSystem, deplo
 			}
 		}
 		header = applyTaskSystemVariables(header, agentID, taskSystem)
-		return header + content, nil
+		return addRuleMarker(header+content, ruleMarkerID(agentID, language, suffix)), nil
 	default:
 		return "", fmt.Errorf("unknown target: %s", target)
 	}
+}
+
+func ruleMarkerID(agentID, language, suffix string) string {
+	parts := []string{language, agentID}
+	if strings.TrimSpace(suffix) != "" {
+		parts = append(parts, suffix)
+	}
+	return strings.Join(parts, "/")
+}
+
+func parseRuleMarker(content string) (*ruleMarker, bool) {
+	matches := ruleMarkerRegex.FindStringSubmatch(content)
+	if len(matches) != 4 {
+		return nil, false
+	}
+	return &ruleMarker{
+		ruleID:   matches[1],
+		version:  matches[2],
+		checksum: strings.ToLower(matches[3]),
+	}, true
+}
+
+func stripRuleMarker(content string) string {
+	return ruleMarkerRegex.ReplaceAllString(content, "")
+}
+
+func calculateRuleChecksum(content string) string {
+	sum := sha256.Sum256([]byte(stripRuleMarker(content)))
+	return hex.EncodeToString(sum[:])
+}
+
+func verifyRuleChecksum(content string) bool {
+	marker, ok := parseRuleMarker(content)
+	return ok && calculateRuleChecksum(content) == marker.checksum
+}
+
+func addRuleMarker(content, ruleID string) string {
+	body := stripRuleMarker(content)
+	marker := fmt.Sprintf(
+		`<!-- ballast:rule id="%s" version="%s" checksum="%s" -->`,
+		ruleID,
+		resolveVersion(),
+		calculateRuleChecksum(body),
+	)
+	frontmatterRegex := regexp.MustCompile(`(?s)^---\r?\n.*?\r?\n---\r?\n?`)
+	if match := frontmatterRegex.FindStringIndex(body); match != nil && match[0] == 0 {
+		return body[:match[1]] + marker + "\n" + body[match[1]:]
+	}
+	return marker + "\n" + body
 }
 
 func renderGitHooksPreCommitGlob(agentID, language, hookMode string) string {

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -205,6 +205,32 @@ func TestBuildDoctorReportRecommendsUpgrades(t *testing.T) {
 	}
 }
 
+func TestBuildContentWritesRuleMarkerAndDetectsDrift(t *testing.T) {
+	content, err := buildContent("linting", "codex", "go", "", "pre-commit", "", "")
+	if err != nil {
+		t.Fatalf("build content: %v", err)
+	}
+	marker, ok := parseRuleMarker(content)
+	if !ok {
+		t.Fatalf("expected rule marker in %q", content[:120])
+	}
+	if marker.ruleID != "go/linting" {
+		t.Fatalf("expected rule id go/linting, got %q", marker.ruleID)
+	}
+	if marker.version != resolveVersion() {
+		t.Fatalf("expected marker version %q, got %q", resolveVersion(), marker.version)
+	}
+	if !regexp.MustCompile(`^[a-f0-9]{64}$`).MatchString(marker.checksum) {
+		t.Fatalf("expected sha256 checksum, got %q", marker.checksum)
+	}
+	if !verifyRuleChecksum(content) {
+		t.Fatalf("expected generated content checksum to verify")
+	}
+	if verifyRuleChecksum(content + "\nManual edit\n") {
+		t.Fatalf("expected checksum verification to fail after body edit")
+	}
+}
+
 func makeGitBoundary(t *testing.T, dir string) {
 	t.Helper()
 	gitDir := filepath.Join(dir, ".git")

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -241,6 +241,29 @@ func TestParseRuleMarkerRequiresGeneratedPrefix(t *testing.T) {
 	}
 }
 
+func TestParseRuleMarkerRequiresGeneratedHeaderPosition(t *testing.T) {
+	marker := "<!-- ballast:rule id=\"go/linting\" version=\"dev\" checksum=\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" -->\n"
+	bodyExample := "# Notes\n\n```md\n" + marker + "```\n"
+	if parsed, ok := parseRuleMarker(bodyExample); ok {
+		t.Fatalf("expected copied marker in body to be ignored, got %#v", parsed)
+	}
+	if stripped := stripRuleMarker(bodyExample); stripped != bodyExample {
+		t.Fatalf("expected copied marker in body to remain, got %q", stripped)
+	}
+
+	withFrontmatter := "---\ntitle: Rule\n---\n" + marker + "# Rule\n"
+	parsed, ok := parseRuleMarker(withFrontmatter)
+	if !ok {
+		t.Fatal("expected marker after frontmatter to parse")
+	}
+	if parsed.ruleID != "go/linting" {
+		t.Fatalf("expected rule id go/linting, got %q", parsed.ruleID)
+	}
+	if stripped := stripRuleMarker(withFrontmatter); stripped != "---\ntitle: Rule\n---\n# Rule\n" {
+		t.Fatalf("expected marker after frontmatter to be stripped, got %q", stripped)
+	}
+}
+
 func makeGitBoundary(t *testing.T, dir string) {
 	t.Helper()
 	gitDir := filepath.Join(dir, ".git")

--- a/packages/ballast-go/cmd/ballast-go/main_test.go
+++ b/packages/ballast-go/cmd/ballast-go/main_test.go
@@ -231,6 +231,16 @@ func TestBuildContentWritesRuleMarkerAndDetectsDrift(t *testing.T) {
 	}
 }
 
+func TestParseRuleMarkerRequiresGeneratedPrefix(t *testing.T) {
+	content := "<!--\nballast:rule id=\"go/linting\" version=\"dev\" checksum=\"0123456789abcdef\" -->\n# Rule\n"
+	if marker, ok := parseRuleMarker(content); ok {
+		t.Fatalf("expected non-generated marker prefix to be ignored, got %#v", marker)
+	}
+	if stripped := stripRuleMarker(content); stripped != content {
+		t.Fatalf("expected non-generated marker prefix to remain, got %q", stripped)
+	}
+}
+
 func makeGitBoundary(t *testing.T, dir string) {
 	t.Helper()
 	gitDir := filepath.Join(dir, ".git")

--- a/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-go/cmd/ballast/agents/common/local-dev/content-env.md
@@ -2,7 +2,7 @@
 
 You are a local development environment specialist for the repository's configured languages and runtimes.
 
-Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+Use this rule to set direction, then read implementation files or docs for details.
 
 For the full playbook and examples, use `docs/agents/local-dev.md`.
 
@@ -28,7 +28,7 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Branch Before Code
 
-Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix. If both default-branch detection methods fail, create or switch to a task branch before editing files.
 
 - If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
 - If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.

--- a/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
+++ b/packages/ballast-python/ballast/agents/common/local-dev/content-env.md
@@ -2,7 +2,7 @@
 
 You are a local development environment specialist for the repository's configured languages and runtimes.
 
-Keep this rule concise. Use it to set direction, then read implementation files or docs for details instead of dumping large boilerplate into the conversation.
+Use this rule to set direction, then read implementation files or docs for details.
 
 For the full playbook and examples, use `docs/agents/local-dev.md`.
 
@@ -28,7 +28,7 @@ For the full playbook and examples, use `docs/agents/local-dev.md`.
 
 ## Branch Before Code
 
-Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix before comparing it to the current branch name. If both default-branch detection methods fail, assume the checkout is unsafe and create or switch to a task branch before editing files.
+Before modifying files, check the current branch with `git branch --show-current` and determine the default branch with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. If that command fails for any reason, use `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the `origin/` prefix. If both default-branch detection methods fail, create or switch to a task branch before editing files.
 
 - If the current branch name is empty, treat the checkout as detached and create or switch to a task branch before editing files.
 - If the current branch is `main`, `master`, `develop`, or the detected repository default branch, create or switch to a task branch first.

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1140,7 +1140,7 @@ def rule_marker_id(agent: str, language: str, suffix: str = "") -> str:
 
 
 def parse_rule_marker(content: str) -> dict[str, str] | None:
-    match = RULE_MARKER_RE.search(content)
+    match = RULE_MARKER_RE.match(content, rule_marker_header_start(content))
     if not match:
         return None
     return {
@@ -1151,7 +1151,15 @@ def parse_rule_marker(content: str) -> dict[str, str] | None:
 
 
 def strip_rule_marker(content: str) -> str:
-    return RULE_MARKER_RE.sub("", content, count=1)
+    match = RULE_MARKER_RE.match(content, rule_marker_header_start(content))
+    if not match:
+        return content
+    return content[: match.start()] + content[match.end() :]
+
+
+def rule_marker_header_start(content: str) -> int:
+    frontmatter = re.match(r"^---\r?\n[\s\S]*?\r?\n---\r?\n?", content)
+    return frontmatter.end() if frontmatter else 0
 
 
 def calculate_rule_checksum(content: str) -> str:
@@ -2644,5 +2652,5 @@ def main(argv: list[str] | None = None) -> int:
 
 
 RULE_MARKER_RE = re.compile(
-    r'<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?'
+    r'<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]{64})"\s*-->\r?\n?'
 )

--- a/packages/ballast-python/ballast/cli.py
+++ b/packages/ballast-python/ballast/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import io
 import json
 import os
@@ -1095,7 +1096,7 @@ def build_content(
         task_system,
     )
     if target == "cursor":
-        return (
+        rendered = (
             apply_hook_template_variables(
                 read_template(agent, language, "cursor-frontmatter.yaml", suffix),
                 agent,
@@ -1105,8 +1106,10 @@ def build_content(
             + "\n"
             + body
         )
+        return add_rule_marker(rendered, rule_marker_id(agent, language, suffix))
     if target == "claude":
-        return read_template(agent, language, "claude-header.md", suffix) + body
+        rendered = read_template(agent, language, "claude-header.md", suffix) + body
+        return add_rule_marker(rendered, rule_marker_id(agent, language, suffix))
     if target == "gemini":
         try:
             header = read_template(agent, language, "gemini-header.md", suffix)
@@ -1115,18 +1118,62 @@ def build_content(
                 header = read_template(agent, language, "claude-header.md", suffix)
             except FileNotFoundError:
                 header = read_template(agent, language, "codex-header.md", suffix)
-        return header + "\n---\n\n" + render_gemini_mandates() + body
+        rendered = header + "\n---\n\n" + render_gemini_mandates() + body
+        return add_rule_marker(rendered, rule_marker_id(agent, language, suffix))
     if target == "opencode":
-        return (
+        rendered = (
             read_template(agent, language, "opencode-frontmatter.yaml", suffix)
             + "\n"
             + body
         )
+        return add_rule_marker(rendered, rule_marker_id(agent, language, suffix))
     try:
         header = read_template(agent, language, "codex-header.md", suffix)
     except FileNotFoundError:
         header = read_template(agent, language, "claude-header.md", suffix)
-    return header + body
+    rendered = header + body
+    return add_rule_marker(rendered, rule_marker_id(agent, language, suffix))
+
+
+def rule_marker_id(agent: str, language: str, suffix: str = "") -> str:
+    return "/".join(part for part in [language, agent, suffix] if part)
+
+
+def parse_rule_marker(content: str) -> dict[str, str] | None:
+    match = RULE_MARKER_RE.search(content)
+    if not match:
+        return None
+    return {
+        "ruleId": match.group(1),
+        "version": match.group(2),
+        "checksum": match.group(3).lower(),
+    }
+
+
+def strip_rule_marker(content: str) -> str:
+    return RULE_MARKER_RE.sub("", content, count=1)
+
+
+def calculate_rule_checksum(content: str) -> str:
+    return hashlib.sha256(strip_rule_marker(content).encode("utf-8")).hexdigest()
+
+
+def verify_rule_checksum(content: str) -> bool:
+    marker = parse_rule_marker(content)
+    return bool(marker and calculate_rule_checksum(content) == marker["checksum"])
+
+
+def add_rule_marker(content: str, rule_id: str) -> str:
+    body = strip_rule_marker(content)
+    checksum = calculate_rule_checksum(body)
+    marker = (
+        f'<!-- ballast:rule id="{rule_id}" version="{ballast_version()}" '
+        f'checksum="{checksum}" -->'
+    )
+    frontmatter = re.match(r"^---\r?\n[\s\S]*?\r?\n---\r?\n?", body)
+    if frontmatter:
+        return body[: frontmatter.end()] + marker + "\n" + body[frontmatter.end() :]
+    return marker + "\n" + body
 
 
 def read_skill(skill: str, language: str) -> str:
@@ -2594,3 +2641,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Unknown command: {command}")
         return 1
     return run_install(args)
+
+
+RULE_MARKER_RE = re.compile(
+    r'<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?'
+)

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -82,6 +82,24 @@ class PatchInstallTests(unittest.TestCase):
         self.assertIn("- deploymentModel: serverless", output)
         self.assertIn("- publishingProfiles: cli, web", output)
 
+    def test_build_content_writes_rule_marker_and_detects_drift(self) -> None:
+        content = cli.build_content("linting", "codex", "python")
+
+        self.assertRegex(
+            content,
+            r'^<!-- ballast:rule id="python/linting" version="[^"]+" checksum="[a-f0-9]{64}" -->\n',
+        )
+        self.assertEqual(
+            cli.parse_rule_marker(content),
+            {
+                "ruleId": "python/linting",
+                "version": cli.ballast_version(),
+                "checksum": cli.parse_rule_marker(content)["checksum"],
+            },
+        )
+        self.assertTrue(cli.verify_rule_checksum(content))
+        self.assertFalse(cli.verify_rule_checksum(content + "\nManual edit\n"))
+
     def test_parser_top_level_help_flag_exits_zero(self) -> None:
         with self.assertRaises(SystemExit) as exc:
             cli.parser().parse_args(["--help"])

--- a/packages/ballast-python/tests/test_cli.py
+++ b/packages/ballast-python/tests/test_cli.py
@@ -100,6 +100,24 @@ class PatchInstallTests(unittest.TestCase):
         self.assertTrue(cli.verify_rule_checksum(content))
         self.assertFalse(cli.verify_rule_checksum(content + "\nManual edit\n"))
 
+    def test_rule_marker_requires_generated_header_position(self) -> None:
+        marker = (
+            '<!-- ballast:rule id="python/linting" version="dev" '
+            'checksum="0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" -->\n'
+        )
+        body_example = "# Notes\n\n```md\n" + marker + "```\n"
+
+        self.assertIsNone(cli.parse_rule_marker(body_example))
+        self.assertEqual(cli.strip_rule_marker(body_example), body_example)
+
+        with_frontmatter = "---\ntitle: Rule\n---\n" + marker + "# Rule\n"
+        parsed = cli.parse_rule_marker(with_frontmatter)
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed["ruleId"], "python/linting")
+        self.assertEqual(
+            cli.strip_rule_marker(with_frontmatter), "---\ntitle: Rule\n---\n# Rule\n"
+        )
+
     def test_parser_top_level_help_flag_exits_zero(self) -> None:
         with self.assertRaises(SystemExit) as exc:
             cli.parser().parse_args(["--help"])

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -23,11 +23,38 @@ import {
   extractDescriptionFromFrontmatter,
   getDestination,
   getSkillDestination,
-  listTargets
+  listTargets,
+  parseRuleMarker,
+  verifyRuleChecksum
 } from './build';
 import { COMMON_SKILL_IDS } from './agents';
 
 describe('build', () => {
+  describe('managed rule marker', () => {
+    test('buildContent writes a machine-readable rule marker', () => {
+      const content = buildContent('linting', 'codex', undefined, 'typescript');
+
+      expect(content).toMatch(
+        /^<!-- ballast:rule id="typescript\/linting" version="[^"]+" checksum="[a-f0-9]{64}" -->\n/
+      );
+      expect(parseRuleMarker(content)).toEqual(
+        expect.objectContaining({
+          ruleId: 'typescript/linting',
+          version: expect.any(String),
+          checksum: expect.stringMatching(/^[a-f0-9]{64}$/)
+        })
+      );
+      expect(verifyRuleChecksum(content)).toBe(true);
+    });
+
+    test('verifyRuleChecksum detects body drift after the marker', () => {
+      const content = buildContent('linting', 'codex', undefined, 'typescript');
+      const drifted = `${content}\nManual edit\n`;
+
+      expect(verifyRuleChecksum(drifted)).toBe(false);
+    });
+  });
+
   describe('listRuleSuffixes', () => {
     test('returns only main rule for linting (no content-*.md)', () => {
       expect(listRuleSuffixes('linting')).toEqual(['']);

--- a/packages/ballast-typescript/src/build.test.ts
+++ b/packages/ballast-typescript/src/build.test.ts
@@ -53,6 +53,38 @@ describe('build', () => {
 
       expect(verifyRuleChecksum(drifted)).toBe(false);
     });
+
+    test('parseRuleMarker ignores markers outside the generated location', () => {
+      const content = [
+        '# Manual rule',
+        '',
+        'Example:',
+        '<!-- ballast:rule id="typescript/linting" version="5.0.0" checksum="0123456789abcdef" -->',
+        ''
+      ].join('\n');
+
+      expect(parseRuleMarker(content)).toBeNull();
+      expect(verifyRuleChecksum(content)).toBe(false);
+    });
+
+    test('parseRuleMarker accepts markers directly after frontmatter', () => {
+      const content = buildContent(
+        'linting',
+        'cursor',
+        undefined,
+        'typescript'
+      );
+
+      expect(content).toMatch(
+        /^---\n[\s\S]*?\n---\n<!-- ballast:rule id="typescript\/linting"/
+      );
+      expect(parseRuleMarker(content)).toEqual(
+        expect.objectContaining({
+          ruleId: 'typescript/linting'
+        })
+      );
+      expect(verifyRuleChecksum(content)).toBe(true);
+    });
   });
 
   describe('listRuleSuffixes', () => {

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import crypto from 'crypto';
 import path from 'path';
 import YAML from 'yaml';
 import {
@@ -29,10 +30,19 @@ interface BuildOptions {
   variables?: Record<string, string>;
 }
 
+export interface RuleMarker {
+  ruleId: string;
+  version: string;
+  checksum: string;
+}
+
 interface SkillEntry {
   name: string;
   data: Buffer;
 }
+
+const RULE_MARKER_PATTERN =
+  /<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?/;
 
 function getCreatedByBallastLine(): string {
   return `Created by [Ballast](${BALLAST_REPO_URL}) v${pkg.version}. Do not edit this section.`;
@@ -74,6 +84,51 @@ function getRuleBasename(
     return basename;
   }
   return `${language}-${basename}`;
+}
+
+export function getRuleMarkerId(
+  agentId: string,
+  language: Language,
+  ruleSuffix?: string
+): string {
+  return [language, agentId, ruleSuffix].filter(Boolean).join('/');
+}
+
+export function parseRuleMarker(content: string): RuleMarker | null {
+  const match = content.match(RULE_MARKER_PATTERN);
+  if (!match) return null;
+  return {
+    ruleId: match[1],
+    version: match[2],
+    checksum: match[3].toLowerCase()
+  };
+}
+
+export function stripRuleMarker(content: string): string {
+  return content.replace(RULE_MARKER_PATTERN, '');
+}
+
+export function calculateRuleChecksum(content: string): string {
+  return crypto
+    .createHash('sha256')
+    .update(stripRuleMarker(content), 'utf8')
+    .digest('hex');
+}
+
+export function verifyRuleChecksum(content: string): boolean {
+  const marker = parseRuleMarker(content);
+  if (!marker) return false;
+  return calculateRuleChecksum(content) === marker.checksum;
+}
+
+function addRuleMarker(content: string, ruleId: string): string {
+  const body = stripRuleMarker(content);
+  const marker = `<!-- ballast:rule id="${ruleId}" version="${pkg.version}" checksum="${calculateRuleChecksum(body)}" -->`;
+  const frontmatter = body.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  if (frontmatter) {
+    return `${frontmatter[0]}${marker}\n${body.slice(frontmatter[0].length)}`;
+  }
+  return `${marker}\n${body}`;
 }
 
 function getPreferredAgentDir(agentId: string, language: Language): string {
@@ -1222,7 +1277,7 @@ export function buildContent(
       result = result.replaceAll(`{{${key}}}`, value);
     }
   }
-  return result;
+  return addRuleMarker(result, getRuleMarkerId(agentId, language, ruleSuffix));
 }
 
 /**

--- a/packages/ballast-typescript/src/build.ts
+++ b/packages/ballast-typescript/src/build.ts
@@ -42,7 +42,8 @@ interface SkillEntry {
 }
 
 const RULE_MARKER_PATTERN =
-  /<!--\s*ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?/;
+  /^<!-- ballast:rule\s+id="([^"]+)"\s+version="([^"]+)"\s+checksum="([a-fA-F0-9]+)"\s*-->\r?\n?/;
+const FRONTMATTER_PATTERN = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
 
 function getCreatedByBallastLine(): string {
   return `Created by [Ballast](${BALLAST_REPO_URL}) v${pkg.version}. Do not edit this section.`;
@@ -95,7 +96,11 @@ export function getRuleMarkerId(
 }
 
 export function parseRuleMarker(content: string): RuleMarker | null {
-  const match = content.match(RULE_MARKER_PATTERN);
+  const frontmatter = content.match(FRONTMATTER_PATTERN);
+  const markerContent = frontmatter
+    ? content.slice(frontmatter[0].length)
+    : content;
+  const match = markerContent.match(RULE_MARKER_PATTERN);
   if (!match) return null;
   return {
     ruleId: match[1],
@@ -105,7 +110,12 @@ export function parseRuleMarker(content: string): RuleMarker | null {
 }
 
 export function stripRuleMarker(content: string): string {
-  return content.replace(RULE_MARKER_PATTERN, '');
+  const frontmatter = content.match(FRONTMATTER_PATTERN);
+  if (!frontmatter) {
+    return content.replace(RULE_MARKER_PATTERN, '');
+  }
+  const body = content.slice(frontmatter[0].length);
+  return `${frontmatter[0]}${body.replace(RULE_MARKER_PATTERN, '')}`;
 }
 
 export function calculateRuleChecksum(content: string): string {
@@ -124,7 +134,7 @@ export function verifyRuleChecksum(content: string): boolean {
 function addRuleMarker(content: string, ruleId: string): string {
   const body = stripRuleMarker(content);
   const marker = `<!-- ballast:rule id="${ruleId}" version="${pkg.version}" checksum="${calculateRuleChecksum(body)}" -->`;
-  const frontmatter = body.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+  const frontmatter = body.match(FRONTMATTER_PATTERN);
   if (frontmatter) {
     return `${frontmatter[0]}${marker}\n${body.slice(frontmatter[0].length)}`;
   }

--- a/packages/ballast-typescript/src/cli.ts
+++ b/packages/ballast-typescript/src/cli.ts
@@ -25,7 +25,7 @@ export type ParseArgsResult =
   | CliOptions
   | { help: true }
   | { version: true }
-  | { doctor: true }
+  | { doctor: true; fix?: boolean }
   | { list: true };
 
 function readFlagValue(args: string[], index: number, flag: string): string {
@@ -40,7 +40,9 @@ export function parseArgs(argv: string[]): ParseArgsResult {
   const args = argv.slice(2);
   const command = args[0];
   if (command === 'doctor') {
-    return { doctor: true };
+    return args.includes('--fix')
+      ? { doctor: true, fix: true }
+      : { doctor: true };
   }
   if (command === 'list') {
     return { list: true };
@@ -218,7 +220,7 @@ export async function main(): Promise<void> {
 
   if (!isInstall) {
     if (command === 'doctor') {
-      process.exit(runDoctor());
+      process.exit(runDoctor({ fix: argv.includes('--fix') }));
     }
     if (command === 'list') {
       printList();
@@ -239,7 +241,7 @@ export async function main(): Promise<void> {
     process.exit(0);
   }
   if ('doctor' in options && options.doctor) {
-    process.exit(runDoctor());
+    process.exit(runDoctor({ fix: options.fix }));
   }
   const cliOptions = options as CliOptions;
   if (!LANGUAGES.includes(cliOptions.language as (typeof LANGUAGES)[number])) {

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -1,9 +1,83 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { buildDoctorReport, detectAppType, formatDoctorReport } from './doctor';
+import { buildContent } from './build';
+import {
+  buildDoctorReport,
+  collectRuleFileStatuses,
+  detectAppType,
+  formatDoctorReport,
+  removeStaleRuleFiles
+} from './doctor';
 
 describe('doctor', () => {
+  test('formats rule file status categories and remediation recommendations', () => {
+    const report = buildDoctorReport(
+      'ballast-typescript',
+      '5.0.2',
+      '/tmp/project/.rulesrc.json',
+      '5.0.2',
+      ['codex'],
+      ['linting'],
+      [],
+      ['typescript'],
+      {},
+      {},
+      [],
+      null,
+      null,
+      [],
+      [{ name: 'ballast-typescript', version: '5.0.2', path: '/tmp/bt' }],
+      'unknown',
+      [
+        {
+          path: '/tmp/project/.codex/rules/typescript-linting.md',
+          target: 'codex',
+          ruleId: 'typescript/linting',
+          status: 'ok'
+        },
+        {
+          path: '/tmp/project/.codex/rules/typescript-testing.md',
+          target: 'codex',
+          ruleId: 'typescript/testing',
+          status: 'drifted'
+        },
+        {
+          path: '/tmp/project/.codex/rules/typescript-docs.md',
+          target: 'codex',
+          ruleId: 'typescript/docs',
+          status: 'stale'
+        },
+        {
+          path: '/tmp/project/.codex/rules/manual.md',
+          target: 'codex',
+          ruleId: null,
+          status: 'unowned'
+        }
+      ]
+    );
+
+    const output = formatDoctorReport(report);
+
+    expect(output).toContain('Rule files:');
+    expect(output).toContain('.codex/rules/typescript-linting.md [ok]');
+    expect(output).toContain(
+      '.codex/rules/typescript-testing.md [DRIFTED - run ballast install --refresh-config to restore]'
+    );
+    expect(output).toContain(
+      '.codex/rules/typescript-docs.md [STALE - run ballast doctor --fix to remove]'
+    );
+    expect(output).toContain(
+      '.codex/rules/manual.md [unowned - not managed by Ballast, skipped]'
+    );
+    expect(report.recommendations).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Refresh drifted rule file'),
+        expect.stringContaining('Remove stale managed rule file')
+      ])
+    );
+  });
+
   test('recommends upgrades for older CLIs and config', () => {
     const report = buildDoctorReport(
       'ballast-typescript',
@@ -199,6 +273,107 @@ describe('doctor', () => {
       r.includes('add the publishing agent')
     );
     expect(publishingRecs).toHaveLength(0);
+  });
+});
+
+describe('rule file status collection', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ballast-rule-status-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('categorizes ok, drifted, stale, and unowned rule files', () => {
+    const codexRules = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(codexRules, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexRules, 'typescript-linting.md'),
+      buildContent('linting', 'codex', undefined, 'typescript'),
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(codexRules, 'typescript-testing.md'),
+      `${buildContent('testing', 'codex', undefined, 'typescript')}\nManual edit\n`,
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(codexRules, 'typescript-logging.md'),
+      buildContent('logging', 'codex', undefined, 'typescript'),
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(codexRules, 'manual.md'),
+      '# Manual notes\n',
+      'utf8'
+    );
+
+    const statuses = collectRuleFileStatuses(tmpDir, {
+      targets: ['codex'],
+      agents: ['linting', 'testing'],
+      languages: ['typescript']
+    });
+
+    expect(
+      statuses.map((status) => ({
+        basename: path.basename(status.path),
+        ruleId: status.ruleId,
+        status: status.status
+      }))
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          basename: 'typescript-linting.md',
+          ruleId: 'typescript/linting',
+          status: 'ok'
+        },
+        {
+          basename: 'typescript-testing.md',
+          ruleId: 'typescript/testing',
+          status: 'drifted'
+        },
+        {
+          basename: 'typescript-logging.md',
+          ruleId: 'typescript/logging',
+          status: 'stale'
+        },
+        { basename: 'manual.md', ruleId: null, status: 'unowned' }
+      ])
+    );
+  });
+
+  test('removeStaleRuleFiles removes only stale managed files', () => {
+    const codexRules = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(codexRules, { recursive: true });
+    const stale = path.join(codexRules, 'typescript-logging.md');
+    const drifted = path.join(codexRules, 'typescript-testing.md');
+    const unowned = path.join(codexRules, 'manual.md');
+    fs.writeFileSync(
+      stale,
+      buildContent('logging', 'codex', undefined, 'typescript'),
+      'utf8'
+    );
+    fs.writeFileSync(
+      drifted,
+      `${buildContent('testing', 'codex', undefined, 'typescript')}\nManual edit\n`,
+      'utf8'
+    );
+    fs.writeFileSync(unowned, '# Manual notes\n', 'utf8');
+
+    const statuses = collectRuleFileStatuses(tmpDir, {
+      targets: ['codex'],
+      agents: ['testing'],
+      languages: ['typescript']
+    });
+    const removed = removeStaleRuleFiles(statuses);
+
+    expect(removed).toEqual([stale]);
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(drifted)).toBe(true);
+    expect(fs.existsSync(unowned)).toBe(true);
   });
 });
 

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -7,7 +7,8 @@ import {
   collectRuleFileStatuses,
   detectAppType,
   formatDoctorReport,
-  removeStaleRuleFiles
+  removeStaleRuleFiles,
+  runDoctor
 } from './doctor';
 
 describe('doctor', () => {
@@ -314,7 +315,8 @@ describe('rule file status collection', () => {
     const statuses = collectRuleFileStatuses(tmpDir, {
       targets: ['codex'],
       agents: ['linting', 'testing'],
-      languages: ['typescript']
+      languages: ['typescript'],
+      paths: {}
     });
 
     expect(
@@ -366,7 +368,8 @@ describe('rule file status collection', () => {
     const statuses = collectRuleFileStatuses(tmpDir, {
       targets: ['codex'],
       agents: ['testing'],
-      languages: ['typescript']
+      languages: ['typescript'],
+      paths: {}
     });
     const removed = removeStaleRuleFiles(statuses);
 
@@ -374,6 +377,85 @@ describe('rule file status collection', () => {
     expect(fs.existsSync(stale)).toBe(false);
     expect(fs.existsSync(drifted)).toBe(true);
     expect(fs.existsSync(unowned)).toBe(true);
+  });
+
+  test('uses TypeScript-only hook mode when comparing git-hooks content', () => {
+    const codexRules = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(codexRules, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexRules, 'git-hooks.md'),
+      buildContent('git-hooks', 'codex', undefined, 'typescript', {
+        hookMode: 'husky'
+      }),
+      'utf8'
+    );
+
+    const statuses = collectRuleFileStatuses(tmpDir, {
+      targets: ['codex'],
+      agents: ['git-hooks'],
+      languages: ['typescript'],
+      paths: { typescript: ['apps/web'] }
+    });
+
+    expect(statuses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'typescript/git-hooks',
+          status: 'ok'
+        })
+      ])
+    );
+  });
+
+  test('uses multi-path hook mode when comparing git-hooks content', () => {
+    const codexRules = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(codexRules, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexRules, 'git-hooks.md'),
+      buildContent('git-hooks', 'codex', undefined, 'typescript', {
+        hookMode: 'pre-commit'
+      }),
+      'utf8'
+    );
+
+    const statuses = collectRuleFileStatuses(tmpDir, {
+      targets: ['codex'],
+      agents: ['git-hooks'],
+      languages: ['typescript'],
+      paths: { typescript: ['apps/web'], python: ['packages/api'] }
+    });
+
+    expect(statuses).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: 'typescript/git-hooks',
+          status: 'ok'
+        })
+      ])
+    );
+  });
+
+  test('doctor fix does not delete stale managed rules without a loaded config', () => {
+    const previousCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), '{}\n', 'utf8');
+      fs.writeFileSync(path.join(tmpDir, '.rulesrc.json'), '{not json', 'utf8');
+      const codexRules = path.join(tmpDir, '.codex', 'rules');
+      fs.mkdirSync(codexRules, { recursive: true });
+      const managedRule = path.join(codexRules, 'typescript-linting.md');
+      fs.writeFileSync(
+        managedRule,
+        buildContent('linting', 'codex', undefined, 'typescript'),
+        'utf8'
+      );
+
+      runDoctor({ fix: true });
+
+      expect(fs.existsSync(managedRule)).toBe(true);
+    } finally {
+      process.chdir(previousCwd);
+    }
   });
 });
 

--- a/packages/ballast-typescript/src/doctor.test.ts
+++ b/packages/ballast-typescript/src/doctor.test.ts
@@ -379,6 +379,41 @@ describe('rule file status collection', () => {
     expect(fs.existsSync(unowned)).toBe(true);
   });
 
+  test('treats copied rule marker examples in body content as unowned', () => {
+    const codexRules = path.join(tmpDir, '.codex', 'rules');
+    fs.mkdirSync(codexRules, { recursive: true });
+    const unowned = path.join(codexRules, 'manual.md');
+    fs.writeFileSync(
+      unowned,
+      [
+        '# Manual notes',
+        '',
+        'Example managed marker:',
+        '<!-- ballast:rule id="typescript/logging" version="5.0.0" checksum="0123456789abcdef" -->',
+        ''
+      ].join('\n'),
+      'utf8'
+    );
+
+    const statuses = collectRuleFileStatuses(tmpDir, {
+      targets: ['codex'],
+      agents: ['testing'],
+      languages: ['typescript'],
+      paths: {}
+    });
+    const removed = removeStaleRuleFiles(statuses);
+
+    expect(statuses).toEqual([
+      expect.objectContaining({
+        path: unowned,
+        ruleId: null,
+        status: 'unowned'
+      })
+    ]);
+    expect(removed).toEqual([]);
+    expect(fs.existsSync(unowned)).toBe(true);
+  });
+
   test('uses TypeScript-only hook mode when comparing git-hooks content', () => {
     const codexRules = path.join(tmpDir, '.codex', 'rules');
     fs.mkdirSync(codexRules, { recursive: true });

--- a/packages/ballast-typescript/src/doctor.ts
+++ b/packages/ballast-typescript/src/doctor.ts
@@ -2,6 +2,16 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { findProjectRoot, getRulesrcFilename, loadConfig } from './config';
+import type { PublishingProfile, Target } from './config';
+import type { Language } from './agents';
+import {
+  buildContent,
+  getRuleMarkerId,
+  listRuleSuffixes,
+  parseRuleMarker,
+  stripRuleMarker,
+  verifyRuleChecksum
+} from './build';
 import { BALLAST_VERSION } from './version';
 
 export interface InstalledCliStatus {
@@ -29,7 +39,17 @@ export interface DoctorReport {
   configPublishingProfiles: string[];
   installed: InstalledCliStatus[];
   detectedAppType: AppType;
+  ruleFiles: RuleFileStatus[];
   recommendations: string[];
+}
+
+export type RuleFileState = 'ok' | 'drifted' | 'stale' | 'unowned';
+
+export interface RuleFileStatus {
+  path: string;
+  target: Target;
+  ruleId: string | null;
+  status: RuleFileState;
 }
 
 const CLI_NAMES = [
@@ -198,6 +218,14 @@ function refreshConfigCommand(
   return 'ballast install --refresh-config';
 }
 
+function withImplicitAgents(agents: string[]): string[] {
+  const next = [...agents];
+  if (next.includes('linting') && !next.includes('git-hooks')) {
+    next.push('git-hooks');
+  }
+  return next;
+}
+
 export function buildDoctorReport(
   currentCli: string,
   currentVersion: string,
@@ -214,7 +242,8 @@ export function buildDoctorReport(
   configDeploymentModel: string | null,
   configPublishingProfiles: string[],
   installed: InstalledCliStatus[],
-  detectedAppType: AppType = 'unknown'
+  detectedAppType: AppType = 'unknown',
+  ruleFiles: RuleFileStatus[] = []
 ): DoctorReport {
   const targetVersion = latestVersion([
     currentVersion,
@@ -264,6 +293,19 @@ export function buildDoctorReport(
     );
   }
 
+  for (const ruleFile of ruleFiles) {
+    if (ruleFile.status === 'drifted') {
+      recommendations.push(
+        `Refresh drifted rule file ${ruleFile.path}: ballast install --refresh-config`
+      );
+    }
+    if (ruleFile.status === 'stale') {
+      recommendations.push(
+        `Remove stale managed rule file ${ruleFile.path}: ballast doctor --fix`
+      );
+    }
+  }
+
   return {
     currentCli,
     currentVersion,
@@ -281,8 +323,193 @@ export function buildDoctorReport(
     configPublishingProfiles,
     installed,
     detectedAppType,
+    ruleFiles,
     recommendations
   };
+}
+
+interface RuleConfig {
+  targets: Target[];
+  agents: string[];
+  languages: string[];
+  taskSystem?: string | null;
+  deploymentModel?: string | null;
+  publishingProfiles?: PublishingProfile[];
+}
+
+const TARGET_RULE_DIRS: Record<Target, string[]> = {
+  cursor: ['.cursor/rules'],
+  claude: ['.claude/rules'],
+  opencode: ['.opencode'],
+  codex: ['.codex/rules'],
+  gemini: ['.gemini/rules']
+};
+
+function isRuleFile(filePath: string): boolean {
+  return ['.md', '.mdc'].includes(path.extname(filePath));
+}
+
+function walkRuleFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const files: string[] = [];
+  const walk = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const next = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(next);
+        continue;
+      }
+      if (entry.isFile() && isRuleFile(next)) {
+        files.push(next);
+      }
+    }
+  };
+  walk(dir);
+  return files;
+}
+
+function configuredLanguages(config: RuleConfig): Language[] {
+  const values =
+    config.languages.length > 0 ? config.languages : ['typescript'];
+  return values.filter((value): value is Language =>
+    ['typescript', 'python', 'go', 'ansible', 'terraform', 'dart'].includes(
+      value
+    )
+  );
+}
+
+function configuredRuleKeys(config: RuleConfig): Set<string> {
+  const active = new Set<string>();
+  for (const target of config.targets) {
+    for (const language of configuredLanguages(config)) {
+      for (const agentId of withImplicitAgents(config.agents)) {
+        try {
+          for (const suffix of listRuleSuffixes(
+            agentId,
+            language,
+            config.publishingProfiles
+          )) {
+            active.add(
+              `${target}:${getRuleMarkerId(agentId, language, suffix || undefined)}`
+            );
+          }
+        } catch {
+          // Ignore invalid or unavailable agents in saved config; doctor reports
+          // existing marked files as stale rather than failing the whole report.
+        }
+      }
+    }
+  }
+  return active;
+}
+
+function parseRuleId(
+  ruleId: string
+): { language: Language; agentId: string; ruleSuffix?: string } | null {
+  const [language, agentId, ...suffixParts] = ruleId.split('/');
+  if (!language || !agentId) return null;
+  if (
+    !['typescript', 'python', 'go', 'ansible', 'terraform', 'dart'].includes(
+      language
+    )
+  ) {
+    return null;
+  }
+  return {
+    language: language as Language,
+    agentId,
+    ruleSuffix: suffixParts.length > 0 ? suffixParts.join('/') : undefined
+  };
+}
+
+function canonicalRuleContent(
+  target: Target,
+  ruleId: string,
+  config: RuleConfig
+): string | null {
+  const parsed = parseRuleId(ruleId);
+  if (!parsed) return null;
+  const variables: Record<string, string> = {
+    ...(parsed.agentId === 'tasks' && config.taskSystem
+      ? { taskSystem: config.taskSystem }
+      : {}),
+    ...(parsed.agentId === 'publishing' && config.deploymentModel
+      ? { deploymentModel: config.deploymentModel }
+      : {})
+  };
+  try {
+    return buildContent(
+      parsed.agentId,
+      target,
+      parsed.ruleSuffix,
+      parsed.language,
+      Object.keys(variables).length > 0 ? { variables } : undefined
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function collectRuleFileStatuses(
+  projectRoot: string,
+  config: RuleConfig
+): RuleFileStatus[] {
+  const active = configuredRuleKeys(config);
+  const statuses: RuleFileStatus[] = [];
+  for (const [target, dirs] of Object.entries(TARGET_RULE_DIRS) as Array<
+    [Target, string[]]
+  >) {
+    for (const relativeDir of dirs) {
+      const dir = path.join(projectRoot, relativeDir);
+      for (const filePath of walkRuleFiles(dir)) {
+        const content = fs.readFileSync(filePath, 'utf8');
+        const marker = parseRuleMarker(content);
+        if (!marker) {
+          statuses.push({
+            path: filePath,
+            target,
+            ruleId: null,
+            status: 'unowned'
+          });
+          continue;
+        }
+        const key = `${target}:${marker.ruleId}`;
+        if (!active.has(key)) {
+          statuses.push({
+            path: filePath,
+            target,
+            ruleId: marker.ruleId,
+            status: 'stale'
+          });
+          continue;
+        }
+        const canonical = canonicalRuleContent(target, marker.ruleId, config);
+        const drifted =
+          !verifyRuleChecksum(content) ||
+          !canonical ||
+          stripRuleMarker(content) !== stripRuleMarker(canonical);
+        statuses.push({
+          path: filePath,
+          target,
+          ruleId: marker.ruleId,
+          status: drifted ? 'drifted' : 'ok'
+        });
+      }
+    }
+  }
+  return statuses.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+export function removeStaleRuleFiles(ruleFiles: RuleFileStatus[]): string[] {
+  const removed: string[] = [];
+  for (const ruleFile of ruleFiles) {
+    if (ruleFile.status !== 'stale' || ruleFile.ruleId === null) {
+      continue;
+    }
+    fs.rmSync(ruleFile.path, { force: true });
+    removed.push(ruleFile.path);
+  }
+  return removed;
 }
 
 function formatConfigPaths(
@@ -323,6 +550,30 @@ function formatConfigTools(
   return entries.length > 0 ? entries.join('; ') : null;
 }
 
+function formatRuleFilePath(report: DoctorReport, filePath: string): string {
+  if (!path.isAbsolute(filePath)) return filePath;
+  const root = report.configPath
+    ? path.dirname(report.configPath)
+    : process.cwd();
+  const relative = path.relative(root, filePath);
+  return relative && !relative.startsWith('..') ? relative : filePath;
+}
+
+function formatRuleStatus(status: RuleFileState): string {
+  switch (status) {
+    case 'ok':
+      return 'ok';
+    case 'drifted':
+      return 'DRIFTED - run ballast install --refresh-config to restore';
+    case 'stale':
+      return 'STALE - run ballast doctor --fix to remove';
+    case 'unowned':
+      return 'unowned - not managed by Ballast, skipped';
+    default:
+      return status;
+  }
+}
+
 export function formatDoctorReport(report: DoctorReport): string {
   const lines = [
     'Ballast doctor',
@@ -341,6 +592,17 @@ export function formatDoctorReport(report: DoctorReport): string {
 
   if (report.detectedAppType !== 'unknown') {
     lines.push('', `Detected app type: ${report.detectedAppType}`);
+  }
+
+  lines.push('', 'Rule files:');
+  if (report.ruleFiles.length === 0) {
+    lines.push('- none found');
+  } else {
+    for (const ruleFile of report.ruleFiles) {
+      lines.push(
+        `- ${formatRuleFilePath(report, ruleFile.path)} [${formatRuleStatus(ruleFile.status)}]`
+      );
+    }
   }
 
   lines.push('', 'Config:');
@@ -405,10 +667,25 @@ export function formatDoctorReport(report: DoctorReport): string {
   return `${lines.join('\n')}\n`;
 }
 
-export function runDoctor(): number {
+export function runDoctor(options: { fix?: boolean } = {}): number {
   const projectRoot = findProjectRoot();
   const configPath = path.join(projectRoot, getRulesrcFilename());
   const config = loadConfig(projectRoot);
+  const ruleFiles = collectRuleFileStatuses(projectRoot, {
+    targets: config?.targets ?? [],
+    agents: config?.agents ?? [],
+    languages: config?.languages ?? [],
+    taskSystem: config?.taskSystem ?? null,
+    deploymentModel: config?.deploymentModel ?? null,
+    publishingProfiles: config?.publishingProfiles ?? []
+  });
+  const removedRuleFiles = options.fix ? removeStaleRuleFiles(ruleFiles) : [];
+  const nextRuleFiles =
+    removedRuleFiles.length > 0
+      ? ruleFiles.filter(
+          (ruleFile) => !removedRuleFiles.includes(ruleFile.path)
+        )
+      : ruleFiles;
   const report = buildDoctorReport(
     'ballast-typescript',
     BALLAST_VERSION,
@@ -425,8 +702,16 @@ export function runDoctor(): number {
     config?.deploymentModel ?? null,
     config?.publishingProfiles ?? [],
     CLI_NAMES.map((name) => detectInstalledCli(name)),
-    detectAppType(projectRoot)
+    detectAppType(projectRoot),
+    nextRuleFiles
   );
+  if (removedRuleFiles.length > 0) {
+    process.stdout.write('Removed stale managed rule files:\n');
+    for (const filePath of removedRuleFiles) {
+      process.stdout.write(`- ${filePath}\n`);
+    }
+    process.stdout.write('\n');
+  }
   process.stdout.write(formatDoctorReport(report));
   return 0;
 }

--- a/packages/ballast-typescript/src/doctor.ts
+++ b/packages/ballast-typescript/src/doctor.ts
@@ -332,6 +332,7 @@ interface RuleConfig {
   targets: Target[];
   agents: string[];
   languages: string[];
+  paths: Record<string, string[]>;
   taskSystem?: string | null;
   deploymentModel?: string | null;
   publishingProfiles?: PublishingProfile[];
@@ -437,17 +438,41 @@ function canonicalRuleContent(
       ? { deploymentModel: config.deploymentModel }
       : {})
   };
+  const hookMode =
+    parsed.agentId === 'git-hooks'
+      ? ruleHookMode(parsed.language, config)
+      : undefined;
+  const options = {
+    ...(hookMode ? { hookMode } : {}),
+    ...(Object.keys(variables).length > 0 ? { variables } : {})
+  };
   try {
     return buildContent(
       parsed.agentId,
       target,
       parsed.ruleSuffix,
       parsed.language,
-      Object.keys(variables).length > 0 ? { variables } : undefined
+      Object.keys(options).length > 0 ? options : undefined
     );
   } catch {
     return null;
   }
+}
+
+function ruleHookMode(
+  language: Language,
+  config: RuleConfig
+): 'pre-commit' | 'husky' {
+  if (language !== 'typescript') {
+    return 'pre-commit';
+  }
+  if (new Set(config.languages).size > 1) {
+    return 'pre-commit';
+  }
+  if (Object.keys(config.paths).length > 1) {
+    return 'pre-commit';
+  }
+  return 'husky';
 }
 
 export function collectRuleFileStatuses(
@@ -675,11 +700,13 @@ export function runDoctor(options: { fix?: boolean } = {}): number {
     targets: config?.targets ?? [],
     agents: config?.agents ?? [],
     languages: config?.languages ?? [],
+    paths: config?.paths ?? {},
     taskSystem: config?.taskSystem ?? null,
     deploymentModel: config?.deploymentModel ?? null,
     publishingProfiles: config?.publishingProfiles ?? []
   });
-  const removedRuleFiles = options.fix ? removeStaleRuleFiles(ruleFiles) : [];
+  const removedRuleFiles =
+    options.fix && config ? removeStaleRuleFiles(ruleFiles) : [];
   const nextRuleFiles =
     removedRuleFiles.length > 0
       ? ruleFiles.filter(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,5 +1,15 @@
 # Tasks
 
+- [x] Confirm issue #166 scope, operating mode, and governing PRD requirements.
+- [x] Add PRD requirements for managed rule markers, doctor categorization, and stale cleanup safety.
+- [x] Add focused failing tests for marker parsing, checksum comparison, report formatting, stale cleanup, and safety.
+- [x] Implement TypeScript rule marker generation and doctor rule-file status reporting.
+- [x] Mirror marker generation and focused coverage across Python and Go rule-generation surfaces as appropriate.
+- [x] Run focused tests, formatting, and relevant cross-surface checks.
+- [ ] Push branch, open PR against `main`, request Copilot review, and check CI/review state.
+
+## Previous Tasks
+
 - [x] Confirm issue #154 scope, operating mode, and governing PRD requirements.
 - [x] Add PRD requirements for distributing plan-lifecycle guidance through Ballast.
 - [x] Add failing generated-content coverage for the plan-lifecycle rule and installed support-file entries.
@@ -7,8 +17,6 @@
 - [x] Sync package mirrors and regenerate checked-in `.codex`/`.claude` outputs.
 - [x] Run focused tests and required sync/generation checks.
 - [x] Push branch, open PR for #154, request Copilot review, and resolve actionable review comments. No actionable review comments were present at the latest poll.
-
-## Previous Tasks
 
 - [x] Confirm issue #145 scope, operating mode, and governing PRD gap.
 - [x] Add PRD requirements for integration-framework detection and Playwright preference across supported languages.


### PR DESCRIPTION
## Summary

- Add machine-readable Ballast rule markers with version and SHA-256 checksum to generated rule files across TypeScript, Python, and Go generators.
- Extend TypeScript doctor to report rule files as ok, drifted, stale, or unowned and make doctor --fix remove only stale managed rules.
- Tighten wrapper stale cleanup ownership checks so markerless/unowned files are preserved, and refresh tracked generated rule files with markers.

## Validation

- [x] Tests or checks run: scripts/run-unit-tests-pre-push.sh; pnpm --filter @everydaydevopsio/ballast run lint; pnpm --filter @everydaydevopsio/ballast run build; pnpm --filter @everydaydevopsio/ballast exec jest --runInBand src/build.test.ts src/doctor.test.ts src/install.test.ts src/cli.test.ts src/repo-generated-artifacts.test.ts; go test ./cmd/ballast-go; go test . in cli/ballast; uv run python -m unittest packages.ballast-python.tests.test_cli -q; git diff --check; node packages/ballast-typescript/bin/ballast.js doctor
- [x] Docs updated or not needed: PRD.md updated for issue #166 acceptance criteria.
- [x] Generated files updated or not needed: tracked .codex/.claude rule files regenerated with markers; package content mirrors synced for local-dev context budget trim.

## Agent Notes

- Related issue/PRD: closes #166; PRD.md Ballast Doctor Rule Drift Detection
- Risk level: Medium
- Follow-up needed: Strict generated-artifact enforcement still reports pre-existing skill artifact drift, so validation used the normal generated-artifact test mode plus regenerated tracked rule outputs.