### PR TITLE
Fix OpenCode legacy rule cleanup on target removal

### DIFF
--- a/cli/ballast/main.go
+++ b/cli/ballast/main.go
@@ -3872,7 +3872,11 @@ func removeManagedTargetFiles(root string, target string, config *monorepoConfig
 	if config == nil {
 		return nil
 	}
-	for _, file := range managedRulePaths(root, target, config) {
+	rulePaths := managedRulePaths(root, target, config)
+	if target == "opencode" {
+		rulePaths = append(rulePaths, legacyOpenCodeRulePaths(root, config.Agents, config.Languages)...)
+	}
+	for _, file := range uniqueStrings(rulePaths) {
 		if err := os.Remove(file); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -3903,6 +3907,28 @@ func managedRulePaths(root string, target string, config *monorepoConfig) []stri
 			for _, suffix := range ruleSuffixesForAgent(agent) {
 				base := agentBaseName(agent, suffix)
 				paths = append(paths, filepath.Join(rulesRoot, lang, lang+"-"+base+ext))
+			}
+		}
+	}
+	return uniqueStrings(paths)
+}
+
+func legacyOpenCodeRulePaths(root string, agents []string, languages []string) []string {
+	paths := []string{}
+	rulesRoot := filepath.Join(root, ".opencode", "rules")
+	commonSelection := filterAgents(agents, commonAgentIDs())
+	languageSelection := filterAgents(agents, languageAgentIDs())
+	for _, agent := range commonSelection {
+		for _, suffix := range ruleSuffixesForAgent(agent) {
+			base := agentBaseName(agent, suffix)
+			paths = append(paths, filepath.Join(rulesRoot, "common", base+".md"))
+		}
+	}
+	for _, lang := range languages {
+		for _, agent := range languageSelection {
+			for _, suffix := range ruleSuffixesForAgent(agent) {
+				base := agentBaseName(agent, suffix)
+				paths = append(paths, filepath.Join(rulesRoot, lang, lang+"-"+base+".md"))
 			}
 		}
 	}

--- a/cli/ballast/main_test.go
+++ b/cli/ballast/main_test.go
@@ -4618,6 +4618,9 @@ func TestRunMonorepoRemoveTargetCleansOpencodeManagedRulesAndSkills(t *testing.T
 
 	mustWriteFile(t, filepath.Join(root, ".opencode", "python", "python-linting.md"), "managed")
 	mustWriteFile(t, filepath.Join(root, ".opencode", "go", "go-linting.md"), "managed")
+	mustWriteFile(t, filepath.Join(root, ".opencode", "rules", "python", "python-linting.md"), "legacy managed")
+	mustWriteFile(t, filepath.Join(root, ".opencode", "rules", "go", "go-linting.md"), "legacy managed")
+	mustWriteFile(t, filepath.Join(root, ".opencode", "rules", "go", "manual.md"), "manual opencode rule")
 	mustWriteFile(t, filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md"), "managed")
 	mustWriteFile(t, filepath.Join(root, ".claude", "rules", "python", "python-linting.md"), "managed")
 	mustWriteFile(t, filepath.Join(root, ".claude", "skills", "owasp-security-scan.skill"), "managed")
@@ -4646,6 +4649,15 @@ func TestRunMonorepoRemoveTargetCleansOpencodeManagedRulesAndSkills(t *testing.T
 	}
 	if _, err := os.Stat(filepath.Join(root, ".opencode", "go", "go-linting.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected opencode go rule to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "rules", "python", "python-linting.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy opencode python rule to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "rules", "go", "go-linting.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected legacy opencode go rule to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".opencode", "rules", "go", "manual.md")); err != nil {
+		t.Fatalf("expected manual legacy opencode rule to remain, got %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(root, ".opencode", "skills", "owasp-security-scan.md")); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("expected opencode skill to be removed, got err=%v", err)

--- a/scripts/e2e-remove-target-existing-install.sh
+++ b/scripts/e2e-remove-target-existing-install.sh
@@ -63,6 +63,16 @@ run_opencode_case() {
 EOF
 
   materialize_saved_install "${project}"
+  mkdir -p "${project}/.opencode/rules/python" "${project}/.opencode/rules/go"
+  cat > "${project}/.opencode/rules/python/python-linting.md" <<'EOF'
+legacy managed python linting rule
+EOF
+  cat > "${project}/.opencode/rules/go/go-linting.md" <<'EOF'
+legacy managed go linting rule
+EOF
+  cat > "${project}/.opencode/rules/go/manual.md" <<'EOF'
+manual opencode rule
+EOF
 
   (
     cd "${project}"
@@ -73,6 +83,9 @@ EOF
   assert_contains '"claude"' "${project}/.rulesrc.json"
   assert_file_absent "${project}/.opencode/python/python-linting.md"
   assert_file_absent "${project}/.opencode/go/go-linting.md"
+  assert_file_absent "${project}/.opencode/rules/python/python-linting.md"
+  assert_file_absent "${project}/.opencode/rules/go/go-linting.md"
+  assert_file_exists "${project}/.opencode/rules/go/manual.md"
   assert_file_absent "${project}/.opencode/skills/owasp-security-scan.md"
   assert_file_exists "${project}/.claude/rules/python/python-linting.md"
   assert_file_exists "${project}/.claude/skills/owasp-security-scan.skill"


### PR DESCRIPTION
## Summary
- remove legacy Ballast-managed OpenCode rule files under .opencode/rules when --remove-target opencode runs
- keep canonical .opencode/<language>/... rule and .opencode/skills cleanup behavior intact
- add wrapper and E2E regression coverage for legacy .opencode/rules/<language>/<language>-linting.md fixtures while preserving manual files and Claude artifacts

## Tests
- go test . -run TestRunMonorepoRemoveTargetCleansOpencodeManagedRulesAndSkills -count=1 (from cli/ballast)
- go test . -run 'Test(RunMonorepoRemoveTarget|RemoveStaleManagedFiles)' -count=1 (from cli/ballast)
- scripts/e2e-remove-target-existing-install.sh
- git push pre-push hook: cli and language package unit tests