### PR TITLE
Clarify Ansible syntax-check pre-push guidance

### DIFF
--- a/agents/ansible/linting/content.md
+++ b/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
+- `ansible-playbook --syntax-check` for representative top-level playbooks, run at pre-push or during manual validation
 
 Install both hook stages:
 

--- a/agents/ansible/linting/content.md
+++ b/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- `ansible-playbook --syntax-check` for each representative top-level playbook
+- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
 
 Install both hook stages:
 

--- a/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
+- `ansible-playbook --syntax-check` for representative top-level playbooks, run at pre-push or during manual validation
 
 Install both hook stages:
 

--- a/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- `ansible-playbook --syntax-check` for each representative top-level playbook
+- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
 
 Install both hook stages:
 

--- a/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
+- `ansible-playbook --syntax-check` for representative top-level playbooks, run at pre-push or during manual validation
 
 Install both hook stages:
 

--- a/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- `ansible-playbook --syntax-check` for each representative top-level playbook
+- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
 
 Install both hook stages:
 

--- a/packages/ballast-python/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-python/ballast/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
+- `ansible-playbook --syntax-check` for representative top-level playbooks, run at pre-push or during manual validation
 
 Install both hook stages:
 

--- a/packages/ballast-python/ballast/agents/ansible/linting/content.md
+++ b/packages/ballast-python/ballast/agents/ansible/linting/content.md
@@ -25,7 +25,7 @@ The root `.pre-commit-config.yaml` should run:
 
 - `ansible-lint` for playbooks, roles, and collections
 - `yamllint` for YAML formatting and style
-- `ansible-playbook --syntax-check` for each representative top-level playbook
+- pre-push or manual `ansible-playbook --syntax-check` for representative top-level playbooks
 
 Install both hook stages:
 


### PR DESCRIPTION
## Summary
- Clarify that ansible-playbook syntax checks belong in pre-push or manual validation rather than ordinary commit-time hooks.
- Keep the Ansible linting guidance consistent across source and packaged copies.

## Traceability
Follow-up for merged PR #269 unresolved Copilot comments:
- https://github.com/everydaydevopsio/ballast/pull/269#discussion_r3791253681
- https://github.com/everydaydevopsio/ballast/pull/269#discussion_r3791253690
- https://github.com/everydaydevopsio/ballast/pull/269#discussion_r3791253693
- https://github.com/everydaydevopsio/ballast/pull/269#discussion_r3791253701

## Validation
- rg -n 'pre-push or manual `ansible-playbook --syntax-check`' agents/ansible/linting/content.md packages/ballast-python/ballast/agents/ansible/linting/content.md packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
- rg -n '`ansible-playbook --syntax-check` for each representative top-level playbook' agents/ansible/linting/content.md packages/ballast-python/ballast/agents/ansible/linting/content.md packages/ballast-go/cmd/ballast-go/agents/ansible/linting/content.md packages/ballast-go/cmd/ballast/agents/ansible/linting/content.md
- git diff --check
- cmp consistency checks across all four Ansible linting content copies